### PR TITLE
Debug/stop start

### DIFF
--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -1170,18 +1170,40 @@ PID files are cleaned up automatically.`,
 }
 
 func stopComponent(component string) bool {
+	// Strategy 1: PID file (preferred — reliable, written by start/serve/web/api).
 	pidPath := pidfile.Path(component)
-	pid, err := pidfile.Read(pidPath)
+	if pid, err := pidfile.Read(pidPath); err == nil {
+		if !pidfile.IsRunning(pid) {
+			fmt.Printf("%s: stale PID file (PID %d not running), cleaning up\n", component, pid)
+			pidfile.Remove(pidPath)
+		} else if signalProcess(component, pid) {
+			pidfile.Remove(pidPath)
+			return true
+		}
+	}
+
+	// Strategy 2: pgrep fallback — finds processes started before PID file support
+	// was added, or started manually without 'aveloxis start'.
+	out, err := exec.Command("pgrep", "-f", "aveloxis "+component).Output()
 	if err != nil {
 		return false
 	}
 
-	if !pidfile.IsRunning(pid) {
-		fmt.Printf("%s: stale PID file (PID %d not running), cleaning up\n", component, pid)
-		pidfile.Remove(pidPath)
-		return false
+	myPID := os.Getpid()
+	stopped := false
+	for _, field := range strings.Fields(strings.TrimSpace(string(out))) {
+		pid, err := strconv.Atoi(field)
+		if err != nil || pid == myPID {
+			continue
+		}
+		if signalProcess(component, pid) {
+			stopped = true
+		}
 	}
+	return stopped
+}
 
+func signalProcess(component string, pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
@@ -1190,9 +1212,7 @@ func stopComponent(component string) bool {
 		fmt.Printf("Failed to stop %s (PID %d): %v\n", component, pid, err)
 		return false
 	}
-
 	fmt.Printf("Stopped %s (PID %d)\n", component, pid)
-	pidfile.Remove(pidPath)
 	return true
 }
 

--- a/internal/collector/commit_resolver.go
+++ b/internal/collector/commit_resolver.go
@@ -70,6 +70,7 @@ type ResolveResult struct {
 	ResolvedSearch  int
 	Unresolved      int
 	KeyExhausted    int // commits that failed because no API keys were available
+	Consecutive422  int // consecutive 422 "No commit found" errors from GitHub API
 	ContribsCreated int
 	ContribsUpdated int
 	AliasesCreated  int
@@ -85,6 +86,14 @@ func (r *ResolveResult) IsSuccess() bool {
 	}
 	// If more than 50% of commits failed due to key exhaustion, this is not a success.
 	return r.KeyExhausted < r.TotalCommits/2
+}
+
+// ShouldAbort422 returns true when the resolver should stop making API calls
+// because too many consecutive 422 "No commit found" errors indicate the
+// commits in the database don't belong to this repo (e.g., stale clone data
+// from a previous repo_id assignment).
+func (r *ResolveResult) ShouldAbort422() bool {
+	return r.Consecutive422 >= 50
 }
 
 // ResolveCommits resolves all unresolved commits for a repo.
@@ -129,10 +138,32 @@ func (r *CommitResolver) ResolveCommits(ctx context.Context, repoID int64, owner
 					"remaining", result.KeyExhausted)
 				break
 			}
+			// Track consecutive 422 "No commit found" errors. These mean the
+			// commit SHAs in the database don't exist in this repo (usually caused
+			// by a stale bare clone that belonged to a different repo). After 50
+			// consecutive 422s, abort — continuing would just waste API calls.
+			if strings.Contains(errMsg, "unprocessable entity") {
+				result.Consecutive422++
+				if result.ShouldAbort422() {
+					remaining := result.TotalCommits - (result.ResolvedNoreply + result.ResolvedDBHit + result.ResolvedAPI + result.ResolvedSearch + result.Unresolved + result.Errors)
+					r.logger.Error("commit resolution aborted: commits do not belong to this repo",
+						"repo_id", repoID, "owner", owner, "repo", repo,
+						"consecutive_422", result.Consecutive422,
+						"remaining", remaining,
+						"hint", "the bare clone may be stale — delete the clone dir and re-collect")
+					result.Errors += remaining
+					break
+				}
+			} else {
+				result.Consecutive422 = 0 // reset on non-422 error
+			}
 			r.logger.Warn("failed to resolve commit", "hash", cmt.Hash[:8], "error", err)
 			result.Errors++
 			continue
 		}
+		// Successful resolution (or clean skip) — reset 422 counter.
+		result.Consecutive422 = 0
+
 		if login == "" {
 			result.Unresolved++
 			// Store unresolved email for future resolution attempts.

--- a/internal/collector/facade.go
+++ b/internal/collector/facade.go
@@ -88,7 +88,21 @@ func (f *FacadeCollector) clonePath(repoID int64) string {
 func (f *FacadeCollector) ensureClone(ctx context.Context, gitURL, path string) error {
 	// Bare repos don't have a .git subdirectory — check for HEAD file instead.
 	if _, err := os.Stat(filepath.Join(path, "HEAD")); err == nil {
-		// Existing bare clone — fetch updates.
+		// Existing bare clone found — verify it's the right repo.
+		// When repo IDs are reassigned (e.g., new database pointing at the same
+		// clone directory), the old clone may belong to a completely different repo.
+		// Reusing it would parse the wrong git history.
+		configData, _ := os.ReadFile(filepath.Join(path, "config"))
+		existingURL := parseOriginURL(string(configData))
+		if existingURL != "" && normalizeCloneURL(existingURL) != normalizeCloneURL(gitURL) {
+			f.logger.Warn("stale clone detected: origin URL mismatch, re-cloning",
+				"path", path,
+				"existing_url", existingURL,
+				"expected_url", gitURL)
+			os.RemoveAll(path)
+			return f.freshClone(ctx, gitURL, path)
+		}
+
 		f.logger.Info("fetching updates", "path", path)
 		var stderr bytes.Buffer
 		cmd := exec.CommandContext(ctx, "git", "-C", path, "fetch", "--all", "--prune")
@@ -109,6 +123,39 @@ func (f *FacadeCollector) ensureClone(ctx context.Context, gitURL, path string) 
 	}
 
 	return f.freshClone(ctx, gitURL, path)
+}
+
+// parseOriginURL extracts the remote.origin.url from a git config file's content.
+func parseOriginURL(configContent string) string {
+	inOrigin := false
+	for _, line := range strings.Split(configContent, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == `[remote "origin"]` {
+			inOrigin = true
+			continue
+		}
+		if inOrigin {
+			if strings.HasPrefix(trimmed, "[") {
+				break // next section
+			}
+			if strings.HasPrefix(trimmed, "url = ") {
+				return strings.TrimPrefix(trimmed, "url = ")
+			}
+		}
+	}
+	return ""
+}
+
+// normalizeCloneURL strips protocol, trailing slashes, .git suffix, and lowercases
+// for URL comparison. Two URLs that point to the same repo should match after this.
+func normalizeCloneURL(u string) string {
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	u = strings.TrimPrefix(u, "git://")
+	u = strings.TrimPrefix(u, "ssh://")
+	u = strings.TrimSuffix(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	return strings.ToLower(u)
 }
 
 func (f *FacadeCollector) freshClone(ctx context.Context, gitURL, path string) error {

--- a/internal/collector/facade_clone_test.go
+++ b/internal/collector/facade_clone_test.go
@@ -1,0 +1,63 @@
+package collector
+
+import (
+	"testing"
+)
+
+// TestCloneURLMismatch verifies that when a bare clone exists at repo_N/ but
+// its remote.origin.url doesn't match the expected gitURL, we detect the mismatch
+// and re-clone instead of reusing the stale clone.
+func TestCloneOriginURL_Extraction(t *testing.T) {
+	// cloneOriginURL should return the remote.origin.url from a git config.
+	// For a bare repo, git config is at <path>/config.
+	// We test the helper function that reads it.
+
+	// Valid origin URL — should be extracted correctly.
+	cfg := `[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = true
+[remote "origin"]
+	url = https://github.com/augurlabs/augur.git
+	fetch = +refs/*:refs/*
+`
+	url := parseOriginURL(cfg)
+	if url != "https://github.com/augurlabs/augur.git" {
+		t.Errorf("parseOriginURL = %q, want augur URL", url)
+	}
+}
+
+func TestCloneOriginURL_NoOrigin(t *testing.T) {
+	cfg := `[core]
+	bare = true
+`
+	url := parseOriginURL(cfg)
+	if url != "" {
+		t.Errorf("no origin: %q, want empty", url)
+	}
+}
+
+func TestCloneOriginURL_Empty(t *testing.T) {
+	if url := parseOriginURL(""); url != "" {
+		t.Errorf("empty: %q", url)
+	}
+}
+
+func TestNormalizeCloneURL_Matches(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"https://github.com/org/repo.git", "https://github.com/org/repo", true},
+		{"https://github.com/org/repo.git", "https://github.com/org/repo.git", true},
+		{"https://github.com/Org/Repo.git", "https://github.com/org/repo", true},
+		{"https://github.com/org/repo", "https://github.com/other/repo", false},
+		{"https://github.com/augurlabs/augur.git", "https://github.com/aveloxis/OCDX-Specification.git", false},
+	}
+	for _, tt := range tests {
+		got := normalizeCloneURL(tt.a) == normalizeCloneURL(tt.b)
+		if got != tt.want {
+			t.Errorf("normalizeCloneURL(%q) == normalizeCloneURL(%q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/internal/collector/resolve_422_test.go
+++ b/internal/collector/resolve_422_test.go
@@ -1,0 +1,30 @@
+package collector
+
+import (
+	"testing"
+)
+
+// TestResolveResult_ConsecutiveNotFound verifies that the resolver tracks
+// consecutive 422/not-found errors and can detect when it should bail out.
+func TestResolveResult_ShouldAbort422(t *testing.T) {
+	// After 50 consecutive 422s, the resolver should abort — the commits
+	// clearly don't belong to this repo.
+	r := &ResolveResult{TotalCommits: 1000, Consecutive422: 50}
+	if !r.ShouldAbort422() {
+		t.Error("50 consecutive 422s should trigger abort")
+	}
+}
+
+func TestResolveResult_ShouldNotAbort422_Low(t *testing.T) {
+	r := &ResolveResult{TotalCommits: 1000, Consecutive422: 10}
+	if r.ShouldAbort422() {
+		t.Error("10 consecutive 422s should not trigger abort yet")
+	}
+}
+
+func TestResolveResult_ShouldNotAbort422_Zero(t *testing.T) {
+	r := &ResolveResult{}
+	if r.ShouldAbort422() {
+		t.Error("0 consecutive 422s should not trigger abort")
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.13.5"
+var ToolVersion = "0.13.6"


### PR DESCRIPTION
"found an edge case where, if you reinstall Aveloxis and don't clean out the bare clones, tonsf of errors are generated because the bare clone in repo_1 for example, isn't the current "repo 1
Bug 1: Stale bare clone reuse (root cause of 12,694 wrong commits)                                                                      
                                                                                                                                        
What happened: OCDX-Specification was assigned repo_id=1 in the new database. repo_1 still contained a   
bare clone of augurlabs/augur from a previous database. The facade's ensureClone saw that HEAD existed, did git fetch --all, and then   
parsed augur's 12,694 commits as if they belonged to OCDX-Specification (which actually has 83 commits).
                                                                                                                                        
Fix: ensureClone now reads remote.origin.url from the bare clone's git config and compares it (case-insensitive, .git-stripped) against 
the expected URL. If they don't match, the clone is deleted and re-cloned from scratch. Log message: "stale clone detected: origin URL 
mismatch, re-cloning".                                                                                                                  
                                                          
New helpers: parseOriginURL() (extracts URL from git config text), normalizeCloneURL() (strips  for comparison).        
 
Tests: 4 new tests in facade_clone_test.go.                                                                                             
                                                          
Bug 2: No bail-out on mass 422 "No commit found" errors                                                                                 
 
What happened: The commit resolver tried to look up each of the 12,694 augur commits via GET                                            
GitHub returned 422 "No commit found" for every one because those SHAs don't exist in
OCDX-Specification. The resolver logged 5,978+ warnings and wasted thousands of API calls before finishing.                             
                                                          
Fix: ResolveResult now tracks Consecutive422 — a counter that increments on each 422 error and resets on any success. ShouldAbort422()  
returns true after 50 consecutive 422s. When triggered, the resolver aborts with an ERROR log: "commit resolution aborted: commits do 
not belong to this repo" with a hint to delete the stale clone directory.                                                               
                                                          
Tests: 3 new tests in resolve_422_test.go."