### PR TITLE
Debug/long license text

### DIFF
--- a/internal/db/license_fulltext_test.go
+++ b/internal/db/license_fulltext_test.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"testing"
+)
+
+// Tests for detecting full license texts (e.g., Python packages that store the
+// entire BSD/MIT/Apache license body in the "license" field) and mapping them
+// to canonical SPDX identifiers.
+
+func TestNormalizeLicense_FullBSD3Text(t *testing.T) {
+	// Must include "neither the name" to distinguish from BSD-2-Clause.
+	fullText := `BSD 3-Clause License Copyright (c) 2008-2011, AQR Capital Management, LLC. All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: * Redistributions of source code must retain the above copyright notice. * Neither the name of the copyright holder nor the names of its contributors may be used.`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "BSD-3-Clause" {
+		t.Errorf("full BSD-3 text: got %q, want BSD-3-Clause", got)
+	}
+}
+
+func TestNormalizeLicense_FullMITText(t *testing.T) {
+	fullText := `MIT License Copyright (c) 2019 Someone Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "MIT" {
+		t.Errorf("full MIT text: got %q, want MIT", got)
+	}
+}
+
+func TestNormalizeLicense_FullApache2Text(t *testing.T) {
+	fullText := `Apache License Version 2.0, January 2004 http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION...`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "Apache-2.0" {
+		t.Errorf("full Apache text: got %q, want Apache-2.0", got)
+	}
+}
+
+func TestNormalizeLicense_FullPSFText(t *testing.T) {
+	fullText := `A. HISTORY OF THE SOFTWARE ========================== Python was created in the early 1990s by Guido van Rossum at Stichting Mathematisch Centrum...PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2...`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "PSF-2.0" {
+		t.Errorf("full PSF text: got %q, want PSF-2.0", got)
+	}
+}
+
+func TestNormalizeLicense_PermissionHerebyGrantedMIT(t *testing.T) {
+	// MIT-style text that starts with "Permission is hereby granted".
+	fullText := `Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "MIT" {
+		t.Errorf("MIT permission text: got %q, want MIT", got)
+	}
+}
+
+func TestNormalizeLicense_FullISCText(t *testing.T) {
+	fullText := `ISC License Copyright (c) 2023, Someone Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted...`
+	got := NormalizeLicenseToSPDX(fullText)
+	if got != "ISC" {
+		t.Errorf("full ISC text: got %q, want ISC", got)
+	}
+}
+
+func TestNormalizeLicense_LongTextTruncation(t *testing.T) {
+	// Completely unrecognizable long text should be truncated, not passed through.
+	longJunk := ""
+	for i := 0; i < 500; i++ {
+		longJunk += "some random text "
+	}
+	got := NormalizeLicenseToSPDX(longJunk)
+	if len(got) > 100 {
+		t.Errorf("unrecognized long text should be truncated, got len=%d", len(got))
+	}
+}
+
+func TestNormalizeLicense_MultiLicenseText(t *testing.T) {
+	// Multiple license texts concatenated (common in Python).
+	// BSD-3 has "neither the name" so it matches BSD-3-Clause, not BSD-2.
+	multi := `BSD 3-Clause License Copyright (c) 2005-2023, NumPy Developers. All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted. Neither the name of the copyright holder may be used. Apache License Version 2.0, January 2004.`
+	got := NormalizeLicenseToSPDX(multi)
+	if got != "BSD-3-Clause" {
+		t.Errorf("multi-license text: got %q, want BSD-3-Clause (first match)", got)
+	}
+}
+
+func TestNormalizeLicense_ShortStringUnchanged(t *testing.T) {
+	// Short unrecognized strings should pass through unchanged.
+	got := NormalizeLicenseToSPDX("Custom License v3")
+	if got != "Custom License v3" {
+		t.Errorf("short unrecognized: got %q, want unchanged", got)
+	}
+}

--- a/internal/db/license_normalize.go
+++ b/internal/db/license_normalize.go
@@ -21,6 +21,11 @@ import "strings"
 // NormalizeLicenseToSPDX maps a license string to its canonical SPDX identifier.
 // Returns "Unknown" for empty/sentinel values, the canonical form for known
 // synonyms, or the trimmed input for unrecognized licenses.
+//
+// For long strings (>80 chars), it also detects full license texts — some Python
+// packages embed the entire BSD/MIT/Apache license body in the "license" field.
+// These are identified by content fingerprints (e.g., "Permission is hereby
+// granted" = MIT, "Redistribution and use in source and binary forms" = BSD).
 func NormalizeLicenseToSPDX(license string) string {
 	trimmed := strings.TrimSpace(license)
 
@@ -37,8 +42,96 @@ func NormalizeLicenseToSPDX(license string) string {
 		return canonical
 	}
 
+	// For long strings, try to identify full license texts by content fingerprints.
+	// Python packages (via PyPI/pip) frequently store the entire license body in
+	// the "license" metadata field instead of a short SPDX identifier.
+	if len(trimmed) > 80 {
+		if id := detectFullLicenseText(lower); id != "" {
+			return id
+		}
+		// Unrecognized long text — truncate to keep the UI usable.
+		return truncateLicenseText(trimmed, 80)
+	}
+
 	// No match — return trimmed input unchanged.
 	return trimmed
+}
+
+// detectFullLicenseText identifies full license text bodies by looking for
+// distinctive phrases. Checked in priority order — first match wins.
+// Only called for strings > 80 chars (short strings go through the synonym map).
+func detectFullLicenseText(lower string) string {
+	// Order matters: check most specific patterns first. BSD is checked before
+	// Apache because Python packages often concatenate multiple license texts,
+	// and BSD (the more specific match) should win when both appear.
+
+	// MIT: "permission is hereby granted, free of charge" + "as is" warranty
+	if strings.Contains(lower, "permission is hereby granted, free of charge") &&
+		strings.Contains(lower, "the software is provided \"as is\"") {
+		return "MIT"
+	}
+	// ISC: "permission to use, copy, modify, and/or distribute" (no redistribution clause)
+	if strings.Contains(lower, "permission to use, copy, modify, and/or distribute") &&
+		!strings.Contains(lower, "redistribution") {
+		return "ISC"
+	}
+	// PSF: "python software foundation license" (check before BSD — PSF texts include BSD clauses)
+	if strings.Contains(lower, "python software foundation license") {
+		return "PSF-2.0"
+	}
+	// BSD 3-Clause: "redistribution and use" + "neither the name" (more specific than BSD-2)
+	if strings.Contains(lower, "redistribution and use in source and binary forms") &&
+		strings.Contains(lower, "neither the name") {
+		return "BSD-3-Clause"
+	}
+	// BSD 2-Clause: "redistribution and use" without the third clause
+	if strings.Contains(lower, "redistribution and use in source and binary forms") &&
+		!strings.Contains(lower, "neither the name") {
+		return "BSD-2-Clause"
+	}
+	// Apache 2.0: "apache license" + "version 2.0" or "2.0"
+	if strings.Contains(lower, "apache license") && strings.Contains(lower, "2.0") {
+		return "Apache-2.0"
+	}
+	// GPL 3.0: "gnu general public license" + "version 3"
+	if strings.Contains(lower, "gnu general public license") && strings.Contains(lower, "version 3") {
+		return "GPL-3.0-only"
+	}
+	// GPL 2.0: "gnu general public license" + "version 2"
+	if strings.Contains(lower, "gnu general public license") && strings.Contains(lower, "version 2") {
+		return "GPL-2.0-only"
+	}
+	// MPL 2.0: "mozilla public license" + "2.0"
+	if strings.Contains(lower, "mozilla public license") && strings.Contains(lower, "2.0") {
+		return "MPL-2.0"
+	}
+	// Unlicense: "this is free and unencumbered software"
+	if strings.Contains(lower, "this is free and unencumbered software") {
+		return "Unlicense"
+	}
+	// CC0: "creative commons" + "cc0" or "public domain"
+	if strings.Contains(lower, "creative commons") && (strings.Contains(lower, "cc0") || strings.Contains(lower, "public domain")) {
+		return "CC0-1.0"
+	}
+	return ""
+}
+
+// truncateLicenseText truncates a long license string for display purposes.
+// Tries to find the first recognizable license name in the first line, otherwise
+// cuts at maxLen and appends an indicator.
+func truncateLicenseText(s string, maxLen int) string {
+	// Try to extract a meaningful first line (up to the first period or newline).
+	firstLine := s
+	for _, sep := range []string{"\n", ". ", " Copyright"} {
+		if idx := strings.Index(s, sep); idx > 0 && idx < maxLen {
+			firstLine = s[:idx]
+			break
+		}
+	}
+	if len(firstLine) <= maxLen {
+		return firstLine
+	}
+	return s[:maxLen] + "..."
 }
 
 // licenseSynonyms maps lowercased license strings to canonical SPDX identifiers.

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.13.6"
+var ToolVersion = "0.13.7"


### PR DESCRIPTION

  Problem: Python packages (via PyPI) store the entire license text — sometimes thousands of characters including the full BSD
  boilerplate, Apache 2.0 terms, Python Software Foundation license, musl contributor lists, etc. — in their license metadata field. The
  normalizer only did exact synonym matching, so these multi-kilobyte blobs passed through unchanged and showed up as massive unreadable
  rows in the license table.

  Fix: NormalizeLicenseToSPDX now has three levels of detection:

  1. Exact synonym match (existing) — for short identifiers like "MIT License", "Apache 2.0"
  2. Full-text fingerprinting (new) — for strings >80 chars, detectFullLicenseText() scans for distinctive phrases:
    - MIT: "permission is hereby granted, free of charge" + "the software is provided \"as is\""
    - ISC: "permission to use, copy, modify, and/or distribute" without redistribution clause
    - PSF: "python software foundation license"
    - BSD-3-Clause: "redistribution and use in source and binary forms" + "neither the name"
    - BSD-2-Clause: same redistribution clause without the third clause
    - Apache-2.0: "apache license" + "2.0"
    - GPL-3.0, GPL-2.0, MPL-2.0, Unlicense, CC0-1.0
  3. Truncation fallback (new) — unrecognized long text (>80 chars) is truncated to the first meaningful line (up to 80 chars), so the UI
  stays readable

  Priority ordering matters: BSD is checked before Apache because Python packages often concatenate both texts, and the more specific BSD
  match should win.

  9 new tests covering full BSD-3, MIT, Apache-2.0, PSF, ISC texts, the "Permission is hereby granted" pattern, multi-license
  concatenation, long unrecognized text truncation, and short string passthrough.