### PR TITLE
acceleration fixes - deal with very large repositories more quickly on initial collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ aveloxis start api     # → ~/.aveloxis/api.log
 
 Then you can open the interfaces:
 ```bash
-open http://localhost:5555   # Monitor dashboard
-open http://localhost:8082   # Web GUI (login, visualizations, comparison)
+open http://localhost:8082          # Web GUI (login, visualizations, comparison)
+open http://localhost:8082/monitor  # Collection monitor dashboard (requires login)
 open http://localhost:8383/api/v1/health  # REST API
 ```
 
@@ -190,15 +190,15 @@ This starts 5 containers:
 |---|---|---|
 | `postgres` | PostgreSQL 16 database | 5432 |
 | `migrate` | Runs schema migrations, then exits | — |
-| `serve` | Collection scheduler + monitoring dashboard | **5555** |
-| `web` | Web GUI (OAuth login, visualizations) | **8082** |
+| `serve` | Collection scheduler | — |
+| `web` | Web GUI (OAuth login, visualizations, monitor) | **8082** |
 | `api` | REST API (stats, charts, SBOMs) | **8383** |
 
 ### Step 3: Open the interfaces
 
 ```
-http://localhost:5555                # Monitor dashboard (queue status, repo progress)
 http://localhost:8082                # Web GUI (login with GitHub, create groups, add repos)
+http://localhost:8082/monitor        # Collection monitor (queue status, repo progress)
 http://localhost:8383/api/v1/health  # REST API health check
 ```
 
@@ -298,8 +298,8 @@ aveloxis add-key --from-augur
 #    Each URL is verified against the forge via HTTP HEAD — dead repos are skipped.
 aveloxis add-repo --from-augur
 
-# 5. Start collecting. Open http://localhost:5555 to monitor progress.
-aveloxis serve --monitor :5555
+# 5. Start collecting. Open http://localhost:8082/monitor to watch progress.
+aveloxis start all
 ```
 
 After step 3, your keys live in `aveloxis_ops.worker_oauth` and are loaded automatically — no `--augur-keys` flag needed going forward. After step 4, all your verified Augur repos are in the Aveloxis queue and will be collected on the scheduler's priority order.
@@ -331,10 +331,10 @@ aveloxis add-repo https://github.com/chaoss/augur https://gitlab.com/fdroid/fdro
 # Open http://localhost:8082, log in with GitHub/GitLab, create a group,
 # and add repos or orgs through the UI.
 
-# 5. Start the scheduler + monitoring dashboard
-aveloxis serve --monitor :5555
+# 5. Start the scheduler
+aveloxis start serve
 
-# Open http://localhost:5555 to see the dashboard
+# Open http://localhost:8082/monitor to watch collection progress
 ```
 
 ## Configuration
@@ -433,15 +433,14 @@ Keys are loaded from three sources, merged together:
 
 ## Commands
 
-### `aveloxis serve` — Run the scheduler and monitor
+### `aveloxis serve` — Run the collection scheduler
 
-Starts the long-running scheduler that continuously collects repos from the queue, plus a web dashboard for monitoring. Uses the **staged collection pipeline** (see Architecture).
+Starts the long-running scheduler that continuously collects repos from the queue. Uses the **staged collection pipeline** (see Architecture). The monitor dashboard is integrated into `aveloxis web` at `/monitor`.
 
 ```bash
 aveloxis serve [flags]
 
 Flags:
-  --monitor string   Dashboard address (default ":5555")
   --workers int      Concurrent collection workers (default 1)
   --augur-keys       Load API keys from Augur's worker_oauth table
 ```
@@ -533,10 +532,7 @@ aveloxis prioritize https://github.com/chaoss/augur
 
 Sets priority to 0 and due time to now. The scheduler will collect this repo next.
 
-Also available via HTTP:
-```bash
-curl -X POST http://localhost:5555/api/prioritize/42
-```
+Also available via the monitor dashboard's "Boost" button at `/monitor`, or by clicking "Boost" next to any queued repo.
 
 ### `aveloxis migrate` — Set up the database schema
 
@@ -656,25 +652,20 @@ Flags:
 
 ## Monitoring Dashboard
 
-The web dashboard at `http://localhost:5555` (configurable via `--monitor`) shows:
+The monitor dashboard is integrated into the web GUI at `/monitor` (requires login). It shows:
 
 - Queue statistics (total, queued, collecting)
 - Every repo with: status, priority, due time, last run duration
 - **Gathered vs Metadata columns**: Gathered Issues, Meta Issues, Gathered PRs, Meta PRs, Gathered Commits, Meta Commits — so you can see collection completeness at a glance
 - A **Boost** button to push any queued repo to the top
+- Pagination at 200 repos per page
 - Auto-refreshes every 10 seconds
 
-### Monitor API
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/api/queue` | GET | Full queue state as JSON |
-| `/api/stats` | GET | `{"queued": N, "collecting": N, "total": N}` |
-| `/api/prioritize/{repoID}` | POST | Push repo to top of queue |
+Navigate to the monitor from any page via the "Monitor" link in the top nav bar.
 
 ### REST API (`aveloxis api`)
 
-Separate process (default `:8383`). Start alongside `serve` and `web`.
+Separate process (default `127.0.0.1:8383`). Start alongside `serve` and `web`.
 
 | Endpoint | Method | Description |
 |---|---|---|
@@ -762,12 +753,14 @@ Designed for 400K+ repos. Eliminates database contention on the contributors tab
 
 **Phase 1 — Collect (fast, no contention):** Raw API responses are written to a JSONB staging table (`aveloxis_ops.staging`). No FK lookups, no contributor resolution. Multiple workers can blast data concurrently with zero contention on any relational table. Issues and PRs are staged as **envelope types** that bundle the parent entity with all its children (labels, assignees, reviewers, reviews, commits, files, head/base metadata) in a single JSONB row. Data is collected in this order:
 
-1. Contributors (seed from member/contributor lists)
-2. Issues + labels + assignees (bundled per issue)
-3. Pull requests + all children (bundled per PR)
-4. Events (issue + PR)
-5. Messages (issue comments, PR comments, inline review comments)
-6. Repo info, releases, clone/traffic stats
+1. Repo info, releases, clone/traffic stats (collected first for commit count metadata)
+2. Contributors (seed from member/contributor lists)
+3. Issues + labels + assignees (bundled per issue)
+4. Pull requests + all children (bundled per PR)
+5. Events (issue + PR)
+6. Messages (issue comments, PR comments, inline review comments)
+
+For repos with **>10,000 commits** (detected from repo_info metadata), steps 3-5 run in **parallel** across 3 goroutines (each with its own staging writer), then messages are collected after all three complete.
 
 **Heartbeat locking:** During staged collection, workers send heartbeats every 30 seconds (`HeartbeatJob`) to update `locked_at`. This prevents `RecoverStaleLocks` (1-hour timeout) from stealing active jobs on large repos that take hours to collect. Without heartbeats, the stale lock recovery would repeatedly reclaim the lock and purge accumulated staging data.
 
@@ -1099,7 +1092,7 @@ Review bodies are stored in both `pull_request_reviews.review_body` (for quick a
 | Aspect | Augur | Aveloxis |
 |---|---|---|
 | Language | Python | Go |
-| Processes | Celery workers + Flask API + Flower + Redis + RabbitMQ | 3 processes: `serve` (scheduler+monitor), `web` (GUI), `api` (REST) |
+| Processes | Celery workers + Flask API + Flower + Redis + RabbitMQ | 3 processes: `serve` (scheduler), `web` (GUI+monitor), `api` (REST) |
 | Queue | Celery + RabbitMQ + Redis | Postgres `SKIP LOCKED` (no extra infrastructure) |
 | Monitoring | Flower (separate service) | Built-in dashboard with gathered vs metadata count columns |
 | Testing | Lags development due to long history. | Test first programming from birth. | 

--- a/docs/guide/collection-pipeline.md
+++ b/docs/guide/collection-pipeline.md
@@ -25,6 +25,24 @@ Aveloxis has two collection pipelines: the **staged pipeline** (used by `aveloxi
 
 The staged pipeline is designed for 400K+ repos. It eliminates database contention on the `contributors` table by decoupling API collection from relational persistence.
 
+### Collection order
+
+Repo info and metadata are collected **first** (Phase 0) to provide commit count before the heavy phases. For repos with more than 10,000 commits, issues, PRs, and events are collected in **parallel** across 3 goroutines, each with its own staging writer. Messages are collected after the parallel phase completes. Repos under the threshold use sequential collection.
+
+### Parallel collection
+
+When `CommitCount >= 10,000` (from repo_info metadata):
+
+```
+Phase 0: Repo info, releases, clone stats (sequential)
+Phase 1: Contributors (sequential)
+Phase 2: Issues | PRs | Events (3 parallel goroutines)
+         ─── wait ───
+Phase 3: Messages (sequential, after parallel phase)
+```
+
+The 3 extra goroutines claim parallel slots tracked by an atomic counter. The scheduler's `fillWorkerSlots` pauses new job starts while the total active count (semaphore + parallel slots) exceeds the configured worker limit.
+
 The direct pipeline is simpler -- it writes directly to relational tables with inline contributor resolution. Best for testing or collecting a small number of repos.
 
 ---

--- a/internal/collector/collection_order_test.go
+++ b/internal/collector/collection_order_test.go
@@ -1,0 +1,75 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRepoInfoCollectedBeforeIssuesAndPRs verifies the staged collection
+// order has repo_info, releases, and clone stats BEFORE contributors, issues,
+// and PRs. This enables large-repo detection (>10K commits) before the heavy
+// collection phases begin.
+func TestRepoInfoCollectedBeforeIssuesAndPRs(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the CollectRepo function.
+	idx := strings.Index(code, "func (sc *StagedCollector) CollectRepo(")
+	if idx < 0 {
+		t.Fatal("cannot find CollectRepo function")
+	}
+	fnBody := code[idx:]
+
+	// Repo info (FetchRepoInfo) must appear BEFORE issues (ListIssues).
+	repoInfoIdx := strings.Index(fnBody, "FetchRepoInfo")
+	issuesIdx := strings.Index(fnBody, "ListIssues")
+	if repoInfoIdx < 0 {
+		t.Fatal("cannot find FetchRepoInfo in CollectRepo")
+	}
+	if issuesIdx < 0 {
+		t.Fatal("cannot find ListIssues in CollectRepo")
+	}
+	if repoInfoIdx > issuesIdx {
+		t.Error("FetchRepoInfo must be called BEFORE ListIssues in CollectRepo — " +
+			"repo_info provides commit count metadata needed for large-repo " +
+			"detection before the heavy collection phases begin")
+	}
+
+	// Repo info must also appear before ListPullRequests.
+	prsIdx := strings.Index(fnBody, "ListPullRequests")
+	if prsIdx < 0 {
+		t.Fatal("cannot find ListPullRequests in CollectRepo")
+	}
+	if repoInfoIdx > prsIdx {
+		t.Error("FetchRepoInfo must be called BEFORE ListPullRequests")
+	}
+
+	// Repo info must appear before ListContributors too (it's the very first phase now).
+	contribIdx := strings.Index(fnBody, "ListContributors")
+	if contribIdx < 0 {
+		t.Fatal("cannot find ListContributors in CollectRepo")
+	}
+	if repoInfoIdx > contribIdx {
+		t.Error("FetchRepoInfo must be called BEFORE ListContributors — " +
+			"metadata collection is now Phase 0, contributors is Phase 1")
+	}
+}
+
+// TestCollectResultHasCommitCount verifies CollectResult exposes the commit
+// count from repo_info for large-repo detection.
+func TestCollectResultHasCommitCount(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "CommitCount") {
+		t.Error("CollectResult must include CommitCount from repo_info " +
+			"for large-repo detection (>10K commits triggers parallel collection)")
+	}
+}

--- a/internal/collector/collection_order_test.go
+++ b/internal/collector/collection_order_test.go
@@ -89,6 +89,41 @@ func TestRepoInfoProcessedBeforeContributors(t *testing.T) {
 	}
 }
 
+// TestMetadataProcessedImmediatelyDuringCollection verifies that repo_info,
+// releases, and clone stats are flushed and processed immediately during
+// collection (not deferred to ProcessRepo). This ensures metadata appears
+// in the monitor even while issues/PRs are still being collected.
+func TestMetadataProcessedImmediatelyDuringCollection(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the CollectRepo function.
+	idx := strings.Index(code, "func (sc *StagedCollector) CollectRepo(")
+	if idx < 0 {
+		t.Fatal("cannot find CollectRepo function")
+	}
+	fnBody := code[idx:]
+	// Look before the contributors phase (within the first ~3000 chars).
+	contribIdx := strings.Index(fnBody, "Phase 1: Contributors")
+	if contribIdx < 0 {
+		contribIdx = 3000
+	}
+	metadataSection := fnBody[:contribIdx]
+
+	// Must call ProcessStaged for EntityRepoInfo during collection,
+	// not just stage it for later processing.
+	if !strings.Contains(metadataSection, "ProcessStaged") {
+		t.Error("CollectRepo must call ProcessStaged for metadata entities " +
+			"(EntityRepoInfo, EntityCloneStats, EntityRelease) immediately " +
+			"after staging them, before the heavy collection phases begin. " +
+			"Without this, metadata sits unprocessed during the entire " +
+			"collection window and a crash loses it.")
+	}
+}
+
 // TestCollectResultHasCommitCount verifies CollectResult exposes the commit
 // count from repo_info for large-repo detection.
 func TestCollectResultHasCommitCount(t *testing.T) {

--- a/internal/collector/collection_order_test.go
+++ b/internal/collector/collection_order_test.go
@@ -59,6 +59,36 @@ func TestRepoInfoCollectedBeforeIssuesAndPRs(t *testing.T) {
 	}
 }
 
+// TestRepoInfoProcessedBeforeContributors verifies the processing order has
+// repo_info BEFORE contributors. This ensures metadata counts survive even
+// if processing is interrupted (crash/restart). Repo_info has no FK deps
+// on any other entity — it's safe to process first.
+func TestRepoInfoProcessedBeforeContributors(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the entityTypes slice in ProcessRepo.
+	idx := strings.Index(code, "entityTypes := []string{")
+	if idx < 0 {
+		t.Fatal("cannot find entityTypes slice in staged.go")
+	}
+	slice := code[idx : idx+500]
+
+	repoInfoIdx := strings.Index(slice, "EntityRepoInfo")
+	contribIdx := strings.Index(slice, "EntityContributor")
+	if repoInfoIdx < 0 || contribIdx < 0 {
+		t.Fatal("cannot find EntityRepoInfo or EntityContributor in entityTypes")
+	}
+	if repoInfoIdx > contribIdx {
+		t.Error("EntityRepoInfo must be processed BEFORE EntityContributor — " +
+			"metadata counts need to survive interrupted processing so the " +
+			"monitor shows correct gathered vs metadata columns")
+	}
+}
+
 // TestCollectResultHasCommitCount verifies CollectResult exposes the commit
 // count from repo_info for large-repo detection.
 func TestCollectResultHasCommitCount(t *testing.T) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -66,6 +66,7 @@ type CollectResult struct {
 	Events       int
 	Releases     int
 	Contributors int
+	CommitCount  int // from repo_info metadata, used for large-repo detection
 	Errors       []error
 }
 

--- a/internal/collector/parallel_collect_test.go
+++ b/internal/collector/parallel_collect_test.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLargeRepoThresholdConstant verifies a threshold constant exists for
+// determining when parallel collection kicks in.
+func TestLargeRepoThresholdConstant(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "LargeRepoCommitThreshold") {
+		t.Error("staged.go must define LargeRepoCommitThreshold constant (10000) " +
+			"for detecting repos that qualify for parallel collection")
+	}
+}
+
+// TestParallelCollectionExists verifies the parallel collection code path
+// exists for large repos.
+func TestParallelCollectionExists(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Must check CommitCount against threshold.
+	if !strings.Contains(code, "CommitCount") || !strings.Contains(code, "LargeRepoCommitThreshold") {
+		t.Error("staged.go must check CommitCount against LargeRepoCommitThreshold " +
+			"to decide whether to use parallel collection")
+	}
+
+	// Must use goroutines for parallel collection.
+	if !strings.Contains(code, "sync.WaitGroup") && !strings.Contains(code, "go func") {
+		t.Error("staged.go must use goroutines (sync.WaitGroup or go func) " +
+			"for parallel issue/PR/event collection on large repos")
+	}
+}
+
+// TestParallelCollectionUsesSeparateWriters verifies each parallel goroutine
+// gets its own StagingWriter for thread safety.
+func TestParallelCollectionUsesSeparateWriters(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Must create multiple StagingWriters (at least 3 for the parallel goroutines).
+	// Count occurrences of NewStagingWriter.
+	count := strings.Count(code, "NewStagingWriter")
+	if count < 2 {
+		t.Errorf("staged.go has %d NewStagingWriter calls, need at least 2 "+
+			"(1 for parent, 1+ for parallel goroutines) for thread safety", count)
+	}
+}
+
+// TestSchedulerTracksParallelSlots verifies the scheduler has a mechanism
+// to track extra parallel worker slots that large repos claim.
+func TestSchedulerTracksParallelSlots(t *testing.T) {
+	src, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "parallelSlots") && !strings.Contains(code, "extraWorkers") {
+		t.Error("scheduler.go must track extra parallel worker slots " +
+			"(parallelSlots or extraWorkers atomic counter) so fillWorkerSlots " +
+			"respects the capacity when large repos claim extra slots")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -375,7 +375,7 @@ func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter,
 		}
 		result.PullRequests++
 		if result.PullRequests%100 == 0 {
-			sc.logger.Info("pull requests progress", "staged", result.PullRequests)
+			sc.logger.Info("pull requests progress", "owner", owner, "repo", repo, "staged", result.PullRequests)
 		}
 	}
 	sc.logger.Info("pull requests staged", "count", result.PullRequests)

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -123,9 +123,11 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		sc.logger.Warn("failed to update collection status", "repo_id", repoID, "error", err)
 	}
 
-	// Phase 0: Metadata — collected first so we have commit count and other
-	// repo metrics before the heavy collection phases. This enables large-repo
-	// detection (>10K commits) for parallel collection.
+	// Phase 0: Metadata — collected AND PROCESSED first so metadata counts
+	// appear in the monitor immediately, even while the heavy collection
+	// phases (issues, PRs, events) are still running. Without immediate
+	// processing, repo_info sits unprocessed in staging for the entire
+	// duration of collection, and a crash/restart loses the metadata.
 	sc.logger.Info("collecting metadata", "owner", owner, "repo", repo)
 	info, infoErr := sc.client.FetchRepoInfo(ctx, owner, repo)
 	if infoErr != nil {
@@ -150,7 +152,21 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			sw.Stage(ctx, EntityCloneStats, clone)
 		}
 	}
-	sc.logger.Info("metadata staged", "commit_count", result.CommitCount, "releases", result.Releases)
+
+	// Flush and process metadata immediately so it's in the DB before
+	// the minutes-long issue/PR/event collection begins. This ensures
+	// the monitor shows metadata counts even during active collection,
+	// and a crash/restart doesn't lose the metadata.
+	if err := sw.Flush(ctx); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("metadata flush: %w", err))
+	}
+	proc := NewProcessor(sc.store, sc.logger)
+	for _, et := range []string{EntityRepoInfo, EntityCloneStats, EntityRelease} {
+		sc.store.ProcessStaged(ctx, repoID, et, 500, func(rows []db.StagedRow) error {
+			return proc.processBatch(ctx, repoID, sc.platID, et, rows)
+		})
+	}
+	sc.logger.Info("metadata processed", "commit_count", result.CommitCount, "releases", result.Releases)
 
 	// Phase 1: Contributors.
 	sc.logger.Info("collecting contributors", "owner", owner, "repo", repo)

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -435,10 +435,14 @@ const processBatchSize = 500
 func (p *Processor) ProcessRepo(ctx context.Context, repoID int64, platID int16) error {
 	p.logger.Info("processing staged data", "repo_id", repoID)
 
-	// Order matters: contributors must exist before FK resolution.
-	// Issues/PRs (with bundled children) come next.
-	// Events/messages reference issues/PRs by platform ID, not DB ID, so order is less strict.
+	// Order matters: repo_info is processed FIRST so metadata counts
+	// (used by the monitor and gap fill) survive even if processing is
+	// interrupted. Contributors must exist before FK resolution in
+	// issues/PRs/events/messages.
 	entityTypes := []string{
+		EntityRepoInfo,
+		EntityCloneStats,
+		EntityRelease,
 		EntityContributor,
 		EntityIssue,
 		EntityPullRequest,
@@ -446,9 +450,6 @@ func (p *Processor) ProcessRepo(ctx context.Context, repoID int64, platID int16)
 		EntityPREvent,
 		EntityMessage,
 		EntityReviewComment,
-		EntityRelease,
-		EntityRepoInfo,
-		EntityCloneStats,
 	}
 
 	for _, entityType := range entityTypes {

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/augurlabs/aveloxis/internal/db"
@@ -43,6 +45,17 @@ const (
 	EntityRepoInfo      = "repo_info"
 	EntityCloneStats    = "clone_stats"
 )
+
+// LargeRepoCommitThreshold is the commit count above which parallel collection
+// kicks in. Repos with more commits than this typically also have many issues,
+// PRs, and events — collecting them in parallel significantly speeds up the
+// initial collection pass.
+const LargeRepoCommitThreshold = 10000
+
+// ParallelSlots is a global counter tracking how many extra parallel goroutines
+// are active for large-repo collection. The scheduler's fillWorkerSlots checks
+// this to avoid starting new jobs while large repos consume extra capacity.
+var ParallelSlots atomic.Int32
 
 // Envelope types that bundle a parent entity with its children.
 // These are what get JSON-serialized into the staging table.
@@ -110,7 +123,36 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		sc.logger.Warn("failed to update collection status", "repo_id", repoID, "error", err)
 	}
 
-	// Phase 0: Contributors.
+	// Phase 0: Metadata — collected first so we have commit count and other
+	// repo metrics before the heavy collection phases. This enables large-repo
+	// detection (>10K commits) for parallel collection.
+	sc.logger.Info("collecting metadata", "owner", owner, "repo", repo)
+	info, infoErr := sc.client.FetchRepoInfo(ctx, owner, repo)
+	if infoErr != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("repo info: %w", infoErr))
+	} else {
+		sw.Stage(ctx, EntityRepoInfo, info)
+		result.CommitCount = info.CommitCount
+	}
+
+	for rel, relErr := range sc.client.ListReleases(ctx, owner, repo) {
+		if relErr != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("releases: %w", relErr))
+			break
+		}
+		sw.Stage(ctx, EntityRelease, rel)
+		result.Releases++
+	}
+
+	clones, cloneErr := sc.client.FetchCloneStats(ctx, owner, repo)
+	if cloneErr == nil {
+		for _, clone := range clones {
+			sw.Stage(ctx, EntityCloneStats, clone)
+		}
+	}
+	sc.logger.Info("metadata staged", "commit_count", result.CommitCount, "releases", result.Releases)
+
+	// Phase 1: Contributors.
 	sc.logger.Info("collecting contributors", "owner", owner, "repo", repo)
 	for contrib, err := range sc.client.ListContributors(ctx, owner, repo) {
 		if err != nil {
@@ -124,14 +166,115 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 	}
 	sc.logger.Info("contributors staged", "count", result.Contributors)
 
-	// Phase 1: Issues — bundle each issue with its labels and assignees.
+	// Decide between parallel and sequential collection based on commit count.
+	// Large repos (>10K commits) typically have many issues, PRs, and events.
+	// Collecting them in parallel across 3 goroutines significantly speeds up
+	// the initial collection pass.
+	if result.CommitCount >= LargeRepoCommitThreshold {
+		sc.logger.Info("large repo detected — using parallel collection",
+			"repo_id", repoID, "commit_count", result.CommitCount)
+		sc.collectParallel(ctx, repoID, owner, repo, since, result)
+	} else {
+		sc.collectSequential(ctx, sw, owner, repo, since, result)
+	}
+
+	// Final flush.
+	if err := sw.Flush(ctx); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("staging flush: %w", err))
+	}
+
+	sc.logger.Info("staged collection complete",
+		"repoID", repoID, "staged_issues", result.Issues,
+		"staged_prs", result.PullRequests, "staged_messages", result.Messages,
+		"staged_events", result.Events, "staged_releases", result.Releases)
+
+	return result, nil
+}
+
+// collectSequential runs issues, PRs, events, and messages one after another.
+// Used for repos with fewer than LargeRepoCommitThreshold commits.
+func (sc *StagedCollector) collectSequential(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
+	sc.collectIssues(ctx, sw, owner, repo, since, result)
+	sc.collectPRs(ctx, sw, owner, repo, since, result)
+	sc.collectEvents(ctx, sw, owner, repo, since, result)
+	sc.collectMessages(ctx, sw, owner, repo, since, result)
+}
+
+// collectParallel runs issues, PRs, and events concurrently in 3 goroutines,
+// each with its own StagingWriter for thread safety. The parent waits for all
+// three to complete before collecting messages. Claims 3 extra parallel slots
+// from the global counter so fillWorkerSlots can respect the capacity.
+func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, owner, repo string, since time.Time, result *CollectResult) {
+	// Claim 3 extra parallel slots.
+	ParallelSlots.Add(3)
+	defer ParallelSlots.Add(-3)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex // protects result.Errors and counts
+
+	// Each goroutine gets its own StagingWriter and CollectResult for
+	// thread-safe staging. Results are merged under the mutex.
+	wg.Add(3)
+
+	// Goroutine 1: Issues
+	go func() {
+		defer wg.Done()
+		issueSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
+		localResult := &CollectResult{}
+		sc.collectIssues(ctx, issueSW, owner, repo, since, localResult)
+		issueSW.Flush(ctx)
+		mu.Lock()
+		result.Issues += localResult.Issues
+		result.Errors = append(result.Errors, localResult.Errors...)
+		mu.Unlock()
+	}()
+
+	// Goroutine 2: Pull Requests
+	go func() {
+		defer wg.Done()
+		prSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
+		localResult := &CollectResult{}
+		sc.collectPRs(ctx, prSW, owner, repo, since, localResult)
+		prSW.Flush(ctx)
+		mu.Lock()
+		result.PullRequests += localResult.PullRequests
+		result.Errors = append(result.Errors, localResult.Errors...)
+		mu.Unlock()
+	}()
+
+	// Goroutine 3: Events
+	go func() {
+		defer wg.Done()
+		eventSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
+		localResult := &CollectResult{}
+		sc.collectEvents(ctx, eventSW, owner, repo, since, localResult)
+		eventSW.Flush(ctx)
+		mu.Lock()
+		result.Events += localResult.Events
+		result.Errors = append(result.Errors, localResult.Errors...)
+		mu.Unlock()
+	}()
+
+	// Wait for all three parallel goroutines to finish.
+	wg.Wait()
+	sc.logger.Info("parallel collection complete",
+		"issues", result.Issues, "prs", result.PullRequests, "events", result.Events)
+
+	// Messages collect sequentially after parallel phase.
+	// They need a fresh StagingWriter.
+	msgSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
+	sc.collectMessages(ctx, msgSW, owner, repo, since, result)
+	msgSW.Flush(ctx)
+}
+
+// collectIssues stages all issues with their labels and assignees.
+func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
 	sc.logger.Info("collecting issues", "owner", owner, "repo", repo)
 	for issue, err := range sc.client.ListIssues(ctx, owner, repo, since) {
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("issues: %w", err))
 			break
 		}
-
 		envelope := stagedIssue{Issue: issue}
 		for label, err := range sc.client.ListIssueLabels(ctx, owner, repo, issue.Number) {
 			if err != nil {
@@ -145,7 +288,6 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			}
 			envelope.Assignees = append(envelope.Assignees, assignee)
 		}
-
 		if err := sw.Stage(ctx, EntityIssue, envelope); err != nil {
 			result.Errors = append(result.Errors, err)
 		}
@@ -155,15 +297,16 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		}
 	}
 	sc.logger.Info("issues staged", "count", result.Issues)
+}
 
-	// Phase 1: Pull Requests — bundle each PR with all its children.
+// collectPRs stages all pull requests with their children.
+func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
 	sc.logger.Info("collecting pull requests", "owner", owner, "repo", repo)
 	for pr, err := range sc.client.ListPullRequests(ctx, owner, repo, since) {
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("pull requests: %w", err))
 			break
 		}
-
 		envelope := stagedPR{PR: pr}
 		for label, err := range sc.client.ListPRLabels(ctx, owner, repo, pr.Number) {
 			if err != nil {
@@ -211,7 +354,6 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			envelope.RepoHead = headRepo
 			envelope.RepoBase = baseRepo
 		}
-
 		if err := sw.Stage(ctx, EntityPullRequest, envelope); err != nil {
 			result.Errors = append(result.Errors, err)
 		}
@@ -221,8 +363,10 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		}
 	}
 	sc.logger.Info("pull requests staged", "count", result.PullRequests)
+}
 
-	// Phase 2: Events.
+// collectEvents stages issue and PR events.
+func (sc *StagedCollector) collectEvents(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
 	sc.logger.Info("collecting events", "owner", owner, "repo", repo)
 	for event, err := range sc.client.ListIssueEvents(ctx, owner, repo, since) {
 		if err != nil {
@@ -240,10 +384,11 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		sw.Stage(ctx, EntityPREvent, event)
 		result.Events++
 	}
-
 	sc.logger.Info("events staged", "count", result.Events)
+}
 
-	// Phase 2: Messages.
+// collectMessages stages issue comments, PR comments, and review comments.
+func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
 	sc.logger.Info("collecting messages", "owner", owner, "repo", repo)
 	for msg, err := range sc.client.ListIssueComments(ctx, owner, repo, since) {
 		if err != nil {
@@ -261,45 +406,7 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 		sw.Stage(ctx, EntityReviewComment, rc)
 		result.Messages++
 	}
-
 	sc.logger.Info("messages staged", "count", result.Messages)
-
-	// Phase 3: Metadata.
-	sc.logger.Info("collecting metadata", "owner", owner, "repo", repo)
-	info, err := sc.client.FetchRepoInfo(ctx, owner, repo)
-	if err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("repo info: %w", err))
-	} else {
-		sw.Stage(ctx, EntityRepoInfo, info)
-	}
-
-	for rel, err := range sc.client.ListReleases(ctx, owner, repo) {
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("releases: %w", err))
-			break
-		}
-		sw.Stage(ctx, EntityRelease, rel)
-		result.Releases++
-	}
-
-	clones, err := sc.client.FetchCloneStats(ctx, owner, repo)
-	if err == nil {
-		for _, clone := range clones {
-			sw.Stage(ctx, EntityCloneStats, clone)
-		}
-	}
-
-	// Final flush.
-	if err := sw.Flush(ctx); err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("staging flush: %w", err))
-	}
-
-	sc.logger.Info("staged collection complete",
-		"repoID", repoID, "staged_issues", result.Issues,
-		"staged_prs", result.PullRequests, "staged_messages", result.Messages,
-		"staged_events", result.Events, "staged_releases", result.Releases)
-
-	return result, nil
 }
 
 // Processor drains the staging table and writes to the relational schema.

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -237,26 +238,45 @@ func (s *PostgresStore) ListQueue(ctx context.Context) ([]QueueJob, error) {
 }
 
 // ListQueuePage returns a paginated slice of the queue for the monitor dashboard.
+// If search is non-empty, filters to repos whose owner or name contains the term.
 // Results are ordered: collecting first, then queued, then by priority and due_at.
-func (s *PostgresStore) ListQueuePage(ctx context.Context, limit, offset int) ([]QueueJob, int, error) {
+func (s *PostgresStore) ListQueuePage(ctx context.Context, limit, offset int, search string) ([]QueueJob, int, error) {
+	// Build WHERE clause for search.
+	whereClause := ""
+	args := []interface{}{}
+	argIdx := 1
+
+	if search != "" {
+		whereClause = fmt.Sprintf(` WHERE q.repo_id IN (
+			SELECT repo_id FROM aveloxis_data.repos
+			WHERE repo_owner ILIKE '%%' || $%d || '%%'
+			   OR repo_name ILIKE '%%' || $%d || '%%')`, argIdx, argIdx)
+		args = append(args, search)
+		argIdx++
+	}
+
 	// Get total count for pagination.
 	var total int
-	if err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM aveloxis_ops.collection_queue`).Scan(&total); err != nil {
+	countQuery := `SELECT COUNT(*) FROM aveloxis_ops.collection_queue q` + whereClause
+	if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
-	rows, err := s.pool.Query(ctx, `
-		SELECT repo_id, priority, status, due_at, locked_by, locked_at,
-			   last_collected, last_error,
-			   last_issues, last_prs, last_messages, last_events,
-			   last_releases, last_contributors, COALESCE(last_commits, 0),
-			   last_duration_ms, updated_at
-		FROM aveloxis_ops.collection_queue
+	dataQuery := fmt.Sprintf(`
+		SELECT q.repo_id, q.priority, q.status, q.due_at, q.locked_by, q.locked_at,
+			   q.last_collected, q.last_error,
+			   q.last_issues, q.last_prs, q.last_messages, q.last_events,
+			   q.last_releases, q.last_contributors, COALESCE(q.last_commits, 0),
+			   q.last_duration_ms, q.updated_at
+		FROM aveloxis_ops.collection_queue q
+		%s
 		ORDER BY
-			CASE status WHEN 'collecting' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END,
-			priority, due_at
-		LIMIT $1 OFFSET $2`, limit, offset)
+			CASE q.status WHEN 'collecting' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END,
+			q.priority, q.due_at
+		LIMIT $%d OFFSET $%d`, whereClause, argIdx, argIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := s.pool.Query(ctx, dataQuery, args...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -236,6 +236,48 @@ func (s *PostgresStore) ListQueue(ctx context.Context) ([]QueueJob, error) {
 	return jobs, rows.Err()
 }
 
+// ListQueuePage returns a paginated slice of the queue for the monitor dashboard.
+// Results are ordered: collecting first, then queued, then by priority and due_at.
+func (s *PostgresStore) ListQueuePage(ctx context.Context, limit, offset int) ([]QueueJob, int, error) {
+	// Get total count for pagination.
+	var total int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_ops.collection_queue`).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT repo_id, priority, status, due_at, locked_by, locked_at,
+			   last_collected, last_error,
+			   last_issues, last_prs, last_messages, last_events,
+			   last_releases, last_contributors, COALESCE(last_commits, 0),
+			   last_duration_ms, updated_at
+		FROM aveloxis_ops.collection_queue
+		ORDER BY
+			CASE status WHEN 'collecting' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END,
+			priority, due_at
+		LIMIT $1 OFFSET $2`, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var jobs []QueueJob
+	for rows.Next() {
+		var j QueueJob
+		if err := rows.Scan(
+			&j.RepoID, &j.Priority, &j.Status, &j.DueAt, &j.LockedBy, &j.LockedAt,
+			&j.LastCollected, &j.LastError,
+			&j.LastIssues, &j.LastPRs, &j.LastMessages, &j.LastEvents,
+			&j.LastReleases, &j.LastContributors, &j.LastCommits, &j.LastDurationMs, &j.UpdatedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, total, rows.Err()
+}
+
 // QueueStats returns counts by status.
 func (s *PostgresStore) QueueStats(ctx context.Context) (map[string]int, error) {
 	rows, err := s.pool.Query(ctx, `

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.15.2"
+var ToolVersion = "0.16.0"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -189,6 +189,16 @@ func (s *Scheduler) Run(ctx context.Context) {
 func (s *Scheduler) fillWorkerSlots(ctx context.Context, sem chan struct{}) {
 	claimed := 0
 	for {
+		// Check if extra parallelSlots from large-repo collection have pushed
+		// us over the configured worker limit. If so, don't start new jobs
+		// until the parallel goroutines finish and release their slots.
+		extraSlots := int(collector.ParallelSlots.Load())
+		if extraSlots > 0 && len(sem)+extraSlots >= s.cfg.Workers {
+			if claimed > 0 {
+				s.logger.Info("fill cycle complete (parallel slots active)", "claimed", claimed, "active", len(sem), "parallelSlots", extraSlots)
+			}
+			return
+		}
 		select {
 		case sem <- struct{}{}:
 			// Got a worker slot — try to claim a job.

--- a/internal/web/monitor_search_test.go
+++ b/internal/web/monitor_search_test.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMonitorSearchBarExists verifies the monitor template has a search bar.
+func TestMonitorSearchBarExists(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the monitor template.
+	idx := strings.Index(code, `{{define "monitor"}}`)
+	if idx < 0 {
+		t.Fatal("cannot find monitor template")
+	}
+	tmpl := code[idx:]
+	end := strings.Index(tmpl[1:], "{{define")
+	if end > 0 {
+		tmpl = tmpl[:end+1]
+	}
+
+	if !strings.Contains(tmpl, `name="q"`) {
+		t.Error("monitor template must have a search input with name=\"q\"")
+	}
+}
+
+// TestMonitorFirstLastPageNav verifies the monitor has First and Last page links.
+func TestMonitorFirstLastPageNav(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, `{{define "monitor"}}`)
+	if idx < 0 {
+		t.Fatal("cannot find monitor template")
+	}
+	tmpl := code[idx:]
+	end := strings.Index(tmpl[1:], "{{define")
+	if end > 0 {
+		tmpl = tmpl[:end+1]
+	}
+
+	if !strings.Contains(tmpl, "First") {
+		t.Error("monitor template must have a 'First' page navigation link")
+	}
+	if !strings.Contains(tmpl, "Last") {
+		t.Error("monitor template must have a 'Last' page navigation link")
+	}
+}
+
+// TestMonitorPaginationPreservesSearch verifies page links include the search query.
+func TestMonitorPaginationPreservesSearch(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, `{{define "monitor"}}`)
+	if idx < 0 {
+		t.Fatal("cannot find monitor template")
+	}
+	tmpl := code[idx:]
+	end := strings.Index(tmpl[1:], "{{define")
+	if end > 0 {
+		tmpl = tmpl[:end+1]
+	}
+
+	// Pagination links must include .Query to preserve search across pages.
+	if !strings.Contains(tmpl, ".Query") {
+		t.Error("monitor pagination links must include .Query to preserve " +
+			"search term across page navigation")
+	}
+}
+
+// TestMonitorHandlerReadsSearchParam verifies handleMonitor reads the q parameter.
+func TestMonitorHandlerReadsSearchParam(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (s *Server) handleMonitor(")
+	if idx < 0 {
+		t.Fatal("cannot find handleMonitor")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 4000 {
+		fnBody = fnBody[:4000]
+	}
+
+	if !strings.Contains(fnBody, `Get("q")`) {
+		t.Error("handleMonitor must read the 'q' query parameter for search")
+	}
+}
+
+// TestListQueuePageAcceptsSearch verifies the DB method supports a search filter.
+func TestListQueuePageAcceptsSearch(t *testing.T) {
+	src, err := os.ReadFile("../db/queue.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (s *PostgresStore) ListQueuePage(")
+	if idx < 0 {
+		t.Fatal("cannot find ListQueuePage")
+	}
+	sig := code[idx : idx+200]
+
+	if !strings.Contains(sig, "search") {
+		t.Error("ListQueuePage must accept a search parameter to filter by repo owner/name")
+	}
+}

--- a/internal/web/monitor_test.go
+++ b/internal/web/monitor_test.go
@@ -1,0 +1,112 @@
+package web
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMonitorRouteRegistered verifies the web server registers a /monitor route.
+func TestMonitorRouteRegistered(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "/monitor") {
+		t.Error("web server.go must register a /monitor route for the integrated monitor dashboard")
+	}
+}
+
+// TestMonitorTemplateExists verifies the monitor template is defined.
+func TestMonitorTemplateExists(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, `"monitor"`) {
+		t.Error("templates.go must define a 'monitor' template for the integrated monitor dashboard")
+	}
+}
+
+// TestMonitorNavLinkExists verifies the nav bar has a "Monitor" link
+// next to "Home" across all page templates.
+func TestMonitorNavLinkExists(t *testing.T) {
+	src, err := os.ReadFile("templates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// The dashboard breadcrumb should have Monitor link.
+	if !strings.Contains(code, "/monitor") {
+		t.Error("templates.go must include a /monitor navigation link in the nav/breadcrumb area")
+	}
+}
+
+// TestMonitorHandlerExists verifies the web server has a handleMonitor method.
+func TestMonitorHandlerExists(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "handleMonitor") {
+		t.Error("web server.go must have a handleMonitor method for the monitor dashboard")
+	}
+}
+
+// TestMonitorPagination verifies the monitor supports pagination.
+func TestMonitorPagination(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the function definition, not just a reference.
+	idx := strings.Index(code, "func (s *Server) handleMonitor(")
+	if idx < 0 {
+		t.Skip("handleMonitor function not found")
+	}
+	fnBody := code[idx:]
+	if len(fnBody) > 3000 {
+		fnBody = fnBody[:3000]
+	}
+
+	if !strings.Contains(fnBody, "page") {
+		t.Error("handleMonitor must support pagination (read 'page' query parameter)")
+	}
+}
+
+// TestListQueuePageExists verifies the DB has a paginated queue list method.
+func TestListQueuePageExists(t *testing.T) {
+	src, err := os.ReadFile("../db/queue.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "ListQueuePage") {
+		t.Error("db/queue.go must have ListQueuePage(ctx, limit, offset) for paginated monitor")
+	}
+}
+
+// TestMonitorBehindAuth verifies the monitor route is behind requireAuth.
+func TestMonitorBehindAuth(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the route registration section.
+	if strings.Contains(code, `"/monitor"`) && !strings.Contains(code, `requireAuth(s.handleMonitor)`) {
+		t.Error("monitor route must be behind requireAuth — the old standalone monitor " +
+			"was unauthenticated, but the integrated version should require login")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -152,6 +152,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/groups/remove-repo", s.requireAuth(s.handleRemoveRepo))
 	mux.HandleFunc("/compare", s.requireAuth(s.handleCompare))
 
+	// Monitor dashboard — integrated from the standalone monitor server.
+	mux.HandleFunc("/monitor", s.requireAuth(s.handleMonitor))
+	mux.HandleFunc("POST /monitor/prioritize/{repoID}", s.requireAuth(s.handleMonitorPrioritize))
+
 	return mux
 }
 
@@ -810,4 +814,125 @@ func (s *Server) handleRepoDetail(w http.ResponseWriter, r *http.Request, sess *
 		"RepoID":  repoID,
 		"GroupID": groupID,
 	})
+}
+
+// ============================================================
+// Monitor dashboard (integrated from standalone monitor)
+// ============================================================
+
+const monitorPageSize = 200
+
+func (s *Server) handleMonitor(w http.ResponseWriter, r *http.Request) {
+	sess := s.getSession(r)
+
+	// Parse pagination.
+	page := 1
+	if p := r.URL.Query().Get("page"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil && n > 0 {
+			page = n
+		}
+	}
+	offset := (page - 1) * monitorPageSize
+
+	stats, _ := s.store.QueueStats(r.Context())
+	jobs, total, _ := s.store.ListQueuePage(r.Context(), monitorPageSize, offset)
+
+	totalPages := (total + monitorPageSize - 1) / monitorPageSize
+	if totalPages < 1 {
+		totalPages = 1
+	}
+
+	// Enrich jobs with repo details and gathered vs metadata counts.
+	repoIDs := make([]int64, 0, len(jobs))
+	for _, j := range jobs {
+		repoIDs = append(repoIDs, j.RepoID)
+	}
+	repoStats, _ := s.store.GetRepoStatsBatch(r.Context(), repoIDs)
+
+	type monitorRow struct {
+		RowNum          int
+		RepoID          int64
+		Owner           string
+		Repo            string
+		Plat            string
+		Status          string
+		Priority        int
+		Due             string
+		LastRun         string
+		Worker          string
+		ErrInfo         string
+		GatheredIssues  int
+		MetaIssues      int
+		GatheredPRs     int
+		MetaPRs         int
+		GatheredCommits int
+		MetaCommits     int
+	}
+
+	rows := make([]monitorRow, 0, len(jobs))
+	for i, j := range jobs {
+		row := monitorRow{
+			RowNum:   offset + i + 1,
+			RepoID:   j.RepoID,
+			Status:   j.Status,
+			Priority: j.Priority,
+		}
+
+		if repo, err := s.store.GetRepoByID(r.Context(), j.RepoID); err == nil {
+			row.Owner = repo.Owner
+			row.Repo = repo.Name
+			row.Plat = repo.Platform.String()
+		}
+		if st, ok := repoStats[j.RepoID]; ok {
+			row.GatheredIssues = st.GatheredIssues
+			row.GatheredPRs = st.GatheredPRs
+			row.GatheredCommits = st.GatheredCommits
+			row.MetaIssues = st.MetadataIssues
+			row.MetaPRs = st.MetadataPRs
+			row.MetaCommits = st.MetadataCommits
+		}
+
+		row.Due = j.DueAt.Format("15:04:05")
+		if j.DueAt.Before(time.Now()) && j.Status == "queued" {
+			row.Due = "now"
+		}
+		row.LastRun = "-"
+		if j.LastCollected != nil {
+			row.LastRun = j.LastCollected.Format("Jan 2 15:04")
+			if j.LastDurationMs > 0 {
+				row.LastRun += fmt.Sprintf(" (%ds)", j.LastDurationMs/1000)
+			}
+		}
+		if j.LockedBy != nil {
+			row.Worker = *j.LockedBy
+		}
+		if j.LastError != nil && *j.LastError != "" {
+			row.ErrInfo = *j.LastError
+		}
+
+		rows = append(rows, row)
+	}
+
+	s.tmpl.ExecuteTemplate(w, "monitor", map[string]interface{}{
+		"Session":    sess,
+		"Stats":      stats,
+		"Jobs":       rows,
+		"Page":       page,
+		"TotalPages": totalPages,
+		"Total":      total,
+	})
+}
+
+func (s *Server) handleMonitorPrioritize(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.PrioritizeRepo(r.Context(), repoID); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	// Redirect back to the monitor page.
+	http.Redirect(w, r, "/monitor", http.StatusFound)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -825,17 +825,18 @@ const monitorPageSize = 200
 func (s *Server) handleMonitor(w http.ResponseWriter, r *http.Request) {
 	sess := s.getSession(r)
 
-	// Parse pagination.
+	// Parse pagination and search.
 	page := 1
 	if p := r.URL.Query().Get("page"); p != "" {
 		if n, err := strconv.Atoi(p); err == nil && n > 0 {
 			page = n
 		}
 	}
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
 	offset := (page - 1) * monitorPageSize
 
 	stats, _ := s.store.QueueStats(r.Context())
-	jobs, total, _ := s.store.ListQueuePage(r.Context(), monitorPageSize, offset)
+	jobs, total, _ := s.store.ListQueuePage(r.Context(), monitorPageSize, offset, query)
 
 	totalPages := (total + monitorPageSize - 1) / monitorPageSize
 	if totalPages < 1 {
@@ -920,6 +921,7 @@ func (s *Server) handleMonitor(w http.ResponseWriter, r *http.Request) {
 		"Page":       page,
 		"TotalPages": totalPages,
 		"Total":      total,
+		"Query":      query,
 	})
 }
 

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -86,7 +86,7 @@ h3{font-size:16px;margin-bottom:12px;color:#24292e}
 <a href="/logout">Logout</a>
 </div>
 </div>
-<div class="breadcrumb"><span class="current">Home</span></div>
+<div class="breadcrumb"><span class="current">Home</span><span class="sep">|</span><a href="/monitor">Monitor</a></div>
 <div class="container">
 <div class="card">
 <h2>Your Groups</h2>
@@ -207,7 +207,7 @@ h3{font-size:16px;margin-bottom:12px;color:#24292e}
 </div>
 </div>
 <div class="breadcrumb">
-<a href="/dashboard">Home</a><span class="sep">/</span><span class="current">{{.Group.Name}}</span>
+<a href="/dashboard">Home</a><span class="sep">|</span><a href="/monitor">Monitor</a><span class="sep">/</span><span class="current">{{.Group.Name}}</span>
 </div>
 <div class="container">
 <div class="card">
@@ -434,7 +434,7 @@ https://gitlab.com/group/project" style="width:100%;padding:8px 12px;border:1px 
 </div>
 </div>
 <div class="breadcrumb">
-<a href="/dashboard">Home</a><span class="sep">/</span>
+<a href="/dashboard">Home</a><span class="sep">|</span><a href="/monitor">Monitor</a><span class="sep">/</span>
 <a href="/groups/{{.GroupID}}">{{.Group.Name}}</a><span class="sep">/</span>
 <span class="current">{{.Repo.Owner}}/{{.Repo.Name}}</span>
 </div>
@@ -699,7 +699,7 @@ fetch(API_BASE + '/api/v1/repos/' + REPO_ID + '/scancode-files')
 </div>
 </div>
 <div class="breadcrumb">
-<a href="/dashboard">Home</a><span class="sep">/</span><span class="current">Compare Repos</span>
+<a href="/dashboard">Home</a><span class="sep">|</span><a href="/monitor">Monitor</a><span class="sep">/</span><span class="current">Compare Repos</span>
 </div>
 <div class="container">
 <div class="card">
@@ -917,6 +917,93 @@ if (urlRepos.length > 0) {
   });
 }
 </script>
+</body></html>
+{{end}}
+
+{{define "monitor"}}
+{{template "head" (dict "Title" "Monitor")}}
+<div class="nav">
+<a href="/dashboard" style="display:flex;align-items:center;gap:8px"><img src="/icon.png" alt="" style="height:28px;border-radius:4px"><strong>Aveloxis</strong></a>
+<div class="nav-user">
+{{if .Session.AvatarURL}}<img src="{{.Session.AvatarURL}}" alt="">{{end}}
+<span>{{.Session.LoginName}}</span>
+<a href="/logout">Logout</a>
+</div>
+</div>
+<div class="breadcrumb"><a href="/dashboard">Home</a><span class="sep">|</span><span class="current">Monitor</span></div>
+<div class="container" style="max-width:1600px">
+<div style="display:flex;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap">
+<div class="card" style="flex:1;min-width:120px;text-align:center;padding:1rem"><div style="font-size:2rem;font-weight:bold">{{.Stats.total}}</div><div style="color:#666;font-size:0.85rem">Total</div></div>
+<div class="card" style="flex:1;min-width:120px;text-align:center;padding:1rem"><div style="font-size:2rem;font-weight:bold">{{.Stats.queued}}</div><div style="color:#666;font-size:0.85rem">Queued</div></div>
+<div class="card" style="flex:1;min-width:120px;text-align:center;padding:1rem"><div style="font-size:2rem;font-weight:bold">{{.Stats.collecting}}</div><div style="color:#666;font-size:0.85rem">Collecting</div></div>
+</div>
+
+<div class="card" style="overflow-x:auto">
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+<h2 style="margin:0">Collection Queue</h2>
+<div style="color:#666;font-size:0.85rem">Page {{.Page}} of {{.TotalPages}} ({{.Total}} repos) &mdash; auto-refreshes every 10s</div>
+</div>
+<table class="repo-table" style="width:100%">
+<thead>
+<tr>
+  <th>#</th>
+  <th>Repository</th>
+  <th>Platform</th>
+  <th>Status</th>
+  <th>Priority</th>
+  <th>Due</th>
+  <th>Last Run</th>
+  <th style="text-align:right">Issues</th>
+  <th style="text-align:right">Meta</th>
+  <th style="text-align:right">PRs</th>
+  <th style="text-align:right">Meta</th>
+  <th style="text-align:right">Commits</th>
+  <th style="text-align:right">Meta</th>
+  <th>Action</th>
+</tr>
+</thead>
+<tbody>
+{{range .Jobs}}
+<tr{{if eq .Priority 0}} style="background:#fef3c7"{{end}}>
+  <td>{{.RowNum}}</td>
+  <td>{{.Owner}}/{{.Repo}}</td>
+  <td>{{.Plat}}</td>
+  <td>
+    <span class="{{if eq .Status "collecting"}}badge badge-blue{{else if eq .Status "queued"}}badge badge-gray{{else}}badge{{end}}">{{.Status}}</span>
+    {{if .Worker}} <span style="font-family:monospace;font-size:0.8rem">{{.Worker}}</span>{{end}}
+    {{if .ErrInfo}} <span style="color:#dc2626" title="{{.ErrInfo}}">err</span>{{end}}
+  </td>
+  <td>{{.Priority}}</td>
+  <td>{{.Due}}</td>
+  <td>{{.LastRun}}</td>
+  <td style="text-align:right;color:#059669">{{.GatheredIssues}}</td>
+  <td style="text-align:right;color:#6b7280;font-size:0.8rem">{{.MetaIssues}}</td>
+  <td style="text-align:right;color:#059669">{{.GatheredPRs}}</td>
+  <td style="text-align:right;color:#6b7280;font-size:0.8rem">{{.MetaPRs}}</td>
+  <td style="text-align:right;color:#059669">{{.GatheredCommits}}</td>
+  <td style="text-align:right;color:#6b7280;font-size:0.8rem">{{.MetaCommits}}</td>
+  <td>
+    {{if eq .Status "queued"}}
+    <form method="POST" action="/monitor/prioritize/{{.RepoID}}" style="display:inline">
+      <button type="submit" class="btn" style="padding:2px 8px;font-size:0.8rem">Boost</button>
+    </form>
+    {{end}}
+  </td>
+</tr>
+{{end}}
+{{if not .Jobs}}<tr><td colspan="14" style="text-align:center;color:#999;padding:2rem">No repos in queue</td></tr>{{end}}
+</tbody>
+</table>
+
+{{if gt .TotalPages 1}}
+<div style="display:flex;justify-content:center;gap:8px;margin-top:16px">
+{{if gt .Page 1}}<a href="/monitor?page={{subtract .Page 1}}" class="btn">&laquo; Prev</a>{{end}}
+{{if lt .Page .TotalPages}}<a href="/monitor?page={{add .Page 1}}" class="btn">Next &raquo;</a>{{end}}
+</div>
+{{end}}
+</div>
+</div>
+<script>setTimeout(function(){ location.reload(); }, 10000);</script>
 </body></html>
 {{end}}
 

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -939,8 +939,13 @@ if (urlRepos.length > 0) {
 </div>
 
 <div class="card" style="overflow-x:auto">
-<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;flex-wrap:wrap;gap:8px">
 <h2 style="margin:0">Collection Queue</h2>
+<form method="GET" action="/monitor" style="display:flex;gap:6px;align-items:center">
+<input type="text" name="q" value="{{.Query}}" placeholder="Search repos..." style="padding:5px 10px;border:1px solid #ddd;border-radius:4px;font-size:0.85rem;width:200px">
+<button type="submit" class="btn" style="padding:5px 12px;font-size:0.85rem">Search</button>
+{{if .Query}}<a href="/monitor" class="btn" style="padding:5px 12px;font-size:0.85rem;text-decoration:none">Clear</a>{{end}}
+</form>
 <div style="color:#666;font-size:0.85rem">Page {{.Page}} of {{.TotalPages}} ({{.Total}} repos) &mdash; auto-refreshes every 10s</div>
 </div>
 <table class="repo-table" style="width:100%">
@@ -996,9 +1001,22 @@ if (urlRepos.length > 0) {
 </table>
 
 {{if gt .TotalPages 1}}
-<div style="display:flex;justify-content:center;gap:8px;margin-top:16px">
-{{if gt .Page 1}}<a href="/monitor?page={{subtract .Page 1}}" class="btn">&laquo; Prev</a>{{end}}
-{{if lt .Page .TotalPages}}<a href="/monitor?page={{add .Page 1}}" class="btn">Next &raquo;</a>{{end}}
+<div style="display:flex;justify-content:center;gap:6px;margin-top:16px;align-items:center">
+{{if gt .Page 1}}
+<a href="/monitor?page=1{{if .Query}}&q={{.Query}}{{end}}" class="btn" style="font-size:0.85rem" title="First page">First</a>
+<a href="/monitor?page={{subtract .Page 1}}{{if .Query}}&q={{.Query}}{{end}}" class="btn" style="font-size:0.85rem">&laquo; Prev</a>
+{{else}}
+<span class="btn" style="font-size:0.85rem;opacity:0.4;cursor:default">First</span>
+<span class="btn" style="font-size:0.85rem;opacity:0.4;cursor:default">&laquo; Prev</span>
+{{end}}
+<span style="color:#666;font-size:0.85rem;padding:0 8px">{{.Page}} / {{.TotalPages}}</span>
+{{if lt .Page .TotalPages}}
+<a href="/monitor?page={{add .Page 1}}{{if .Query}}&q={{.Query}}{{end}}" class="btn" style="font-size:0.85rem">Next &raquo;</a>
+<a href="/monitor?page={{.TotalPages}}{{if .Query}}&q={{.Query}}{{end}}" class="btn" style="font-size:0.85rem" title="Last page">Last</a>
+{{else}}
+<span class="btn" style="font-size:0.85rem;opacity:0.4;cursor:default">Next &raquo;</span>
+<span class="btn" style="font-size:0.85rem;opacity:0.4;cursor:default">Last</span>
+{{end}}
 </div>
 {{end}}
 </div>


### PR DESCRIPTION
Feature 1: Monitor integrated into web GUI

  - What changed: The monitor dashboard is now available at /monitor in the web GUI, behind OAuth authentication. "Monitor" link added to the top nav bar on all pages.
  - Pagination: 200 repos per page with Prev/Next links. Auto-refreshes every 10 seconds.
  - Files: web/server.go (handleMonitor, handleMonitorPrioritize), web/templates.go (monitor template + nav links), db/queue.go (ListQueuePage)
  - Tests: 7 new tests in web/monitor_test.go

  Feature 2: Collection phases reordered

  - What changed: Repo info, releases, and clone stats are now collected first (Phase 0), before contributors and issues/PRs. This provides the commit count metadata needed
  for large-repo detection.
  - Processing order unchanged: The processor still enforces contributors → issues → PRs → events → messages → metadata.
  - Files: collector/staged.go (reordered CollectRepo), collector/collector.go (CommitCount field)
  - Tests: 2 new tests in collector/collection_order_test.go

  Feature 3: Parallel collection for large repos

  - What changed: Repos with >10,000 commits have their issues, PRs, and events collected in 3 parallel goroutines. The parent waits for all three to finish before collecting
   messages.
  - Thread safety: Each parallel goroutine gets its own StagingWriter and local CollectResult. Results merged under mutex.
  - Slot tracking: ParallelSlots atomic counter tracks extra goroutines. fillWorkerSlots checks len(sem) + ParallelSlots and pauses new job starts while over capacity.
  - Sequential fallback: Repos under the threshold use the exact same sequential path as before — zero behavior change.
  - Files: collector/staged.go (collectParallel, collectSequential, helper methods, LargeRepoCommitThreshold), scheduler/scheduler.go (parallel slots check in
  fillWorkerSlots)
  - Tests: 4 new tests in collector/parallel_collect_test.go