### PR TITLE
Several fixes from error logs in 10k repo test

### DIFF
--- a/internal/collector/analysis.go
+++ b/internal/collector/analysis.go
@@ -91,6 +91,9 @@ func (ac *AnalysisCollector) AnalyzeRepo(ctx context.Context, repoID int64) (*An
 	}
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "git", "clone", barePath, workDir)
+	// Skip LFS smudge filters — dependency/license scanners only need text
+	// source files. LFS objects with expired quotas cause fatal checkout failures.
+	cmd.Env = gitCloneEnv()
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return result, fmt.Errorf("local clone failed: %w: %s", err, stderr.String())
@@ -250,6 +253,10 @@ func parseDependencyFile(path, lang string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Detect and transcode UTF-16 encoded files. Some Windows-created
+	// requirements.txt files use UTF-16LE (BOM 0xff 0xfe) which produces
+	// null-interleaved ASCII that PostgreSQL rejects with "invalid byte sequence".
+	data = decodeIfUTF16(data)
 	content := string(data)
 
 	switch filepath.Base(path) {
@@ -1276,6 +1283,60 @@ func cleanVersion(v string) string {
 
 	// Trim any whitespace left after operator removal (e.g., "~> 1.2" -> " 1.2").
 	return strings.TrimSpace(v)
+}
+
+// decodeIfUTF16 detects UTF-16 BOM and converts to UTF-8. Some Windows-created
+// manifest files (especially requirements.txt) are saved as UTF-16LE, producing
+// null-interleaved ASCII that fails PostgreSQL's UTF-8 validation.
+func decodeIfUTF16(data []byte) []byte {
+	if len(data) < 2 {
+		return data
+	}
+	// UTF-16LE BOM: 0xff 0xfe
+	if data[0] == 0xff && data[1] == 0xfe {
+		return utf16LEToUTF8(data[2:]) // skip BOM
+	}
+	// UTF-16BE BOM: 0xfe 0xff
+	if data[0] == 0xfe && data[1] == 0xff {
+		return utf16BEToUTF8(data[2:]) // skip BOM
+	}
+	return data
+}
+
+func utf16LEToUTF8(data []byte) []byte {
+	if len(data)%2 != 0 {
+		data = data[:len(data)-1] // drop trailing byte
+	}
+	var result []byte
+	for i := 0; i+1 < len(data); i += 2 {
+		ch := rune(data[i]) | rune(data[i+1])<<8
+		if ch < 0x80 {
+			result = append(result, byte(ch))
+		} else if ch < 0x800 {
+			result = append(result, byte(0xC0|(ch>>6)), byte(0x80|(ch&0x3F)))
+		} else {
+			result = append(result, byte(0xE0|(ch>>12)), byte(0x80|((ch>>6)&0x3F)), byte(0x80|(ch&0x3F)))
+		}
+	}
+	return result
+}
+
+func utf16BEToUTF8(data []byte) []byte {
+	if len(data)%2 != 0 {
+		data = data[:len(data)-1]
+	}
+	var result []byte
+	for i := 0; i+1 < len(data); i += 2 {
+		ch := rune(data[i])<<8 | rune(data[i+1])
+		if ch < 0x80 {
+			result = append(result, byte(ch))
+		} else if ch < 0x800 {
+			result = append(result, byte(0xC0|(ch>>6)), byte(0x80|(ch&0x3F)))
+		} else {
+			result = append(result, byte(0xE0|(ch>>12)), byte(0x80|((ch>>6)&0x3F)), byte(0x80|(ch&0x3F)))
+		}
+	}
+	return result
 }
 
 // resolveNPMLibyear checks the npm registry for the latest version.

--- a/internal/collector/facade.go
+++ b/internal/collector/facade.go
@@ -168,11 +168,23 @@ func (f *FacadeCollector) freshClone(ctx context.Context, gitURL, path string) e
 	}
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", "--", gitURL, path)
+	cmd.Env = gitCloneEnv()
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%w: %s", err, stderr.String())
 	}
 	return nil
+}
+
+// gitCloneEnv returns environment variables for git clone commands:
+// - GIT_LFS_SKIP_SMUDGE=1: prevents LFS smudge filter failures when remote
+//   objects are missing (common with free GitHub LFS quota).
+// - GIT_TERMINAL_PROMPT=0: prevents macOS keychain prompts
+//   (errSecInteractionNotAllowed) when running as a background process.
+func gitCloneEnv() []string {
+	env := os.Environ()
+	env = append(env, "GIT_LFS_SKIP_SMUDGE=1", "GIT_TERMINAL_PROMPT=0")
+	return env
 }
 
 // validateGitURL checks that a URL is safe to pass to git commands.

--- a/internal/collector/git_env_test.go
+++ b/internal/collector/git_env_test.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestFacadeCloneSetsLFSSkip verifies that the bare clone in facade.go sets
+// GIT_LFS_SKIP_SMUDGE=1 to prevent LFS smudge filter failures when repos
+// have LFS objects that are no longer available on the server.
+func TestFacadeCloneSetsLFSSkip(t *testing.T) {
+	src, err := os.ReadFile("facade.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "GIT_LFS_SKIP_SMUDGE") {
+		t.Error("facade.go must set GIT_LFS_SKIP_SMUDGE=1 on git clone commands " +
+			"to prevent failures when LFS objects are missing from the server")
+	}
+}
+
+// TestFacadeCloneSetsTerminalPrompt verifies that the bare clone sets
+// GIT_TERMINAL_PROMPT=0 to prevent macOS keychain prompts when repos
+// are deleted/private and git tries to ask for credentials.
+func TestFacadeCloneSetsTerminalPrompt(t *testing.T) {
+	src, err := os.ReadFile("facade.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "GIT_TERMINAL_PROMPT") {
+		t.Error("facade.go must set GIT_TERMINAL_PROMPT=0 on git clone commands " +
+			"to prevent macOS keychain prompts (errSecInteractionNotAllowed) " +
+			"when running as a background process")
+	}
+}
+
+// TestAnalysisCloneSetsLFSSkip verifies the analysis temp clone sets
+// git env vars (via gitCloneEnv) to skip LFS. This is where most LFS
+// failures occur because the full checkout triggers smudge filters.
+func TestAnalysisCloneSetsLFSSkip(t *testing.T) {
+	src, err := os.ReadFile("analysis.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// The analysis clone must use gitCloneEnv() (defined in facade.go)
+	// which sets GIT_LFS_SKIP_SMUDGE=1 and GIT_TERMINAL_PROMPT=0.
+	if !strings.Contains(code, "gitCloneEnv") {
+		t.Error("analysis.go must set cmd.Env = gitCloneEnv() on the temp clone " +
+			"to prevent LFS smudge filter failures — dependency scanners and " +
+			"ScanCode only need text source files, not binary LFS objects")
+	}
+}
+
+// TestUTF16BOMDetection verifies that parseDependencyFile detects UTF-16
+// BOM and transcodes to UTF-8 before parsing. Some Windows-created
+// requirements.txt files are UTF-16LE encoded.
+func TestUTF16BOMDetection(t *testing.T) {
+	src, err := os.ReadFile("analysis.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Must detect the UTF-16 BOM bytes (\xff\xfe or \xfe\xff).
+	if !strings.Contains(code, "0xff") && !strings.Contains(code, "0xfe") &&
+		!strings.Contains(code, "utf16") && !strings.Contains(code, "UTF16") {
+		t.Error("analysis.go must detect UTF-16 BOM in manifest files and transcode " +
+			"to UTF-8 before parsing — Windows-created requirements.txt files with " +
+			"UTF-16LE encoding produce null bytes that PostgreSQL rejects")
+	}
+}

--- a/internal/collector/prelim.go
+++ b/internal/collector/prelim.go
@@ -139,20 +139,48 @@ func resolveRedirects(ctx context.Context, repoURL string) (string, int, error) 
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, repoURL, nil)
-	if err != nil {
-		return "", 0, err
-	}
-	// Use a browser-like user agent to avoid bot blocks.
-	req.Header.Set("User-Agent", "Aveloxis/1.0")
+	// Retry transient DNS/network errors with exponential backoff (1s, 3s, 9s).
+	// During system crashes or network blips, DNS resolution fails briefly and
+	// all prelim checks that fire during that window would permanently skip repos.
+	var lastErr error
+	delays := []time.Duration{0, 1 * time.Second, 3 * time.Second, 9 * time.Second}
+	for attempt, delay := range delays {
+		if attempt > 0 {
+			time.Sleep(delay)
+		}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", 0, err
-	}
-	resp.Body.Close()
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, repoURL, nil)
+		if err != nil {
+			return "", 0, err
+		}
+		req.Header.Set("User-Agent", "Aveloxis/1.0")
 
-	return resp.Request.URL.String(), resp.StatusCode, nil
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			// Only retry on DNS/network errors, not on context cancellation.
+			if ctx.Err() != nil {
+				return "", 0, err
+			}
+			if isTransientNetError(err) && attempt < len(delays)-1 {
+				continue // retry
+			}
+			return "", 0, err
+		}
+		resp.Body.Close()
+		return resp.Request.URL.String(), resp.StatusCode, nil
+	}
+	return "", 0, lastErr
+}
+
+// isTransientNetError returns true for DNS resolution failures and connection
+// refused errors that are likely to resolve on retry.
+func isTransientNetError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "no such host") ||
+		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "network is unreachable") ||
+		strings.Contains(s, "i/o timeout")
 }
 
 // normalizeRepoURL strips protocol, trailing slashes, and .git suffix for comparison.

--- a/internal/collector/prelim_retry_test.go
+++ b/internal/collector/prelim_retry_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPrelimRetriesOnDNSErrors verifies that resolveRedirects retries on
+// transient DNS errors instead of failing immediately. During system crashes
+// or network blips, DNS resolution fails briefly and all prelim checks that
+// happen to fire during that window permanently skip repos.
+func TestPrelimRetriesOnDNSErrors(t *testing.T) {
+	src, err := os.ReadFile("prelim.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func resolveRedirects")
+	if idx < 0 {
+		t.Fatal("cannot find resolveRedirects function")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 2000 {
+		fnBody = fnBody[:2000]
+	}
+
+	// Must have a retry loop for transient network errors.
+	if !strings.Contains(fnBody, "retry") && !strings.Contains(fnBody, "attempt") {
+		t.Error("resolveRedirects must retry on transient DNS errors (no such host) " +
+			"with exponential backoff — 3 retries at 1s, 3s, 9s before giving up")
+	}
+}

--- a/internal/collector/scorecard.go
+++ b/internal/collector/scorecard.go
@@ -104,13 +104,17 @@ func RunScorecard(ctx context.Context, store *db.PostgresStore, repoID int64, re
 	// Scorecard needs GITHUB_TOKEN for API-dependent checks.
 	cmd.Env = append(cmd.Environ(), "GITHUB_TOKEN="+githubToken)
 
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("scorecard failed: %w: %s", err, stderr.String())
-	}
+	runErr := cmd.Run()
 
-	// Parse the JSON output.
+	// Parse the JSON output regardless of exit code. Scorecard exits with
+	// status 1 when individual checks fail (e.g., invalid YAML in workflow
+	// files), but still produces valid JSON with scores for successful checks.
+	// Only error if there's no parseable output at all.
 	var raw scorecardOutput
 	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		if runErr != nil {
+			return nil, fmt.Errorf("scorecard failed: %w: %s", runErr, stderr.String())
+		}
 		return nil, fmt.Errorf("parsing scorecard output: %w", err)
 	}
 

--- a/internal/collector/scorecard_partial_test.go
+++ b/internal/collector/scorecard_partial_test.go
@@ -1,0 +1,46 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestScorecardParsesPartialResults verifies that RunScorecard parses the
+// JSON output even when scorecard exits with status 1 (some checks failed).
+// Scorecard produces valid JSON with scores for successful checks plus
+// error details for failed ones. Treating exit 1 as a total failure
+// discards all the good data.
+func TestScorecardParsesPartialResults(t *testing.T) {
+	src, err := os.ReadFile("scorecard.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func RunScorecard(")
+	if idx < 0 {
+		t.Fatal("cannot find RunScorecard function")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 3000 {
+		fnBody = fnBody[:3000]
+	}
+
+	// The old pattern was:
+	//   if err := cmd.Run(); err != nil { return nil, fmt.Errorf("scorecard failed...") }
+	// This discards the JSON output that scorecard writes to stdout even on exit 1.
+	//
+	// The correct pattern: capture cmd.Run() error, then attempt JSON parse.
+	// Only return error if JSON parse fails AND cmd.Run() failed.
+	if strings.Contains(fnBody, `if err := cmd.Run(); err != nil`) {
+		t.Error("RunScorecard must not return error immediately on non-zero exit — " +
+			"scorecard produces valid JSON with partial results even when " +
+			"individual checks fail (exit 1). Capture error, then parse stdout.")
+	}
+	// Must capture the run error into a variable and continue to JSON parsing.
+	if !strings.Contains(fnBody, "runErr") && !strings.Contains(fnBody, "cmdErr") {
+		t.Error("RunScorecard should capture cmd.Run() error into a named variable " +
+			"(e.g., runErr) and attempt JSON parse regardless")
+	}
+}

--- a/internal/db/contributor_log_test.go
+++ b/internal/db/contributor_log_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestContributorUpsertDuplicateIsDebug verifies that the "failed to upsert
+// contributor" log for duplicate key violations (SQLSTATE 23505) is logged
+// at DEBUG level, not WARN. The duplicate key is a normal race condition
+// between concurrent workers — data integrity is maintained because the
+// contributor exists either way.
+func TestContributorUpsertDuplicateIsDebug(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the contributor upsert error log.
+	idx := strings.Index(code, `"contributor upsert failed"`)
+	if idx < 0 {
+		// Might have been renamed — check alternate form.
+		idx = strings.Index(code, `"failed to upsert contributor"`)
+	}
+	if idx < 0 {
+		t.Skip("cannot find contributor upsert error log")
+	}
+
+	// Look at the 100 chars before the log message to find the log level.
+	start := idx - 100
+	if start < 0 {
+		start = 0
+	}
+	context := code[start:idx]
+
+	if strings.Contains(context, ".Warn(") {
+		t.Error("contributor upsert duplicate-key log must be Debug level, not Warn — " +
+			"this is a normal race condition between concurrent workers, not a problem. " +
+			"Data integrity is maintained because the contributor exists either way.")
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1108,7 +1108,9 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 				ToolVersion,
 			).Scan(&cntrb_id)
 			if err != nil {
-				s.logger.Warn("contributor upsert failed", "login", login, "error", err)
+				// Duplicate key (23505) is a normal race condition between concurrent
+				// workers — the contributor exists either way. Log at Debug, not Warn.
+				s.logger.Debug("contributor upsert failed", "login", login, "error", err)
 				continue
 			}
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.15.1"
+var ToolVersion = "0.15.2"

--- a/internal/platform/keypool_lastkey_test.go
+++ b/internal/platform/keypool_lastkey_test.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestInvalidateKeyEscalatesToErrorWhenLastKey verifies that InvalidateKey
+// logs at ERROR level when the invalidated key is the last valid key for
+// the platform. When the last key is gone, all collection for that platform
+// stops silently — the operator needs a loud signal.
+func TestInvalidateKeyEscalatesToErrorWhenLastKey(t *testing.T) {
+	src, err := os.ReadFile("ratelimit.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (kp *KeyPool) InvalidateKey(")
+	if idx < 0 {
+		t.Fatal("cannot find InvalidateKey function")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 1000 {
+		fnBody = fnBody[:1000]
+	}
+
+	// Must check if this was the last valid key and escalate to Error.
+	if !strings.Contains(fnBody, "Error(") && !strings.Contains(fnBody, "error(") {
+		t.Error("InvalidateKey must log at ERROR level when the invalidated key " +
+			"is the last valid key for the platform — all collection stops silently otherwise")
+	}
+}

--- a/internal/platform/ratelimit.go
+++ b/internal/platform/ratelimit.go
@@ -194,11 +194,29 @@ func (kp *KeyPool) MarkDepleted(key *APIKey, estimatedCalls int) {
 }
 
 // InvalidateKey marks a key as permanently invalid (bad credentials).
+// Escalates to ERROR when this was the last valid key — all collection
+// for the platform stops silently otherwise.
 func (kp *KeyPool) InvalidateKey(key *APIKey) {
 	kp.mu.Lock()
 	defer kp.mu.Unlock()
 	key.Invalid = true
-	kp.logger.Warn("API key invalidated", "token_prefix", key.Token[:min(8, len(key.Token))]+"...")
+
+	// Count remaining valid keys.
+	validRemaining := 0
+	for _, k := range kp.keys {
+		if !k.Invalid {
+			validRemaining++
+		}
+	}
+
+	prefix := key.Token[:min(8, len(key.Token))] + "..."
+	if validRemaining == 0 {
+		kp.logger.Error("LAST API key invalidated — all collection for this platform will fail",
+			"token_prefix", prefix)
+	} else {
+		kp.logger.Warn("API key invalidated",
+			"token_prefix", prefix, "valid_keys_remaining", validRemaining)
+	}
 }
 
 // IsEmpty returns true if the pool was created with zero keys.

--- a/internal/scheduler/git_url_test.go
+++ b/internal/scheduler/git_url_test.go
@@ -1,0 +1,36 @@
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestGitURLDoesNotDoubleGitSuffix verifies that the gitURL construction
+// in runFacadeAndAnalysis does not append .git when the repo name already
+// ends with .git. Many JOSS/Augur-imported URLs have the .git suffix,
+// producing https://github.com/owner/repo.git.git which returns 404.
+func TestGitURLDoesNotDoubleGitSuffix(t *testing.T) {
+	src, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find where gitURL is constructed (near runFacadeAndAnalysis).
+	idx := strings.Index(code, "func (s *Scheduler) runFacadeAndAnalysis")
+	if idx < 0 {
+		t.Fatal("cannot find runFacadeAndAnalysis")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 2000 {
+		fnBody = fnBody[:2000]
+	}
+
+	// Must not blindly append .git — must check/strip first.
+	if strings.Contains(fnBody, `/%s.git"`) && !strings.Contains(fnBody, "TrimSuffix") {
+		t.Error("gitURL construction must not blindly append .git — " +
+			"repos imported from JOSS/Augur already have .git suffix, " +
+			"producing double .git.git which returns 404")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/augurlabs/aveloxis/internal/collector"
@@ -451,8 +452,11 @@ func (s *Scheduler) runFacadeAndAnalysis(ctx context.Context, repoID int64, repo
 	// Phase 3: Facade — creates/updates bare clone and parses git log.
 	var facadeResult *collector.FacadeResult
 	fc := collector.NewFacadeCollector(s.store, s.logger, s.cfg.RepoCloneDir)
+	// Strip any existing .git suffix before appending to avoid double
+	// .git.git URLs. Many JOSS/Augur-imported repos store the URL with .git.
+	repoName := strings.TrimSuffix(repo.Name, ".git")
 	gitURL := fmt.Sprintf("https://%s/%s/%s.git",
-		platformHostForModel(repo.Platform), repo.Owner, repo.Name)
+		platformHostForModel(repo.Platform), repo.Owner, repoName)
 	result, err := fc.CollectRepo(ctx, repoID, gitURL)
 	if err != nil {
 		s.logger.Warn("facade collection failed", "repo_id", repoID, "error", err)


### PR DESCRIPTION
### Changes (v0.15.2) — Production Run Fixes

| # | Issue | Root Cause | Fix | Files |
| :--- | :--- | :--- | :--- | :--- |
| 1 | Double .git.git URLs (404s) | `fmt.Sprintf("%s.git", repo.Name)` with names already ending in `.git` | `strings.TrimSuffix(repo.Name, ".git")` before appending | `scheduler.go` |
| 2 | LFS smudge filter failures | Analysis clone triggers LFS for repos with expired LFS quotas | `GIT_LFS_SKIP_SMUDGE=1` on all git clones via `gitCloneEnv()` | `facade.go`, `analysis.go` |
| 3 | macOS keychain prompts | Background git processes trigger credential helper | `GIT_TERMINAL_PROMPT=0` on all git clones | `facade.go` |
| 4 | UTF-16 requirements.txt | Windows-created files with BOM `0xff 0xfe` → null bytes | `decodeIfUTF16()` detects BOM and transcodes | `analysis.go` |
| 5 | Scorecard discarding partial results | `cmd.Run()` error immediately returned, discarding valid JSON | Parse stdout regardless of exit code; error only if no JSON | `scorecard.go` |
| 6 | Prelim DNS failures permanent | No retry on transient DNS errors | 3 retries with exponential backoff (1s, 3s, 9s) | `prelim.go` |
| 7 | Noisy contributor WARN logs | Normal race condition logged as WARN | Downgraded to DEBUG | `postgres.go` |
| 8 | Silent platform death on last key | Last API key invalidated with just a WARN | Escalated to ERROR with clear message | `ratelimit.go` |