### PR TITLE
8Knot compatibility schema added

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,11 +475,14 @@ curl -X POST http://localhost:5555/api/prioritize/42
 aveloxis migrate
 ```
 
-Creates 108 tables and 19 materialized views across two PostgreSQL schemas:
-- **`aveloxis_data`** (84 tables + 19 materialized views) — all collected data plus 8Knot-compatible analytics views
+Creates 108 tables and 19 materialized views across three PostgreSQL schemas:
+- **`aveloxis_data`** (84 tables + 19 materialized views) — all collected data plus analytics views
 - **`aveloxis_ops`** (24 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
+- **`aveloxis_augur_data`** (6 views) — Augur compatibility layer for 8Knot. Contains views that alias Aveloxis column names to Augur conventions (e.g., `star_count` → `stars_count`, `pr_number` → `pr_src_number`). Only tables with column name differences have views here; identical tables resolve via search_path fallback to `aveloxis_data`.
 
 Safe to run repeatedly. Does not touch Augur schemas if sharing a database. Also creates 19 materialized views for 8Knot/analytics compatibility and runs a data cleanup pass that fixes any garbage timestamps (e.g., year 0001 BC from uninitialized fields) by setting them to NULL.
+
+**8Knot integration:** Set `AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data` in 8Knot's `.env`. The two-schema search path resolves Augur-named columns from `aveloxis_augur_data` first, then falls through to `aveloxis_data` for tables with identical schemas. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` as before — the compatibility schema is not needed.
 
 ### `aveloxis refresh-views` — Refresh materialized views
 

--- a/README.md
+++ b/README.md
@@ -475,12 +475,12 @@ curl -X POST http://localhost:5555/api/prioritize/42
 aveloxis migrate
 ```
 
-Creates 108 tables and 19 materialized views across three PostgreSQL schemas:
-- **`aveloxis_data`** (84 tables + 19 materialized views) — all collected data plus analytics views
+Creates 108 tables and 22 materialized views across three PostgreSQL schemas:
+- **`aveloxis_data`** (84 tables + 22 materialized views) — all collected data plus analytics views
 - **`aveloxis_ops`** (24 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
 - **`aveloxis_augur_data`** (6 views) — Augur compatibility layer for 8Knot. Contains views that alias Aveloxis column names to Augur conventions (e.g., `star_count` → `stars_count`, `pr_number` → `pr_src_number`). Only tables with column name differences have views here; identical tables resolve via search_path fallback to `aveloxis_data`.
 
-Safe to run repeatedly. Does not touch Augur schemas if sharing a database. Also creates 19 materialized views for 8Knot/analytics compatibility and runs a data cleanup pass that fixes any garbage timestamps (e.g., year 0001 BC from uninitialized fields) by setting them to NULL.
+Safe to run repeatedly. Does not touch Augur schemas if sharing a database. Also creates 22 materialized views for 8Knot/analytics compatibility and runs a data cleanup pass that fixes any garbage timestamps (e.g., year 0001 BC from uninitialized fields) by setting them to NULL.
 
 **8Knot integration:** Set `AUGUR_SCHEMA=aveloxis_augur_data,aveloxis_data` (no space after comma) in 8Knot's `.env`. The two-schema search path resolves Augur-named columns from `aveloxis_augur_data` first, then falls through to `aveloxis_data` for tables with identical schemas. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` as before — the compatibility schema is not needed.
 
@@ -490,7 +490,7 @@ Safe to run repeatedly. Does not touch Augur schemas if sharing a database. Also
 aveloxis refresh-views
 ```
 
-Manually refreshes all 19 materialized views used by [8Knot](https://github.com/oss-aspen/8Knot) and other analytics tools. Uses `REFRESH MATERIALIZED VIEW CONCURRENTLY` where unique indexes exist (doesn't block reads). Views are also rebuilt automatically on a configurable schedule by `aveloxis serve` (default: Saturday; set `collection.matview_rebuild_day` in `aveloxis.json` to change, or `"disabled"` to turn off).
+Manually refreshes all 22 materialized views used by [8Knot](https://github.com/oss-aspen/8Knot) and other analytics tools. Uses `REFRESH MATERIALIZED VIEW CONCURRENTLY` where unique indexes exist (doesn't block reads). Views are also rebuilt automatically on a configurable schedule by `aveloxis serve` (default: Saturday; set `collection.matview_rebuild_day` in `aveloxis.json` to change, or `"disabled"` to turn off).
 
 ### `aveloxis install-tools` — Install all optional analysis tools
 
@@ -850,7 +850,7 @@ When the prelim phase detects a repo that returns 404 or 410 (deleted, made priv
 
 ### Materialized Views (8Knot Compatibility)
 
-Aveloxis creates 19 materialized views compatible with [8Knot](https://github.com/oss-aspen/8Knot) and other Augur analytics tools:
+Aveloxis creates 22 materialized views compatible with [8Knot](https://github.com/oss-aspen/8Knot) and other Augur analytics tools:
 
 | View | Purpose |
 |---|---|
@@ -870,6 +870,9 @@ Aveloxis creates 19 materialized views compatible with [8Knot](https://github.co
 | `explorer_repo_languages` | Language breakdown from repo_labor |
 | `explorer_libyear_all` / `_summary` / `_detail` | Dependency age (libyear) metrics |
 | `explorer_contributor_recent_actions` | Same as `explorer_contributor_actions` but limited to last 13 months |
+| `explorer_pr_files` | PR file paths with pull_request_id and repo_id |
+| `explorer_cntrb_per_file` | Contributors and reviewers aggregated per file path |
+| `explorer_repo_files` | Latest SCC file listing per repo (most recent analysis date) |
 | `issue_reporter_created_at` | Legacy issue reporter view |
 
 **Rebuild schedule:** Configurable via `collection.matview_rebuild_day` in `aveloxis.json` (default: `"saturday"`). Set to `"disabled"` to turn off automatic rebuilds. Views are NOT refreshed on every startup (was causing slow starts on large databases). On first run, views are created; subsequent startups skip them. Manual rebuild: `aveloxis refresh-views`. The explicit `aveloxis migrate` command always creates/refreshes views.
@@ -878,7 +881,7 @@ Aveloxis creates 19 materialized views compatible with [8Knot](https://github.co
 
 Three schemas in PostgreSQL with full parity to Augur's `augur_data` and `augur_operations`, plus a dedicated schema for ScanCode results:
 
-- **`aveloxis_data`** (84 tables + 19 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 19 materialized views for 8Knot compatibility.
+- **`aveloxis_data`** (84 tables + 22 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 22 materialized views for 8Knot compatibility.
 - **`aveloxis_ops`** (24 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
 - **`aveloxis_scan`** (4 tables) — ScanCode per-file license and copyright detection: `scancode_scans` (scan metadata), `scancode_file_results` (per-file SPDX license, copyrights, holders, packages as JSONB), plus `_history` tables for both.
 
@@ -1099,7 +1102,7 @@ aveloxis/
       staging.go          # JSONB staging writer and batch processor
       migrate.go          # Schema migration (embeds schema.sql)
       schema.sql          # Full DDL (112+ tables across 3 schemas, 23 indexes)
-      matviews.sql        # 19 materialized views for 8Knot/analytics
+      matviews.sql        # 22 materialized views for 8Knot/analytics
       matviews.go         # View creation and refresh logic
       sanitize.go         # Text sanitization (null bytes, invalid UTF-8, control chars)
       contributors.go     # Contributor resolver with in-memory cache and heartbeat

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Creates 108 tables and 19 materialized views across three PostgreSQL schemas:
 
 Safe to run repeatedly. Does not touch Augur schemas if sharing a database. Also creates 19 materialized views for 8Knot/analytics compatibility and runs a data cleanup pass that fixes any garbage timestamps (e.g., year 0001 BC from uninitialized fields) by setting them to NULL.
 
-**8Knot integration:** Set `AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data` in 8Knot's `.env`. The two-schema search path resolves Augur-named columns from `aveloxis_augur_data` first, then falls through to `aveloxis_data` for tables with identical schemas. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` as before — the compatibility schema is not needed.
+**8Knot integration:** Set `AUGUR_SCHEMA=aveloxis_augur_data,aveloxis_data` (no space after comma) in 8Knot's `.env`. The two-schema search path resolves Augur-named columns from `aveloxis_augur_data` first, then falls through to `aveloxis_data` for tables with identical schemas. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` as before — the compatibility schema is not needed.
 
 ### `aveloxis refresh-views` — Refresh materialized views
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -120,7 +120,7 @@ Augur compatibility layer for [8Knot](https://github.com/oss-aspen/8Knot) and ot
 | `releases` | `created_at` → `release_created_at`, `published_at` → `release_published_at`, `updated_at` → `release_updated_at` |
 | `message` | Alias for `messages` (Augur uses singular) |
 
-**Usage:** Set `AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data` in 8Knot's `.env`. PostgreSQL checks `aveloxis_augur_data` first (finding the aliased views), then falls through to `aveloxis_data` for all other tables. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` — the compatibility schema is not needed.
+**Usage:** Set `AUGUR_SCHEMA=aveloxis_augur_data,aveloxis_data` (no space after comma) in 8Knot's `.env`. PostgreSQL checks `aveloxis_augur_data` first (finding the aliased views), then falls through to `aveloxis_data` for all other tables. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` — the compatibility schema is not needed.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -71,7 +71,7 @@ Aveloxis is a Go-based open source community health data collection pipeline tha
 
 Aveloxis uses three PostgreSQL schemas to separate collected data, operational state, and Augur compatibility.
 
-### `aveloxis_data` (84 tables + 19 materialized views)
+### `aveloxis_data` (84 tables + 22 materialized views)
 
 All collected open source community health data:
 
@@ -91,7 +91,7 @@ All collected open source community health data:
 | Analysis/ML | 8 | `message_analysis`, `message_analysis_summary`, `message_sentiment`, `message_sentiment_summary`, `discourse_insights`, `lstm_anomaly_models`, `lstm_anomaly_results`, `pull_request_analysis` |
 | CHAOSS | 4 | `chaoss_metric_status`, `chaoss_user`, `repo_group_insights`, `commit_comment_ref` |
 
-Plus 19 materialized views for 8Knot compatibility.
+Plus 22 materialized views for 8Knot compatibility.
 
 ### `aveloxis_ops` (24 tables)
 
@@ -235,7 +235,7 @@ aveloxis/
       staging.go          # JSONB staging writer and processor
       migrate.go          # Schema migration
       schema.sql          # Full DDL (108 tables)
-      matviews.sql        # 19 materialized views
+      matviews.sql        # 22 materialized views
       contributors.go     # Contributor resolver with cache
       affiliations.go     # Email domain -> org resolver
       aggregates.go       # Facade aggregate refresh
@@ -271,7 +271,7 @@ Each job runs six phases. After the sequential API collection and processing pha
 | Org refresh | Configurable (default 4h) | Scans GitHub orgs and GitLab groups for new/renamed repos |
 | User org refresh | Same as org refresh | Scans user-requested org additions |
 | Contributor breadth | 6h | Discovers cross-repo activity via GitHub Events API |
-| Matview rebuild | Weekly (Saturday) | Drains all workers, rebuilds 19 materialized views, resumes |
+| Matview rebuild | Weekly (Saturday) | Drains all workers, rebuilds 22 materialized views, resumes |
 
 ### Graceful shutdown
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -67,9 +67,9 @@ Aveloxis is a Go-based open source community health data collection pipeline tha
 
 ---
 
-## Two schemas
+## Three schemas
 
-Aveloxis uses two PostgreSQL schemas to separate collected data from operational state.
+Aveloxis uses three PostgreSQL schemas to separate collected data, operational state, and Augur compatibility.
 
 ### `aveloxis_data` (84 tables + 19 materialized views)
 
@@ -106,6 +106,21 @@ Operational and orchestration tables:
 | Users | `users`, `user_sessions`, `user_repos` | User accounts and auth |
 | Config | `config` | Runtime configuration |
 | Workers | `worker_history`, `worker_job` | Worker run history |
+
+### `aveloxis_augur_data` (6 views)
+
+Augur compatibility layer for [8Knot](https://github.com/oss-aspen/8Knot) and other Augur-era analytics tools. Contains views that alias Aveloxis column names to Augur conventions. Only tables with column name differences need views here — tables with identical columns resolve via the `search_path` fallback to `aveloxis_data`.
+
+| View | Augur column aliases |
+|---|---|
+| `repo` | `repos` table (singular name) + `primary_language` → `repo_language` |
+| `repo_info` | `star_count` → `stars_count`, `watcher_count` → `watchers_count` |
+| `issues` | `issue_number` → `gh_issue_number`, `platform_issue_id` → `gh_issue_id`, `closed_by_id` → `cntrb_id` |
+| `pull_requests` | `pr_number` → `pr_src_number`, `author_id` → `pr_augur_contributor_id`, `created_at` → `pr_created_at`, `closed_at` → `pr_closed_at`, `merged_at` → `pr_merged_at` |
+| `releases` | `created_at` → `release_created_at`, `published_at` → `release_published_at`, `updated_at` → `release_updated_at` |
+| `message` | Alias for `messages` (Augur uses singular) |
+
+**Usage:** Set `AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data` in 8Knot's `.env`. PostgreSQL checks `aveloxis_augur_data` first (finding the aliased views), then falls through to `aveloxis_data` for all other tables. For existing Augur databases, use `AUGUR_SCHEMA=augur_data` — the compatibility schema is not needed.
 
 ---
 

--- a/internal/db/augur_compat_test.go
+++ b/internal/db/augur_compat_test.go
@@ -1,0 +1,121 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAugurCompatSchema verifies that schema.sql creates the aveloxis_augur_data
+// compatibility schema with views that map Augur column names to Aveloxis column names.
+// This schema lets 8Knot and other Augur-era tools query using Augur conventions
+// via search_path = aveloxis_augur_data, aveloxis_data.
+
+func TestAugurCompatSchema_Exists(t *testing.T) {
+	sql := readSchemaSQL(t)
+	if !strings.Contains(sql, "CREATE SCHEMA IF NOT EXISTS aveloxis_augur_data") {
+		t.Error("schema.sql must create the aveloxis_augur_data schema")
+	}
+}
+
+func TestAugurCompatSchema_RepoView(t *testing.T) {
+	sql := readSchemaSQL(t)
+	// Must have a "repo" view (singular) pointing at "repos" (plural)
+	// with repo_language alias for primary_language.
+	if !strings.Contains(sql, "aveloxis_augur_data.repo") {
+		t.Error("missing augur_data.repo compatibility view")
+	}
+	if !strings.Contains(sql, "repo_language") {
+		t.Error("repo view must alias primary_language AS repo_language")
+	}
+}
+
+func TestAugurCompatSchema_RepoInfoView(t *testing.T) {
+	sql := readSchemaSQL(t)
+	if !strings.Contains(sql, "aveloxis_augur_data.repo_info") {
+		t.Error("missing repo_info compatibility view")
+	}
+	// Must alias star_count → stars_count and watcher_count → watchers_count.
+	if !strings.Contains(sql, "stars_count") {
+		t.Error("repo_info view must alias star_count AS stars_count")
+	}
+	if !strings.Contains(sql, "watchers_count") {
+		t.Error("repo_info view must alias watcher_count AS watchers_count")
+	}
+}
+
+func TestAugurCompatSchema_IssuesView(t *testing.T) {
+	sql := readSchemaSQL(t)
+	if !strings.Contains(sql, "aveloxis_augur_data.issues") {
+		t.Error("missing issues compatibility view")
+	}
+	if !strings.Contains(sql, "gh_issue_number") {
+		t.Error("issues view must alias issue_number AS gh_issue_number")
+	}
+	if !strings.Contains(sql, "gh_issue_id") {
+		t.Error("issues view must alias platform_issue_id AS gh_issue_id")
+	}
+}
+
+func TestAugurCompatSchema_PullRequestsView(t *testing.T) {
+	sql := readSchemaSQL(t)
+	if !strings.Contains(sql, "aveloxis_augur_data.pull_requests") {
+		t.Error("missing pull_requests compatibility view")
+	}
+	if !strings.Contains(sql, "pr_src_number") {
+		t.Error("pull_requests view must alias pr_number AS pr_src_number")
+	}
+	if !strings.Contains(sql, "pr_augur_contributor_id") {
+		t.Error("pull_requests view must alias author_id AS pr_augur_contributor_id")
+	}
+	if !strings.Contains(sql, "pr_created_at") {
+		t.Error("pull_requests view must alias created_at AS pr_created_at")
+	}
+	if !strings.Contains(sql, "pr_closed_at") {
+		t.Error("pull_requests view must alias closed_at AS pr_closed_at")
+	}
+	if !strings.Contains(sql, "pr_merged_at") {
+		t.Error("pull_requests view must alias merged_at AS pr_merged_at")
+	}
+}
+
+func TestAugurCompatSchema_ReleasesView(t *testing.T) {
+	sql := readSchemaSQL(t)
+	if !strings.Contains(sql, "aveloxis_augur_data.releases") {
+		t.Error("missing releases compatibility view")
+	}
+	if !strings.Contains(sql, "release_created_at") {
+		t.Error("releases view must alias created_at AS release_created_at")
+	}
+	if !strings.Contains(sql, "release_published_at") {
+		t.Error("releases view must alias published_at AS release_published_at")
+	}
+}
+
+// Tables with identical columns should NOT have views in aveloxis_augur_data.
+// They resolve via the second search_path entry (aveloxis_data) directly.
+func TestAugurCompatSchema_NoUnnecessaryViews(t *testing.T) {
+	sql := readSchemaSQL(t)
+	// commits, contributors, repo_groups have identical columns — no views needed.
+	unnecessaryViews := []string{
+		"aveloxis_augur_data.commits",
+		"aveloxis_augur_data.contributors",
+		"aveloxis_augur_data.repo_groups",
+		"aveloxis_augur_data.pull_request_events",
+		"aveloxis_augur_data.repo_labor",
+	}
+	for _, v := range unnecessaryViews {
+		if strings.Contains(sql, "VIEW "+v) {
+			t.Errorf("unnecessary view %s — table has identical columns, should resolve via search_path fallback to aveloxis_data", v)
+		}
+	}
+}
+
+func readSchemaSQL(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatalf("cannot read schema.sql: %v", err)
+	}
+	return string(data)
+}

--- a/internal/db/matview_8knot_test.go
+++ b/internal/db/matview_8knot_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests verifying that all 8Knot-required materialized views exist in matviews.sql
+// and are listed in the refresh order in matviews.go.
+
+func TestMatviews_ExplorerPrFiles_Exists(t *testing.T) {
+	sql := readMatviewsSQL(t)
+	if !strings.Contains(sql, "explorer_pr_files") {
+		t.Error("matviews.sql must define explorer_pr_files materialized view")
+	}
+}
+
+func TestMatviews_ExplorerCntrbPerFile_Exists(t *testing.T) {
+	sql := readMatviewsSQL(t)
+	if !strings.Contains(sql, "explorer_cntrb_per_file") {
+		t.Error("matviews.sql must define explorer_cntrb_per_file materialized view")
+	}
+}
+
+func TestMatviews_ExplorerRepoFiles_Exists(t *testing.T) {
+	sql := readMatviewsSQL(t)
+	if !strings.Contains(sql, "explorer_repo_files") {
+		t.Error("matviews.sql must define explorer_repo_files materialized view")
+	}
+}
+
+func TestMatviews_ExplorerPrResponse_Exists(t *testing.T) {
+	sql := readMatviewsSQL(t)
+	// Note: 8Knot spells it "explorer_pr_reponse" (missing 's'), but Aveloxis
+	// already has "explorer_pr_response" (correct spelling). We need both names
+	// or the correctly-spelled one that 8Knot actually queries.
+	if !strings.Contains(sql, "explorer_pr_response") && !strings.Contains(sql, "explorer_pr_reponse") {
+		t.Error("matviews.sql must define explorer_pr_response (or explorer_pr_reponse) materialized view")
+	}
+}
+
+// Verify all four new views are in the refresh list.
+func TestMatviews_RefreshList_ContainsNewViews(t *testing.T) {
+	required := []string{
+		"explorer_pr_files",
+		"explorer_cntrb_per_file",
+		"explorer_repo_files",
+	}
+	for _, name := range required {
+		found := false
+		for _, mv := range matviewNames {
+			if strings.Contains(mv, name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("matviewNames refresh list must contain %s", name)
+		}
+	}
+}
+
+// Verify unique indexes exist for CONCURRENTLY refresh support.
+func TestMatviews_UniqueIndexes(t *testing.T) {
+	sql := readMatviewsSQL(t)
+	indexes := []string{
+		"idx_unique_explorer_pr_files",
+		"idx_unique_explorer_cntrb_per_file",
+		"idx_unique_explorer_repo_files",
+	}
+	for _, idx := range indexes {
+		if !strings.Contains(sql, idx) {
+			t.Errorf("matviews.sql must create unique index %s for CONCURRENTLY refresh", idx)
+		}
+	}
+}
+
+func readMatviewsSQL(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("matviews.sql")
+	if err != nil {
+		t.Fatalf("cannot read matviews.sql: %v", err)
+	}
+	return string(data)
+}

--- a/internal/db/matviews.go
+++ b/internal/db/matviews.go
@@ -63,6 +63,9 @@ var matviewNames = []string{
 	"aveloxis_data.explorer_libyear_detail",
 	"aveloxis_data.issue_reporter_created_at",
 	"aveloxis_data.explorer_contributor_recent_actions",
+	"aveloxis_data.explorer_pr_files",
+	"aveloxis_data.explorer_cntrb_per_file",
+	"aveloxis_data.explorer_repo_files",
 }
 
 // RefreshMaterializedViews refreshes all materialized views concurrently.

--- a/internal/db/matviews.sql
+++ b/internal/db/matviews.sql
@@ -1161,7 +1161,7 @@ DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_pr_files CASCADE;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_pr_files AS
 SELECT
-    prf.pr_file_path AS file_path,
+    COALESCE(prf.pr_file_path, '') AS file_path,
     pr.pull_request_id AS pull_request_id,
     pr.repo_id AS repo_id
 FROM
@@ -1182,9 +1182,9 @@ DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_cntrb_per_file CASCADE;
 CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_cntrb_per_file AS
 SELECT
     pr.repo_id AS repo_id,
-    prf.pr_file_path AS file_path,
-    string_agg(DISTINCT CAST(pr.author_id AS varchar(36)), ',') AS cntrb_ids,
-    string_agg(DISTINCT CAST(prr.cntrb_id AS varchar(36)), ',') AS reviewer_ids
+    COALESCE(prf.pr_file_path, '') AS file_path,
+    COALESCE(string_agg(DISTINCT CAST(pr.author_id AS varchar(36)), ','), '') AS cntrb_ids,
+    COALESCE(string_agg(DISTINCT CAST(prr.cntrb_id AS varchar(36)), ','), '') AS reviewer_ids
 FROM
     aveloxis_data.pull_requests pr
 INNER JOIN
@@ -1208,11 +1208,11 @@ DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_repo_files CASCADE;
 CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_repo_files AS
 SELECT
     rl.repo_id AS id,
-    r.repo_name,
-    r.repo_path,
+    COALESCE(r.repo_name, '') AS repo_name,
+    COALESCE(r.repo_path, '') AS repo_path,
     rl.rl_analysis_date,
-    rl.file_path,
-    rl.file_name
+    COALESCE(rl.file_path, '') AS file_path,
+    COALESCE(rl.file_name, '') AS file_name
 FROM
     aveloxis_data.repo_labor rl
 INNER JOIN

--- a/internal/db/matviews.sql
+++ b/internal/db/matviews.sql
@@ -1155,6 +1155,83 @@ SELECT a.id AS cntrb_id,
 
 
 -- =============================================================================
+-- 20. explorer_pr_files — PR file paths for 8Knot file-level analysis
+-- =============================================================================
+DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_pr_files CASCADE;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_pr_files AS
+SELECT
+    prf.pr_file_path AS file_path,
+    pr.pull_request_id AS pull_request_id,
+    pr.repo_id AS repo_id
+FROM
+    aveloxis_data.pull_requests pr
+INNER JOIN
+    aveloxis_data.pull_request_files prf
+ON
+    pr.pull_request_id = prf.pull_request_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_explorer_pr_files
+ON aveloxis_data.explorer_pr_files (file_path, pull_request_id, repo_id);
+
+-- =============================================================================
+-- 21. explorer_cntrb_per_file — contributors and reviewers per file path
+-- =============================================================================
+DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_cntrb_per_file CASCADE;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_cntrb_per_file AS
+SELECT
+    pr.repo_id AS repo_id,
+    prf.pr_file_path AS file_path,
+    string_agg(DISTINCT CAST(pr.author_id AS varchar(36)), ',') AS cntrb_ids,
+    string_agg(DISTINCT CAST(prr.cntrb_id AS varchar(36)), ',') AS reviewer_ids
+FROM
+    aveloxis_data.pull_requests pr
+INNER JOIN
+    aveloxis_data.pull_request_files prf
+ON
+    pr.pull_request_id = prf.pull_request_id
+LEFT OUTER JOIN
+    aveloxis_data.pull_request_reviews prr
+ON
+    pr.pull_request_id = prr.pull_request_id
+GROUP BY prf.pr_file_path, pr.repo_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_explorer_cntrb_per_file
+ON aveloxis_data.explorer_cntrb_per_file (repo_id, file_path);
+
+-- =============================================================================
+-- 22. explorer_repo_files — latest SCC file listing per repo
+-- =============================================================================
+DROP MATERIALIZED VIEW IF EXISTS aveloxis_data.explorer_repo_files CASCADE;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS aveloxis_data.explorer_repo_files AS
+SELECT
+    rl.repo_id AS id,
+    r.repo_name,
+    r.repo_path,
+    rl.rl_analysis_date,
+    rl.file_path,
+    rl.file_name
+FROM
+    aveloxis_data.repo_labor rl
+INNER JOIN
+    aveloxis_data.repos r
+ON
+    rl.repo_id = r.repo_id
+WHERE
+    (rl.repo_id, rl.rl_analysis_date) IN (
+        SELECT DISTINCT ON (repo_id)
+            repo_id, rl_analysis_date
+        FROM aveloxis_data.repo_labor
+        ORDER BY repo_id, rl_analysis_date DESC
+    );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_explorer_repo_files
+ON aveloxis_data.explorer_repo_files (id, file_path, file_name);
+
+
+-- =============================================================================
 -- Materialized View Refresh List
 -- =============================================================================
 -- Use this list in the refresh function. Order matters: simpler views first,
@@ -1179,4 +1256,7 @@ SELECT a.id AS cntrb_id,
 --  17. aveloxis_data.explorer_repo_languages
 --  18. aveloxis_data.issue_reporter_created_at
 --  19. aveloxis_data.explorer_contributor_recent_actions
+--  20. aveloxis_data.explorer_pr_files
+--  21. aveloxis_data.explorer_cntrb_per_file
+--  22. aveloxis_data.explorer_repo_files
 -- =============================================================================

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -66,8 +66,8 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
 -- contributors, repo_groups, etc.) are NOT duplicated here — they resolve
 -- via the search_path fallback to aveloxis_data.
 --
--- Usage: set search_path = aveloxis_augur_data, aveloxis_data
--- In 8Knot .env: AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data
+-- Usage: SET search_path TO aveloxis_augur_data, aveloxis_data;
+-- In 8Knot .env (no spaces after comma): AUGUR_SCHEMA=aveloxis_augur_data,aveloxis_data
 --
 -- This does NOT conflict with existing Augur databases: if someone runs
 -- Aveloxis on an existing Augur DB that already has augur_data, they set

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -58,6 +58,83 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
 );
 
 -- ============================================================
+-- Augur compatibility schema: aveloxis_augur_data
+-- ============================================================
+-- 8Knot and other Augur-era tools use Augur table/column names that differ
+-- from Aveloxis conventions. This schema contains ONLY views for tables
+-- where column names differ. Tables with identical columns (commits,
+-- contributors, repo_groups, etc.) are NOT duplicated here — they resolve
+-- via the search_path fallback to aveloxis_data.
+--
+-- Usage: set search_path = aveloxis_augur_data, aveloxis_data
+-- In 8Knot .env: AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data
+--
+-- This does NOT conflict with existing Augur databases: if someone runs
+-- Aveloxis on an existing Augur DB that already has augur_data, they set
+-- AUGUR_SCHEMA=augur_data and this schema is never consulted.
+--
+-- Column name mapping (Aveloxis → Augur alias):
+--   repos.primary_language        → repo_language
+--   repo_info.star_count          → stars_count
+--   repo_info.watcher_count       → watchers_count
+--   issues.issue_number           → gh_issue_number
+--   issues.platform_issue_id      → gh_issue_id
+--   issues.closed_by_id           → cntrb_id (issue closer)
+--   pull_requests.pr_number       → pr_src_number
+--   pull_requests.platform_pr_id  → pr_src_id
+--   pull_requests.author_id       → pr_augur_contributor_id
+--   pull_requests.created_at      → pr_created_at
+--   pull_requests.closed_at       → pr_closed_at
+--   pull_requests.merged_at       → pr_merged_at
+--   releases.created_at           → release_created_at
+--   releases.published_at         → release_published_at
+--   releases.updated_at           → release_updated_at
+
+CREATE SCHEMA IF NOT EXISTS aveloxis_augur_data;
+
+-- repo (singular table name + repo_language column alias)
+CREATE OR REPLACE VIEW aveloxis_augur_data.repo AS
+SELECT *, primary_language AS repo_language FROM aveloxis_data.repos;
+
+-- repo_info (star_count → stars_count, watcher_count → watchers_count)
+CREATE OR REPLACE VIEW aveloxis_augur_data.repo_info AS
+SELECT *,
+    star_count AS stars_count,
+    watcher_count AS watchers_count
+FROM aveloxis_data.repo_info;
+
+-- issues (Augur gh_ prefixed columns + cntrb_id for closer)
+CREATE OR REPLACE VIEW aveloxis_augur_data.issues AS
+SELECT *,
+    issue_number AS gh_issue_number,
+    platform_issue_id AS gh_issue_id,
+    closed_by_id AS cntrb_id
+FROM aveloxis_data.issues;
+
+-- pull_requests (Augur pr_ prefixed timestamps + pr_src_ columns)
+CREATE OR REPLACE VIEW aveloxis_augur_data.pull_requests AS
+SELECT *,
+    pr_number AS pr_src_number,
+    platform_pr_id AS pr_src_id,
+    author_id AS pr_augur_contributor_id,
+    created_at AS pr_created_at,
+    closed_at AS pr_closed_at,
+    merged_at AS pr_merged_at
+FROM aveloxis_data.pull_requests;
+
+-- releases (Augur release_ prefixed timestamps)
+CREATE OR REPLACE VIEW aveloxis_augur_data.releases AS
+SELECT *,
+    created_at AS release_created_at,
+    published_at AS release_published_at,
+    updated_at AS release_updated_at
+FROM aveloxis_data.releases;
+
+-- message (Augur uses singular "message", Aveloxis uses plural "messages")
+CREATE OR REPLACE VIEW aveloxis_augur_data.message AS
+SELECT * FROM aveloxis_data.messages;
+
+-- ============================================================
 -- Repo groups list serve (mailing lists)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS aveloxis_data.repo_groups_list_serve (

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -103,31 +103,67 @@ SELECT *,
     watcher_count AS watchers_count
 FROM aveloxis_data.repo_info;
 
--- issues (Augur gh_ prefixed columns + cntrb_id for closer)
+-- issues: column renames + timestamps cast to TIMESTAMP (no tz).
+-- Augur uses TIMESTAMP; Aveloxis uses TIMESTAMPTZ. 8Knot's pandas code assumes
+-- tz-naive timestamps and crashes with "Start and end cannot both be tz-aware
+-- with different timezones" if it gets a mix of tz-aware and NULL values.
 CREATE OR REPLACE VIEW aveloxis_augur_data.issues AS
-SELECT *,
+SELECT
+    issue_id, repo_id, platform_issue_id,
+    issue_number,
     issue_number AS gh_issue_number,
     platform_issue_id AS gh_issue_id,
-    closed_by_id AS cntrb_id
+    node_id, issue_title, issue_body, issue_state, issue_url, html_url,
+    reporter_id,
+    closed_by_id,
+    closed_by_id AS cntrb_id,
+    pull_request, pull_request_id,
+    created_at::timestamp AS created_at,
+    updated_at::timestamp AS updated_at,
+    closed_at::timestamp AS closed_at,
+    due_on::timestamp AS due_on,
+    comment_count,
+    tool_source, tool_version, data_source,
+    data_collection_date::timestamp AS data_collection_date
 FROM aveloxis_data.issues;
 
--- pull_requests (Augur pr_ prefixed timestamps + pr_src_ columns)
+-- pull_requests: column renames + timestamps cast to TIMESTAMP (no tz).
 CREATE OR REPLACE VIEW aveloxis_augur_data.pull_requests AS
-SELECT *,
-    pr_number AS pr_src_number,
+SELECT
+    pull_request_id, repo_id, platform_pr_id,
     platform_pr_id AS pr_src_id,
+    node_id,
+    pr_number,
+    pr_number AS pr_src_number,
+    pr_url, pr_html_url, pr_diff_url, pr_title, pr_body, pr_state, pr_locked,
+    author_id,
     author_id AS pr_augur_contributor_id,
-    created_at AS pr_created_at,
-    closed_at AS pr_closed_at,
-    merged_at AS pr_merged_at
+    author_association, meta_head_id, meta_base_id, merge_commit_sha,
+    created_at::timestamp AS created_at,
+    created_at::timestamp AS pr_created_at,
+    updated_at::timestamp AS updated_at,
+    closed_at::timestamp AS closed_at,
+    closed_at::timestamp AS pr_closed_at,
+    merged_at::timestamp AS merged_at,
+    merged_at::timestamp AS pr_merged_at,
+    tool_source, tool_version, data_source,
+    data_collection_date::timestamp AS data_collection_date
 FROM aveloxis_data.pull_requests;
 
--- releases (Augur release_ prefixed timestamps)
+-- releases: column renames + timestamps cast to TIMESTAMP (no tz).
 CREATE OR REPLACE VIEW aveloxis_augur_data.releases AS
-SELECT *,
-    created_at AS release_created_at,
-    published_at AS release_published_at,
-    updated_at AS release_updated_at
+SELECT
+    release_id, repo_id, release_name, release_description, release_author,
+    release_tag_name, release_url,
+    created_at::timestamp AS created_at,
+    created_at::timestamp AS release_created_at,
+    published_at::timestamp AS published_at,
+    published_at::timestamp AS release_published_at,
+    updated_at::timestamp AS updated_at,
+    updated_at::timestamp AS release_updated_at,
+    is_draft, is_prerelease, tag_only,
+    tool_source, tool_version, data_source,
+    data_collection_date::timestamp AS data_collection_date
 FROM aveloxis_data.releases;
 
 -- message (Augur uses singular "message", Aveloxis uses plural "messages")

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.13.7"
+var ToolVersion = "0.14.0"


### PR DESCRIPTION
What was added to Aveloxis:                                                                                                             
   
  schema.sql now creates a third schema aveloxis_augur_data with 6 views — only for tables where Augur and Aveloxis column names differ:  
                                                            
  <html>
<head>

</head>
<body>

<p class="p1">Here is a narrower version that should wrap better in Markdown:</p>



View | Why
-- | --
repo | Augur uses singular repo and repo_language; Aveloxis uses plural repos and primary_language.
repo_info | star_count → stars_count; watcher_count → watchers_count.
issues | issue_number → gh_issue_number; platform_issue_id → gh_issue_id; closed_by_id → cntrb_id.
pull_requests | pr_number → pr_src_number; author_id → pr_augur_contributor_id; timestamps get pr_ prefix.
releases | Timestamps get release_ prefix.
message | Augur singular message; Aveloxis plural messages.


</body>
</html>
   
  Tables with identical columns (commits, contributors, repo_groups, pull_request_events, repo_labor, repo_deps_libyear, etc.) have no    
  views — they resolve via the search_path fallback.        
                                                                                                                                          
  How 8Knot uses it: AUGUR_SCHEMA=aveloxis_augur_data, aveloxis_data in .env. PostgreSQL checks the first schema for each query, falls    
  through to the second.
                                                                                                                                          
  Augur DB compatibility preserved: Users running Aveloxis on an existing Augur database just use AUGUR_SCHEMA=augur_data — the           
  aveloxis_augur_data schema is never consulted.
                                                                                                                                          
  Tests: 7 new tests in augur_compat_test.go verifying schema creation, all required views with correct column aliases, and that no       
  unnecessary pass-through views exist.
                                                                                                                                          
  Docs updated: README.md, docs/architecture/overview.md.                                                                      
   
  To activate: run aveloxis migrate (creates the schema + views), then restart 8Knot. 
  
  
  ------ Second Major Component ------
  
  3 new materialized views (previously missing from 8Knot's requirements):

  <html>
<head>

</head>
<body>


Materialized View | Sources | Index | Purpose
-- | -- | -- | --
explorer_pr_files | pull_requests JOIN pull_request_files | (file_path, pull_request_id, repo_id) | PR file paths for 8Knot file-level analysis
explorer_cntrb_per_file | pull_requests JOIN pull_request_files LEFT JOIN pull_request_reviews | (repo_id, file_path) | Aggregated contributor IDs and reviewer IDs per file
explorer_repo_files | repo_labor JOIN repos | (id, file_path, file_name) | Latest SCC file listing per repo, using only the most recent analysis date


</body>
</html>

  The 4th missing Mateialized view (explorer_pr_reponse — note the typo) already existed as explorer_pr_response (correctly spelled) in Aveloxis.

  All three have unique indexes enabling REFRESH MATERIALIZED VIEW CONCURRENTLY. All three are added to the matviewNames refresh list in
  matviews.go. Column names use Aveloxis conventions (e.g., author_id not pr_augur_contributor_id) — 8Knot accesses them via the
  aveloxis_augur_data compatibility schema where column aliases are applied.

  To activate: aveloxis migrate or aveloxis refresh-views.