### PR TITLE
updated stop and start

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,13 @@ Put those into your `aveloxis.json` file as described in the [Configuration Sect
 
 If you are running on bare metal, at this point you are ready to go!
 ```bash
-(nohup aveloxis api >> api.log &)
-(nohup aveloxis web >> web.log &)
-(nohup aveloxis serve >> aveloxis.log &)
+# Start all three processes in the background (logs to ~/.aveloxis/*.log)
+aveloxis start all
+
+# Or start individually
+aveloxis start serve   # → ~/.aveloxis/aveloxis.log
+aveloxis start web     # → ~/.aveloxis/web.log
+aveloxis start api     # → ~/.aveloxis/api.log
 ```
 
 Then you can open the interfaces:
@@ -501,13 +505,28 @@ Tools that are already installed are skipped. The command verifies each tool is 
 
 **Automatic updates:** On scheduler startup, Aveloxis checks if it has been more than 30 days since the last tool update. If so, it re-runs `go install ...@latest` for each installed tool to pull the latest version. Only tools already on PATH are updated — missing tools are not auto-installed. The check timestamp is stored at `~/.aveloxis-tool-check`.
 
-### `aveloxis stop` — Stop a running instance
+### `aveloxis start` — Start background processes
 
 ```bash
-aveloxis stop
+aveloxis start serve   # scheduler + monitor → ~/.aveloxis/aveloxis.log
+aveloxis start web     # web GUI             → ~/.aveloxis/web.log
+aveloxis start api     # REST API            → ~/.aveloxis/api.log
+aveloxis start all     # all three at once
 ```
 
-Sends SIGTERM to all running `aveloxis serve` processes. Active workers finish their current API call, queue locks are released, and staging data is preserved for the next startup.
+Launches the specified component(s) as detached background processes. Output is appended to log files in `~/.aveloxis/`. PID files are written to `~/.aveloxis/aveloxis-{serve,web,api}.pid` for reliable process tracking. If a component is already running, the command reports it and skips the launch.
+
+### `aveloxis stop` — Stop background processes
+
+```bash
+aveloxis stop serve    # stop only the scheduler
+aveloxis stop web      # stop only the web GUI
+aveloxis stop api      # stop only the REST API
+aveloxis stop all      # stop all three
+aveloxis stop          # (no args) same as 'all'
+```
+
+Sends SIGTERM to the specified component(s) using PID files in `~/.aveloxis/`. Active workers finish their current API call, queue locks are released, and staging data is preserved. PID files are cleaned up automatically. Stale PID files (process no longer running) are detected and removed.
 
 ### `aveloxis sbom` — Generate Software Bill of Materials
 

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/augurlabs/aveloxis/internal/db"
 	"github.com/augurlabs/aveloxis/internal/model"
 	"github.com/augurlabs/aveloxis/internal/monitor"
+	"github.com/augurlabs/aveloxis/internal/pidfile"
 	"github.com/augurlabs/aveloxis/internal/platform"
 	"github.com/augurlabs/aveloxis/internal/platform/github"
 	"github.com/augurlabs/aveloxis/internal/platform/gitlab"
@@ -49,6 +50,7 @@ func main() {
 		serveCmd(&cfgPath),
 		apiCmd(&cfgPath),
 		webCmd(&cfgPath),
+		startCmd(&cfgPath),
 		stopCmd(),
 		addRepoCmd(&cfgPath),
 		addKeyCmd(&cfgPath),
@@ -107,6 +109,11 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 	bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	cfg := loadConfig(cfgPath, bootLog)
 	logger := newLogger(cfg)
+
+	// Write PID file so 'aveloxis stop serve' can find us.
+	pidPath := pidfile.Path("serve")
+	pidfile.Write(pidPath, os.Getpid())
+	defer pidfile.Remove(pidPath)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -185,6 +192,10 @@ func runAPI(cfgPath, addr string) error {
 	bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	cfg := loadConfig(cfgPath, bootLog)
 	logger := newLogger(cfg)
+
+	pidPath := pidfile.Path("api")
+	pidfile.Write(pidPath, os.Getpid())
+	defer pidfile.Remove(pidPath)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -972,6 +983,10 @@ Create a GitLab OAuth app at: https://gitlab.com/-/profile/applications`,
 			cfg := loadConfig(*cfgPath, bootLog)
 			logger := newLogger(cfg)
 
+			webPidPath := pidfile.Path("web")
+			pidfile.Write(webPidPath, os.Getpid())
+			defer pidfile.Remove(webPidPath)
+
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 			defer cancel()
 
@@ -1005,53 +1020,180 @@ Create a GitLab OAuth app at: https://gitlab.com/-/profile/applications`,
 	}
 }
 
-func stopCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "stop",
-		Short: "Stop a running aveloxis serve instance",
-		Long: `Sends SIGTERM to all running aveloxis serve processes, triggering a
-graceful shutdown. Active workers finish their current API call, queue locks
-are released, and any unprocessed staging data is preserved for the next startup.`,
+// validComponents lists the background-manageable process types.
+var validComponents = []string{"serve", "web", "api"}
+
+func startCmd(cfgPath *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start [serve|web|api|all]",
+		Short: "Start aveloxis components in the background",
+		Long: `Launches the specified component(s) as background processes, writing
+output to log files in ~/.aveloxis/:
+
+  aveloxis start serve   → aveloxis.log   (scheduler + monitor)
+  aveloxis start web     → web.log        (web GUI)
+  aveloxis start api     → api.log        (REST API)
+  aveloxis start all     → all three
+
+PID files are written to ~/.aveloxis/aveloxis-{serve,web,api}.pid.
+Use 'aveloxis stop' to shut them down gracefully.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Find aveloxis serve processes and send SIGTERM.
-			out, err := exec.Command("pgrep", "-f", "aveloxis.*serve").Output()
-			if err != nil {
-				fmt.Println("No running aveloxis serve process found.")
-				return nil
-			}
+			target := strings.ToLower(args[0])
 
-			pids := strings.Fields(strings.TrimSpace(string(out)))
-			myPID := fmt.Sprintf("%d", os.Getpid())
-			killed := 0
-
-			for _, pid := range pids {
-				if pid == myPID {
-					continue // don't kill ourselves
-				}
-				p, err := strconv.Atoi(pid)
-				if err != nil {
-					continue
-				}
-				proc, err := os.FindProcess(p)
-				if err != nil {
-					continue
-				}
-				if err := proc.Signal(syscall.SIGTERM); err != nil {
-					fmt.Printf("Failed to stop PID %d: %v\n", p, err)
-					continue
-				}
-				fmt.Printf("Sent SIGTERM to PID %d\n", p)
-				killed++
-			}
-
-			if killed == 0 {
-				fmt.Println("No running aveloxis serve process found.")
+			var components []string
+			if target == "all" {
+				components = validComponents
 			} else {
-				fmt.Printf("Stopped %d aveloxis process(es). Staging data is preserved.\n", killed)
+				valid := false
+				for _, c := range validComponents {
+					if target == c {
+						valid = true
+						break
+					}
+				}
+				if !valid {
+					return fmt.Errorf("unknown component %q (use serve, web, api, or all)", target)
+				}
+				components = []string{target}
+			}
+
+			for _, comp := range components {
+				if err := startComponent(comp, *cfgPath); err != nil {
+					fmt.Printf("Failed to start %s: %v\n", comp, err)
+				}
 			}
 			return nil
 		},
 	}
+	return cmd
+}
+
+func startComponent(component, cfgPath string) error {
+	// Check if already running.
+	pidPath := pidfile.Path(component)
+	if pid, err := pidfile.Read(pidPath); err == nil && pidfile.IsRunning(pid) {
+		fmt.Printf("%s is already running (PID %d)\n", component, pid)
+		return nil
+	}
+
+	logPath := pidfile.LogPath(component)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening log file %s: %w", logPath, err)
+	}
+
+	// Build the command. Pass through the config path flag.
+	execPath, err := os.Executable()
+	if err != nil {
+		logFile.Close()
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	cmdArgs := []string{component, "--config", cfgPath}
+	proc := exec.Command(execPath, cmdArgs...)
+	proc.Stdout = logFile
+	proc.Stderr = logFile
+	// Detach from the parent process group so it survives terminal close.
+	proc.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := proc.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("starting %s: %w", component, err)
+	}
+
+	pid := proc.Process.Pid
+	if err := pidfile.Write(pidPath, pid); err != nil {
+		fmt.Printf("Warning: started %s (PID %d) but failed to write PID file: %v\n", component, pid, err)
+	}
+
+	// Release the child — we don't wait for it.
+	proc.Process.Release()
+	logFile.Close()
+
+	fmt.Printf("Started %s (PID %d), logging to %s\n", component, pid, logPath)
+	return nil
+}
+
+func stopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop [serve|web|api|all]",
+		Short: "Stop running aveloxis background processes",
+		Long: `Sends SIGTERM to the specified component(s), triggering graceful shutdown.
+
+  aveloxis stop serve   — stop the scheduler
+  aveloxis stop web     — stop the web GUI
+  aveloxis stop api     — stop the REST API
+  aveloxis stop all     — stop all three
+  aveloxis stop         — (no args) same as 'all'
+
+Active workers finish their current API call, queue locks are released,
+and any unprocessed staging data is preserved for the next startup.
+PID files are cleaned up automatically.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := "all"
+			if len(args) > 0 {
+				target = strings.ToLower(args[0])
+			}
+
+			var components []string
+			if target == "all" {
+				components = validComponents
+			} else {
+				valid := false
+				for _, c := range validComponents {
+					if target == c {
+						valid = true
+						break
+					}
+				}
+				if !valid {
+					return fmt.Errorf("unknown component %q (use serve, web, api, or all)", target)
+				}
+				components = []string{target}
+			}
+
+			stopped := 0
+			for _, comp := range components {
+				if ok := stopComponent(comp); ok {
+					stopped++
+				}
+			}
+			if stopped == 0 {
+				fmt.Println("No running aveloxis processes found.")
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func stopComponent(component string) bool {
+	pidPath := pidfile.Path(component)
+	pid, err := pidfile.Read(pidPath)
+	if err != nil {
+		return false
+	}
+
+	if !pidfile.IsRunning(pid) {
+		fmt.Printf("%s: stale PID file (PID %d not running), cleaning up\n", component, pid)
+		pidfile.Remove(pidPath)
+		return false
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		fmt.Printf("Failed to stop %s (PID %d): %v\n", component, pid, err)
+		return false
+	}
+
+	fmt.Printf("Stopped %s (PID %d)\n", component, pid)
+	pidfile.Remove(pidPath)
+	return true
 }
 
 func versionCmd() *cobra.Command {

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -285,15 +285,40 @@ If `scc` is not installed, the code complexity phase is silently skipped during 
 
 ---
 
-## `aveloxis stop`
+## `aveloxis start`
 
-Stops all running `aveloxis serve` instances.
+Launches aveloxis components as detached background processes with log output redirected to files in `~/.aveloxis/`.
 
 ```bash
-aveloxis stop
+aveloxis start serve   # scheduler + monitor → ~/.aveloxis/aveloxis.log
+aveloxis start web     # web GUI             → ~/.aveloxis/web.log
+aveloxis start api     # REST API            → ~/.aveloxis/api.log
+aveloxis start all     # all three at once
 ```
 
-Sends `SIGTERM` to all running `aveloxis serve` processes. Active workers finish their current API call, queue locks are released, and staging data is preserved for the next startup.
+PID files are written to `~/.aveloxis/aveloxis-{serve,web,api}.pid`. If a component is already running, the command reports it and skips the launch.
+
+Log files are opened in append mode — existing content is preserved across restarts.
+
+---
+
+## `aveloxis stop`
+
+Gracefully stops background aveloxis processes.
+
+```bash
+aveloxis stop serve    # stop only the scheduler
+aveloxis stop web      # stop only the web GUI
+aveloxis stop api      # stop only the REST API
+aveloxis stop all      # stop all three
+aveloxis stop          # (no args) same as 'all'
+```
+
+Sends `SIGTERM` to the specified component(s) using PID files in `~/.aveloxis/`. Active workers finish their current API call, queue locks are released, and staging data is preserved. PID files are cleaned up automatically. Stale PID files (process no longer running) are detected and removed.
+
+```{note}
+`aveloxis stop` also works for processes started in the foreground (e.g., `aveloxis serve`), because all foreground processes write PID files on startup.
+```
 
 ---
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -230,14 +230,14 @@ If you see this error, it indicates a code path that bypasses sanitization. Repo
 The standard restart procedure for any issue:
 
 ```bash
-# 1. Stop the running instance
-aveloxis stop
+# 1. Stop all running instances
+aveloxis stop all
 
 # 2. (Optional) Clear staging if you suspect corrupt staged data
 psql -U aveloxis -d aveloxis -c "TRUNCATE aveloxis_ops.staging;"
 
-# 3. Restart
-aveloxis serve --workers 4 --monitor :5555
+# 3. Restart all components in the background
+aveloxis start all
 ```
 
 On startup, Aveloxis automatically:

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.13.4"
+var ToolVersion = "0.13.5"

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -1,0 +1,74 @@
+// Package pidfile manages PID files for aveloxis background processes.
+// Each component (serve, web, api) writes its PID to a file at startup
+// and removes it on shutdown. The start/stop commands use these files
+// to reliably identify and manage background processes.
+package pidfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Dir returns the directory for PID and log files.
+// Uses $HOME/.aveloxis/ — created if it doesn't exist.
+func Dir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/tmp"
+	}
+	dir := filepath.Join(home, ".aveloxis")
+	os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+// Path returns the PID file path for a component (serve, web, api).
+func Path(component string) string {
+	return filepath.Join(Dir(), "aveloxis-"+component+".pid")
+}
+
+// LogPath returns the log file path for a component.
+// serve → aveloxis.log (the main log), web → web.log, api → api.log.
+func LogPath(component string) string {
+	switch component {
+	case "serve":
+		return filepath.Join(Dir(), "aveloxis.log")
+	default:
+		return filepath.Join(Dir(), component+".log")
+	}
+}
+
+// Write creates a PID file with the given process ID.
+func Write(path string, pid int) error {
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)), 0o644)
+}
+
+// Read returns the PID from a PID file.
+func Read(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid PID in %s: %w", path, err)
+	}
+	return pid, nil
+}
+
+// Remove deletes a PID file. No error if it doesn't exist.
+func Remove(path string) {
+	os.Remove(path)
+}
+
+// IsRunning checks if the process with the given PID is still alive.
+func IsRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds. Send signal 0 to check if alive.
+	return proc.Signal(nil) == nil
+}

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -1,0 +1,120 @@
+package pidfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWrite_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pid")
+
+	if err := Write(path, 12345); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "12345" {
+		t.Errorf("content = %q, want 12345", data)
+	}
+}
+
+func TestRead_ValidPID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pid")
+	os.WriteFile(path, []byte("99999"), 0o644)
+
+	pid, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if pid != 99999 {
+		t.Errorf("pid = %d, want 99999", pid)
+	}
+}
+
+func TestRead_MissingFile(t *testing.T) {
+	pid, err := Read("/tmp/nonexistent-aveloxis-test.pid")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+	if pid != 0 {
+		t.Errorf("pid = %d, want 0", pid)
+	}
+}
+
+func TestRead_InvalidContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pid")
+	os.WriteFile(path, []byte("not-a-number"), 0o644)
+
+	_, err := Read(path)
+	if err == nil {
+		t.Error("expected error for invalid content")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pid")
+	os.WriteFile(path, []byte("12345"), 0o644)
+
+	Remove(path)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be removed")
+	}
+}
+
+func TestRemove_NonexistentIsNoOp(t *testing.T) {
+	// Should not panic or error.
+	Remove("/tmp/nonexistent-aveloxis-test.pid")
+}
+
+func TestPath_DefaultDir(t *testing.T) {
+	p := Path("serve")
+	if p == "" {
+		t.Error("Path should not be empty")
+	}
+	if filepath.Base(p) != "aveloxis-serve.pid" {
+		t.Errorf("filename = %q, want aveloxis-serve.pid", filepath.Base(p))
+	}
+}
+
+func TestPath_Components(t *testing.T) {
+	tests := []struct {
+		component string
+		wantFile  string
+	}{
+		{"serve", "aveloxis-serve.pid"},
+		{"web", "aveloxis-web.pid"},
+		{"api", "aveloxis-api.pid"},
+	}
+	for _, tt := range tests {
+		got := filepath.Base(Path(tt.component))
+		if got != tt.wantFile {
+			t.Errorf("Path(%q) file = %q, want %q", tt.component, got, tt.wantFile)
+		}
+	}
+}
+
+func TestLogPath_Components(t *testing.T) {
+	tests := []struct {
+		component string
+		wantFile  string
+	}{
+		{"serve", "aveloxis.log"},
+		{"web", "web.log"},
+		{"api", "api.log"},
+	}
+	for _, tt := range tests {
+		got := filepath.Base(LogPath(tt.component))
+		if got != tt.wantFile {
+			t.Errorf("LogPath(%q) file = %q, want %q", tt.component, got, tt.wantFile)
+		}
+	}
+}


### PR DESCRIPTION
New: aveloxis start and aveloxis stop commands
                                                                                                                                          
  New package: internal/pidfile/ — manages PID files for reliable background process tracking (9 tests).
                                                                                                                                          
  aveloxis start [serve|web|api|all]
                                                                                                                                          
  Launches components as detached background processes with output redirected to log files:                                               
   
  ┌──────────────────────┬──────────────────────────┬────────────────────────────────┐                                                    
  │       Command        │         Log file         │            PID file            │
  ├──────────────────────┼──────────────────────────┼────────────────────────────────┤                                                    
  │ aveloxis start serve │ ~/.aveloxis/aveloxis.log │ ~/.aveloxis/aveloxis-serve.pid │
  ├──────────────────────┼──────────────────────────┼────────────────────────────────┤                                                    
  │ aveloxis start web   │ ~/.aveloxis/web.log      │ ~/.aveloxis/aveloxis-web.pid   │
  ├──────────────────────┼──────────────────────────┼────────────────────────────────┤                                                    
  │ aveloxis start api   │ ~/.aveloxis/api.log      │ ~/.aveloxis/aveloxis-api.pid   │
  ├──────────────────────┼──────────────────────────┼────────────────────────────────┤                                                    
  │ aveloxis start all   │ all three                │ all three                      │
  └──────────────────────┴──────────────────────────┴────────────────────────────────┘                                                    
                                                            
  - Processes are fully detached (Setsid: true) and survive terminal close                                                                
  - Logs are opened in append mode (existing content preserved)
  - If a component is already running, it reports the existing PID and skips                                                              
  - The --config flag is passed through to the child process                                                                              
                                                                                                                                          
  aveloxis stop [serve|web|api|all]                                                                                                       
                                                                                                                                          
  Sends SIGTERM to the specified component(s) using PID files:                                                                            
  - aveloxis stop serve / web / api — stop one component
  - aveloxis stop all or aveloxis stop (no args) — stop all three                                                                         
  - Stale PID files (process no longer running) are detected and cleaned up
  - Works for processes started via start or directly in the foreground                                                                   
                                                                       
  PID files for foreground processes                                                                                                      
                                                                                                                                          
  The serve, web, and api commands now write PID files on startup (even when run in the foreground), so aveloxis stop works regardless of 
  how the process was started.