### PR TITLE
updated from 10k stress test findings

### DIFF
--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -411,10 +411,10 @@ func runAddRepo(cfgPath string, repoURLs []string, priority int) error {
 			var repos []orgRepo
 			switch plat {
 			case model.PlatformGitHub:
-				ghHTTP := platform.NewHTTPClient("https://api.github.com", ghKeys, logger)
+				ghHTTP := platform.NewHTTPClient("https://api.github.com", ghKeys, logger, platform.AuthGitHub)
 				repos, err = listGitHubOrgRepos(ctx, ghHTTP, orgName)
 			case model.PlatformGitLab:
-				glHTTP := platform.NewHTTPClient("https://"+host+"/api/v4", glKeys, logger)
+				glHTTP := platform.NewHTTPClient("https://"+host+"/api/v4", glKeys, logger, platform.AuthGitLab)
 				repos, err = listGitLabGroupRepos(ctx, glHTTP, orgName)
 			}
 			if err != nil {

--- a/docs/architecture/platform-layer.md
+++ b/docs/architecture/platform-layer.md
@@ -44,6 +44,7 @@ All list methods return `iter.Seq2[T, error]` (Go 1.23 iterators) for memory-eff
 
 Shared by both GitHub and GitLab implementations. Features:
 
+- **Platform-aware authentication**: `AuthStyle` parameter controls the auth header format. GitHub uses `Authorization: token <key>` (PATs). GitLab uses `PRIVATE-TOKEN: <key>`. Set at construction via `NewHTTPClient(..., AuthGitHub)` or `NewHTTPClient(..., AuthGitLab)`.
 - **Connection pooling**: HTTP/2 enabled, 20 idle connections per host for high-throughput collection.
 - **Automatic retries**: Up to 10 retries with exponential backoff for transient errors (502/503/504).
 - **Rate limit awareness**: Reads `X-RateLimit-*` (GitHub) and `RateLimit-*` (GitLab) headers, waits for reset when exhausted.

--- a/internal/collector/breadth.go
+++ b/internal/collector/breadth.go
@@ -31,7 +31,7 @@ type BreadthWorker struct {
 func NewBreadthWorker(store *db.PostgresStore, keys *platform.KeyPool, logger *slog.Logger) *BreadthWorker {
 	return &BreadthWorker{
 		store:  store,
-		http:   platform.NewHTTPClient("https://api.github.com", keys, logger),
+		http:   platform.NewHTTPClient("https://api.github.com", keys, logger, platform.AuthGitHub),
 		logger: logger,
 	}
 }

--- a/internal/collector/commit_resolver.go
+++ b/internal/collector/commit_resolver.go
@@ -48,7 +48,7 @@ type CommitResolver struct {
 func NewCommitResolver(store *db.PostgresStore, keys *platform.KeyPool, logger *slog.Logger) *CommitResolver {
 	return &CommitResolver{
 		store:      store,
-		http:       platform.NewHTTPClient("https://api.github.com", keys, logger),
+		http:       platform.NewHTTPClient("https://api.github.com", keys, logger, platform.AuthGitHub),
 		logger:     logger,
 		emailCache: make(map[string]string),
 		hashCache:  make(map[string]string),

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.14.5"
+var ToolVersion = "0.14.6"

--- a/internal/platform/auth_test.go
+++ b/internal/platform/auth_test.go
@@ -1,0 +1,131 @@
+package platform
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestGitHubAuthHeader verifies that HTTPClient sends "Authorization: token <key>"
+// for GitHub-style auth (the default and existing behavior).
+func TestGitHubAuthHeader(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	keys := NewKeyPool([]string{"gh-test-token-123"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	client.Get(context.Background(), "/repos/test")
+
+	if gotHeader != "token gh-test-token-123" {
+		t.Errorf("GitHub auth header = %q, want %q", gotHeader, "token gh-test-token-123")
+	}
+}
+
+// TestGitLabAuthHeader verifies that HTTPClient sends "PRIVATE-TOKEN: <key>"
+// for GitLab-style auth. This is the critical fix — previously all requests
+// used GitHub's "Authorization: token" format, which GitLab silently ignores,
+// causing zero issues/MRs/metadata to be collected.
+func TestGitLabAuthHeader(t *testing.T) {
+	var gotPrivateToken string
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPrivateToken = r.Header.Get("PRIVATE-TOKEN")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	keys := NewKeyPool([]string{"gl-test-token-456"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitLab)
+
+	client.Get(context.Background(), "/projects/test")
+
+	if gotPrivateToken != "gl-test-token-456" {
+		t.Errorf("GitLab PRIVATE-TOKEN header = %q, want %q", gotPrivateToken, "gl-test-token-456")
+	}
+	// Must NOT send Authorization header for GitLab.
+	if gotAuth != "" {
+		t.Errorf("GitLab should not send Authorization header, got %q", gotAuth)
+	}
+}
+
+// TestAuthStyleConstants verifies the auth style constants exist.
+func TestAuthStyleConstants(t *testing.T) {
+	if AuthGitHub == AuthGitLab {
+		t.Error("AuthGitHub and AuthGitLab must be different values")
+	}
+}
+
+// TestHTTPClientSourceHasAuthStyle is a source code contract test verifying
+// that NewHTTPClient accepts an authStyle parameter and Get uses it.
+func TestHTTPClientSourceHasAuthStyle(t *testing.T) {
+	src, err := os.ReadFile("httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// NewHTTPClient must accept an AuthStyle parameter.
+	idx := strings.Index(code, "func NewHTTPClient(")
+	if idx < 0 {
+		t.Fatal("cannot find NewHTTPClient function")
+	}
+	sig := code[idx : idx+200]
+	if !strings.Contains(sig, "AuthStyle") {
+		t.Error("NewHTTPClient must accept an AuthStyle parameter to support platform-specific auth headers")
+	}
+
+	// Get must use the auth style (not hardcode "token").
+	getIdx := strings.Index(code, "func (c *HTTPClient) Get(")
+	if getIdx < 0 {
+		t.Fatal("cannot find Get method")
+	}
+	getBody := code[getIdx:]
+	if len(getBody) > 3000 {
+		getBody = getBody[:3000]
+	}
+	if !strings.Contains(getBody, "authStyle") && !strings.Contains(getBody, "AuthStyle") {
+		t.Error("Get method must use the client's auth style to set the correct header")
+	}
+}
+
+// TestGitLabClientUsesGitLabAuth verifies the GitLab client constructs its
+// HTTPClient with AuthGitLab style.
+func TestGitLabClientUsesGitLabAuth(t *testing.T) {
+	src, err := os.ReadFile("gitlab/client.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "AuthGitLab") {
+		t.Error("GitLab client.go must pass AuthGitLab to NewHTTPClient")
+	}
+}
+
+// TestGitHubClientUsesGitHubAuth verifies the GitHub client constructs its
+// HTTPClient with AuthGitHub style.
+func TestGitHubClientUsesGitHubAuth(t *testing.T) {
+	src, err := os.ReadFile("github/client.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "AuthGitHub") {
+		t.Error("GitHub client.go must pass AuthGitHub to NewHTTPClient")
+	}
+}

--- a/internal/platform/github/client.go
+++ b/internal/platform/github/client.go
@@ -24,7 +24,7 @@ type Client struct {
 // (or a GitHub Enterprise URL).
 func New(baseURL string, keys *platform.KeyPool, logger *slog.Logger) *Client {
 	return &Client{
-		http:   platform.NewHTTPClient(baseURL, keys, logger),
+		http:   platform.NewHTTPClient(baseURL, keys, logger, platform.AuthGitHub),
 		logger: logger,
 	}
 }

--- a/internal/platform/github/enrichment_test.go
+++ b/internal/platform/github/enrichment_test.go
@@ -20,7 +20,7 @@ func testGHClient(t *testing.T, handler http.Handler) *Client {
 	t.Cleanup(server.Close)
 	logger := slog.Default()
 	keys := platform.NewKeyPool([]string{"test-token"}, logger)
-	httpClient := platform.NewHTTPClient(server.URL, keys, logger)
+	httpClient := platform.NewHTTPClient(server.URL, keys, logger, platform.AuthGitHub)
 	return &Client{http: httpClient, logger: logger}
 }
 

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -29,7 +29,7 @@ func New(baseURL string, keys *platform.KeyPool, logger *slog.Logger) *Client {
 		host = u.Host
 	}
 	return &Client{
-		http:   platform.NewHTTPClient(baseURL, keys, logger),
+		http:   platform.NewHTTPClient(baseURL, keys, logger, platform.AuthGitLab),
 		logger: logger,
 		host:   host,
 	}

--- a/internal/platform/gitlab/community_files_test.go
+++ b/internal/platform/gitlab/community_files_test.go
@@ -17,7 +17,7 @@ func testClient(t *testing.T, handler http.Handler) *Client {
 	t.Cleanup(server.Close)
 	logger := slog.Default()
 	keys := platform.NewKeyPool([]string{"test-token"}, logger)
-	httpClient := platform.NewHTTPClient(server.URL, keys, logger)
+	httpClient := platform.NewHTTPClient(server.URL, keys, logger, platform.AuthGitLab)
 	return &Client{http: httpClient, logger: logger, host: "gitlab.com"}
 }
 

--- a/internal/platform/gitlab/enrichment_test.go
+++ b/internal/platform/gitlab/enrichment_test.go
@@ -271,6 +271,6 @@ func testClientWithLogger(t *testing.T, handler http.Handler, logger *slog.Logge
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 	keys := platform.NewKeyPool([]string{"test-token"}, logger)
-	httpClient := platform.NewHTTPClient(server.URL, keys, logger)
+	httpClient := platform.NewHTTPClient(server.URL, keys, logger, platform.AuthGitLab)
 	return &Client{http: httpClient, logger: logger, host: "gitlab.com"}
 }

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -21,13 +21,25 @@ import (
 // Callers should use their cached copy of the data.
 var ErrNotModified = errors.New("not modified (304)")
 
+// AuthStyle controls how API tokens are sent in HTTP requests.
+// GitHub and GitLab use different authentication header formats.
+type AuthStyle int
+
+const (
+	// AuthGitHub sends "Authorization: token <key>" (GitHub PAT format).
+	AuthGitHub AuthStyle = iota
+	// AuthGitLab sends "PRIVATE-TOKEN: <key>" (GitLab PAT format).
+	AuthGitLab
+)
+
 // HTTPClient wraps http.Client with rate-limiting, key rotation, retries, and
 // pagination. Used by both GitHub and GitLab implementations.
 type HTTPClient struct {
-	inner   *http.Client
-	keys    *KeyPool
-	logger  *slog.Logger
-	baseURL string // e.g. "https://api.github.com" or "https://gitlab.com/api/v4"
+	inner     *http.Client
+	keys      *KeyPool
+	logger    *slog.Logger
+	baseURL   string // e.g. "https://api.github.com" or "https://gitlab.com/api/v4"
+	authStyle AuthStyle
 
 	// etagCache stores ETags from previous responses, keyed by URL path.
 	// When a cached ETag exists, Get sends If-None-Match, which saves API quota
@@ -38,10 +50,11 @@ type HTTPClient struct {
 	etagCache map[string]string
 }
 
-// NewHTTPClient creates a platform-aware HTTP client.
+// NewHTTPClient creates a platform-aware HTTP client with the given auth style.
+// AuthGitHub sends "Authorization: token <key>"; AuthGitLab sends "PRIVATE-TOKEN: <key>".
 // Uses a transport tuned for high-throughput API collection: keepalives enabled,
 // generous idle connection pool, and HTTP/2 support (Go's default).
-func NewHTTPClient(baseURL string, keys *KeyPool, logger *slog.Logger) *HTTPClient {
+func NewHTTPClient(baseURL string, keys *KeyPool, logger *slog.Logger, authStyle AuthStyle) *HTTPClient {
 	transport := &http.Transport{
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 20, // GitHub/GitLab APIs are few hosts with many requests
@@ -56,6 +69,7 @@ func NewHTTPClient(baseURL string, keys *KeyPool, logger *slog.Logger) *HTTPClie
 		keys:      keys,
 		logger:    logger,
 		baseURL:   strings.TrimSuffix(baseURL, "/"),
+		authStyle: authStyle,
 		etagCache: make(map[string]string),
 	}
 }
@@ -82,9 +96,15 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 		if err != nil {
 			return nil, err
 		}
-		// GitHub accepts both "token" and "Bearer" for PATs.
-		// Old-style OAuth tokens (hex strings) only work with "token".
-		req.Header.Set("Authorization", "token "+key.Token)
+		// Set platform-appropriate auth header.
+		// GitHub: "Authorization: token <key>" (PATs and old OAuth tokens).
+		// GitLab: "PRIVATE-TOKEN: <key>" (Personal Access Tokens).
+		switch c.authStyle {
+		case AuthGitLab:
+			req.Header.Set("PRIVATE-TOKEN", key.Token)
+		default: // AuthGitHub
+			req.Header.Set("Authorization", "token "+key.Token)
+		}
 		req.Header.Set("Accept", "application/json")
 
 		// Conditional request: send If-None-Match when we have a cached ETag.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -704,7 +704,7 @@ func (s *Scheduler) refreshGitHubOrg(ctx context.Context, g db.OrgGroup) int {
 	if s.ghKeys == nil {
 		return 0
 	}
-	http := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger)
+	http := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger, platform.AuthGitHub)
 
 	newCount := 0
 	page := 1
@@ -771,7 +771,7 @@ func (s *Scheduler) refreshGitLabGroup(ctx context.Context, g db.OrgGroup) int {
 	// Need GitLab keys — check if the glClient is available.
 	// We'll reuse the ghKeys pool for now; in practice GitLab keys are separate.
 	// TODO: pass glKeys to the scheduler for GitLab org refresh.
-	http := platform.NewHTTPClient("https://"+glHost+"/api/v4", s.ghKeys, s.logger)
+	http := platform.NewHTTPClient("https://"+glHost+"/api/v4", s.ghKeys, s.logger, platform.AuthGitLab)
 
 	newCount := 0
 	page := 1
@@ -910,7 +910,7 @@ func (s *Scheduler) refreshUserOrgs(ctx context.Context) {
 			if s.ghKeys == nil {
 				continue
 			}
-			httpC := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger)
+			httpC := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger, platform.AuthGitHub)
 			// Try /orgs/ first, fall back to /users/ for personal accounts.
 			basePaths := []string{
 				fmt.Sprintf("/orgs/%s/repos", org.OrgName),

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -615,7 +615,7 @@ func (s *Server) scanOrgRepos(ctx context.Context, groupID int64, orgURL string)
 		return
 	}
 
-	httpClient := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger)
+	httpClient := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger, platform.AuthGitHub)
 	s.logger.Info("scanning repos for user group", "name", name, "group_id", groupID)
 
 	added := 0


### PR DESCRIPTION
## Root Cause                                           
                                                                                                                                                                              
 internal/platform/httpclient.go:87 hardcoded Authorization: token <key> for every HTTP request. This is the GitHub PAT format. GitLab expects PRIVATE-TOKEN: <key> and      
  silently ignores the Authorization: token header, treating all requests as unauthenticated. Result: zero issues, zero merge requests, zero metadata for every GitLab repo.

 Only commits worked because they come from git clone, not the API.                                                                                                          
                                                                                   
  Fix (v0.14.6)                                                                                                                                                               
                                                                                   
  New AuthStyle type with two constants: AuthGitHub and AuthGitLab.                                                                                                           
                                               
  NewHTTPClient now requires an AuthStyle parameter. The Get method sends the right header:                                                                                   
  - AuthGitHub → Authorization: token <key>                                        
  - AuthGitLab → PRIVATE-TOKEN: <key>                                                                                                                                         
                                                            
  All 14 call sites updated — GitHub callers pass AuthGitHub, GitLab callers pass AuthGitLab.                                                                                 
                                                                                                                                                                              
  Files changed:                                                                                                                                                              
  - internal/platform/httpclient.go — AuthStyle type, updated NewHTTPClient signature, platform-aware Get                                                                     
  - internal/platform/github/client.go — AuthGitHub                                                                                                                           
  - internal/platform/gitlab/client.go — AuthGitLab                                                                                                                           
  - internal/collector/commit_resolver.go — AuthGitHub                                                                                                                        
  - internal/collector/breadth.go — AuthGitHub              
  - internal/scheduler/scheduler.go — 3 sites (2 GitHub, 1 GitLab)                                                                                                            
  - cmd/aveloxis/main.go — 2 sites (1 GitHub, 1 GitLab)                                                                                                                       
  - internal/web/server.go — AuthGitHub                                                                                                                                       
  - 3 test files updated                                                                                                                                                      
                                                                                                                                                                              
  After deploying, you'll want to re-collect your GitLab repos to populate the data that was silently missing. You can either wait for the scheduler to pick them up naturally, or use aveloxis collect <gitlab-url> for immediate one-shot collection.  