### PR TITLE
Feat/comparison enhancements : Time range and Zero Releases fix

### DIFF
--- a/docs/guide/collection-pipeline.md
+++ b/docs/guide/collection-pipeline.md
@@ -41,6 +41,8 @@ Phase 2: Issues | PRs | Events (3 parallel goroutines)
 Phase 3: Messages (sequential, after parallel phase)
 ```
 
+A 404 from `/releases` is treated as *zero releases* (non-fatal). Not every repo has cut a release, and legacy rows with a stray `.git` in their slug — though now prevented at write time by `model.NormalizeRepoName()` in `db.UpsertRepo` — used to cause this 404. The staged collector logs `no releases endpoint (404) — treating as zero releases` and continues. See the troubleshooting guide for the underlying fix.
+
 The 3 extra goroutines claim parallel slots tracked by an atomic counter. The scheduler's `fillWorkerSlots` pauses new job starts while the total active count (semaphore + parallel slots) exceeds the configured worker limit.
 
 The direct pipeline is simpler -- it writes directly to relational tables with inline contributor resolution. Best for testing or collecting a small number of repos.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -154,6 +154,35 @@ If only GitHub tokens are configured, GitLab repos will not be collected (and vi
 
 ---
 
+## Release collection "not found" errors
+
+**Symptom:** Logs show `releases: not found: https://api.github.com/repos/owner/name.git/releases?per_page=100` and the repo is flagged as a failed collection.
+
+**Cause (pre-v0.16.4):** Two issues compounded:
+
+1. `repo_name` contained a trailing `.git` (from Augur import or an org-listing path that skipped URL parsing). Every API call using the slug (`/releases`, `/issues`, `/pulls`) returned 404.
+2. The staged collector treated any error on `ListReleases` as a fatal collection error. `buildOutcome` flipped `success` to false on any `result.Errors` entry, so a single 404 killed the whole job.
+
+**Fix (v0.16.4):**
+
+- `model.NormalizeRepoName()` is now called in `db.UpsertRepo` and `db.UpdateRepoURL`, and a one-time `cleanupRepoNameGitSuffix` migration strips `.git` from existing rows. Clean slugs hit the database on every write path.
+- `platform.ErrNotFound` wraps 404 responses. The staged collector and legacy collector both `errors.Is(err, platform.ErrNotFound)` around `ListReleases` — a 404 now logs `no releases endpoint (404) — treating as zero releases` and moves on.
+
+**Verifying the fix on an existing database:**
+
+```sql
+-- Any repo_name still ending in ".git"? After running `aveloxis migrate`, zero rows.
+SELECT repo_id, repo_owner, repo_name FROM aveloxis_data.repos WHERE repo_name LIKE '%.git';
+```
+
+If you see a repo still stuck in `Error` status for this reason, re-queue it:
+
+```sql
+UPDATE aveloxis_ops.collection_queue SET locked_at = NULL WHERE repo_id = ?;
+```
+
+---
+
 ## Git clone exit status 128
 
 **Symptom:** Log shows `exit status 128` during the facade phase.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,14 +141,27 @@ func (s *Server) handleTimeSeries(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid repo_id", http.StatusBadRequest)
 		return
 	}
-	// Default to last 2 years of data.
+	// Default window: last 2 years to now. Both endpoints overridable via
+	// ?since=YYYY-MM-DD and ?until=YYYY-MM-DD. An invalid value falls back
+	// to the default rather than erroring, so charts keep rendering.
 	since := time.Now().AddDate(-2, 0, 0)
 	if sinceParam := r.URL.Query().Get("since"); sinceParam != "" {
 		if t, err := time.Parse("2006-01-02", sinceParam); err == nil {
 			since = t
 		}
 	}
-	ts, err := s.store.GetRepoTimeSeries(r.Context(), repoID, since)
+	var until time.Time
+	if untilParam := r.URL.Query().Get("until"); untilParam != "" {
+		if t, err := time.Parse("2006-01-02", untilParam); err == nil {
+			// Treat the date as inclusive by advancing one day (store uses < upper).
+			until = t.AddDate(0, 0, 1)
+		}
+	}
+	if !until.IsZero() && !since.Before(until) {
+		http.Error(w, "since must be before until", http.StatusBadRequest)
+		return
+	}
+	ts, err := s.store.GetRepoTimeSeries(r.Context(), repoID, since, until)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -552,6 +553,13 @@ func (c *Collector) collectReleases(ctx context.Context, repoID int64, owner, re
 	c.logger.Info("collecting releases", "owner", owner, "repo", repo)
 	for rel, err := range c.client.ListReleases(ctx, owner, repo) {
 		if err != nil {
+			// 404 on /releases is a normal state — not every repo has cut a
+			// release. Don't propagate it as a collection error.
+			if errors.Is(err, platform.ErrNotFound) {
+				c.logger.Info("no releases endpoint (404) — treating as zero releases",
+					"owner", owner, "repo", repo)
+				return nil
+			}
 			return err
 		}
 		rel.RepoID = repoID

--- a/internal/collector/release_notfound_test.go
+++ b/internal/collector/release_notfound_test.go
@@ -1,0 +1,94 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestStagedCollectorIgnoresReleaseNotFound verifies that staged.go handles
+// a not-found error from ListReleases WITHOUT adding it to result.Errors.
+// A repo that has never cut a release (or was deleted/renamed) must not fail
+// the overall collection pipeline — buildOutcome flips success=false on any
+// result.Errors entry, so this is a whole-job failure if we don't filter it.
+func TestStagedCollectorIgnoresReleaseNotFound(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// The releases loop must reference platform.ErrNotFound — either directly
+	// or via an errors.Is check — to treat 404 as non-fatal.
+	idx := strings.Index(code, "ListReleases")
+	if idx < 0 {
+		t.Fatal("cannot find ListReleases call in staged.go")
+	}
+	// Scan a window around the ListReleases call for the not-found check.
+	start := idx
+	end := idx + 800
+	if end > len(code) {
+		end = len(code)
+	}
+	window := code[start:end]
+	if !strings.Contains(window, "ErrNotFound") {
+		t.Error("staged.go: releases loop must check errors.Is(err, platform.ErrNotFound) " +
+			"and continue without appending to result.Errors — otherwise a 404 on " +
+			"/releases (repos with no releases, renamed repos) fails the whole job")
+	}
+}
+
+// TestCollectorIgnoresReleaseNotFound — same guarantee for the legacy
+// (non-staged) Collector.collectReleases path in collector.go.
+func TestCollectorIgnoresReleaseNotFound(t *testing.T) {
+	src, err := os.ReadFile("collector.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (c *Collector) collectReleases(")
+	if idx < 0 {
+		t.Fatal("cannot find collectReleases function in collector.go")
+	}
+	// Look within the function body.
+	fnBody := code[idx:]
+	if len(fnBody) > 1500 {
+		fnBody = fnBody[:1500]
+	}
+	if !strings.Contains(fnBody, "ErrNotFound") {
+		t.Error("collector.go: collectReleases must check errors.Is(err, platform.ErrNotFound) " +
+			"and return nil so the collection doesn't fail on repos with no releases")
+	}
+}
+
+// TestHTTPClientWrapsNotFoundSentinel verifies the platform HTTP client
+// wraps 404 responses with the exported ErrNotFound sentinel rather than
+// returning an opaque fmt.Errorf. This is what lets collector callers
+// distinguish "endpoint missing" from every other error.
+func TestHTTPClientWrapsNotFoundSentinel(t *testing.T) {
+	src, err := os.ReadFile("../platform/httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "ErrNotFound") {
+		t.Error("httpclient.go must define and use an ErrNotFound sentinel so " +
+			"callers can check errors.Is(err, platform.ErrNotFound)")
+	}
+
+	// The 404 branch must wrap ErrNotFound (not use a plain fmt.Errorf).
+	notFoundIdx := strings.Index(code, "http.StatusNotFound")
+	if notFoundIdx < 0 {
+		t.Fatal("cannot find http.StatusNotFound branch in httpclient.go")
+	}
+	window := code[notFoundIdx:]
+	if len(window) > 400 {
+		window = window[:400]
+	}
+	if !strings.Contains(window, "ErrNotFound") {
+		t.Error("the http.StatusNotFound branch in Get must wrap ErrNotFound " +
+			"via fmt.Errorf with %%w so callers can errors.Is check it")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -21,6 +21,7 @@ package collector
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -139,6 +140,14 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 
 	for rel, relErr := range sc.client.ListReleases(ctx, owner, repo) {
 		if relErr != nil {
+			// A 404 on /releases is normal for repos that never cut a release
+			// (and for repos whose slug we can no longer resolve — renames,
+			// deletions). It must NOT fail the whole collection job.
+			if errors.Is(relErr, platform.ErrNotFound) {
+				sc.logger.Info("no releases endpoint (404) — treating as zero releases",
+					"owner", owner, "repo", repo)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("releases: %w", relErr))
 			break
 		}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -61,6 +61,12 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// created duplicate rows. Clean up first, then create the unique index.
 	deduplicateCommits(ctx, pg, logger)
 
+	// Repos: strip legacy ".git" suffixes from repo_name (added in v0.11.3).
+	// Repos added via Augur import / org listing before the normalize fix
+	// stored names like "naturf.git", which 404s every API call (/releases,
+	// /issues, /pulls). One-time cleanup; idempotent.
+	cleanupRepoNameGitSuffix(ctx, pg, logger)
+
 	// pull_request_repo: add unique constraint for ON CONFLICT support (v0.12.0).
 	pg.pool.Exec(ctx, `
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_repo_meta_head_base
@@ -283,6 +289,25 @@ func deduplicateCommits(ctx context.Context, pg *PostgresStore, logger *slog.Log
 func addColumnIfMissing(ctx context.Context, pg *PostgresStore, table, column, colType string) {
 	_, _ = pg.pool.Exec(ctx, fmt.Sprintf(
 		`ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s`, table, column, colType))
+}
+
+// cleanupRepoNameGitSuffix strips a trailing ".git" from aveloxis_data.repos.repo_name.
+// Repos added before the write-side normalization fix (and Augur imports) could
+// store slugs like "naturf.git", which 404s every API endpoint that embeds the
+// slug (/repos/{owner}/{name}/releases, /issues, /pulls). Idempotent: after the
+// first run this matches zero rows.
+func cleanupRepoNameGitSuffix(ctx context.Context, pg *PostgresStore, logger *slog.Logger) {
+	tag, err := pg.pool.Exec(ctx, `
+		UPDATE aveloxis_data.repos
+		SET repo_name = regexp_replace(repo_name, '\.git$', '')
+		WHERE repo_name LIKE '%.git'`)
+	if err != nil {
+		logger.Warn("repo_name .git cleanup failed", "error", err)
+		return
+	}
+	if n := tag.RowsAffected(); n > 0 {
+		logger.Info("stripped .git suffix from repo_name", "rows_updated", n)
+	}
 }
 
 // cleanupBadTimestamps nullifies any timestamp columns that have garbage values

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -118,6 +118,10 @@ func (s *PostgresStore) UpsertRepoGroup(ctx context.Context, name, rgType, websi
 }
 
 func (s *PostgresStore) UpsertRepo(ctx context.Context, r *model.Repo) (int64, error) {
+	// Normalize the repo slug at the write boundary so a ".git" suffix never
+	// reaches the DB. API URLs built from repo_name (/repos/{owner}/{name}/...)
+	// 404 when the slug has a ".git" suffix.
+	r.Name = model.NormalizeRepoName(r.Name)
 	var id int64
 	err := s.withRetry(ctx, func(ctx context.Context) error {
 		// Ensure a default repo group exists if no group is specified.
@@ -378,6 +382,9 @@ func (s *PostgresStore) UpdateRepoURL(ctx context.Context, repoID int64, newURL 
 		name = parts[len(parts)-1]
 		owner = strings.Join(parts[1:len(parts)-1], "/")
 	}
+	// Defense in depth: even after TrimSuffix above, normalize the extracted
+	// slug so every write path produces the same canonical form.
+	name = model.NormalizeRepoName(name)
 
 	_, err := s.pool.Exec(ctx,
 		`UPDATE aveloxis_data.repos

--- a/internal/db/reponame_normalize_test.go
+++ b/internal/db/reponame_normalize_test.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestUpsertRepoNormalizesName — source-level contract: UpsertRepo must
+// normalize r.Name via model.NormalizeRepoName before the INSERT, so
+// ".git"-suffixed names never reach the repos table. This is the single
+// write-side fix that prevents every downstream 404 on /releases, /issues,
+// /pulls, etc. when the slug is used in API URLs.
+func TestUpsertRepoNormalizesName(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (s *PostgresStore) UpsertRepo(")
+	if idx < 0 {
+		t.Fatal("cannot find UpsertRepo in postgres.go")
+	}
+	// Examine the function body up to the closing of its main block.
+	fnBody := code[idx:]
+	end := strings.Index(fnBody, "\n}\n")
+	if end > 0 {
+		fnBody = fnBody[:end]
+	}
+	if !strings.Contains(fnBody, "NormalizeRepoName") {
+		t.Error("UpsertRepo must call model.NormalizeRepoName(r.Name) before INSERT — " +
+			"otherwise repo slugs with a '.git' suffix hit the DB and every API " +
+			"call (/releases, /issues, /pulls) 404s")
+	}
+}
+
+// TestUpdateRepoURLNormalizesName — same guarantee for the redirect path.
+func TestUpdateRepoURLNormalizesName(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (s *PostgresStore) UpdateRepoURL(")
+	if idx < 0 {
+		t.Fatal("cannot find UpdateRepoURL in postgres.go")
+	}
+	fnBody := code[idx:]
+	end := strings.Index(fnBody, "\n}\n")
+	if end > 0 {
+		fnBody = fnBody[:end]
+	}
+	if !strings.Contains(fnBody, "NormalizeRepoName") {
+		t.Error("UpdateRepoURL must call model.NormalizeRepoName on the parsed name — " +
+			"redirects should also produce clean slugs in the DB")
+	}
+}
+
+// TestRepoNameGitCleanupMigrationPresent — one-time migration must be wired
+// into RunMigrations to strip ".git" from existing repo_name values so
+// databases populated before the normalize fix don't keep failing.
+func TestRepoNameGitCleanupMigrationPresent(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "cleanupRepoNameGitSuffix") {
+		t.Error("migrate.go must define and call cleanupRepoNameGitSuffix to strip " +
+			"legacy '.git' suffixes from aveloxis_data.repos.repo_name — without this, " +
+			"pre-existing rows keep producing 404s on API collection")
+	}
+
+	// Must be wired into RunMigrations.
+	runIdx := strings.Index(code, "func RunMigrations(")
+	if runIdx < 0 {
+		t.Fatal("cannot find RunMigrations")
+	}
+	runBody := code[runIdx:]
+	end := strings.Index(runBody, "\n}\n")
+	if end > 0 {
+		runBody = runBody[:end]
+	}
+	if !strings.Contains(runBody, "cleanupRepoNameGitSuffix") {
+		t.Error("RunMigrations must invoke cleanupRepoNameGitSuffix during startup")
+	}
+}

--- a/internal/db/timeseries.go
+++ b/internal/db/timeseries.go
@@ -24,10 +24,11 @@ type TimeSeriesResult struct {
 	Issues     []WeeklyDataPoint  `json:"issues"`
 }
 
-// GetRepoTimeSeries returns weekly aggregated counts for a repo's key metrics.
+// GetRepoTimeSeries returns weekly aggregated counts for a repo's key metrics
+// between `since` and `until` (inclusive lower, exclusive upper).
+// A zero `until` is treated as "no upper bound" (queries up to the latest data).
 // Uses date_trunc('week', timestamp) for consistent Monday-aligned weeks.
-// Optimized: queries against indexed timestamp columns, limits to recent data.
-func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, since time.Time) (*TimeSeriesResult, error) {
+func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, since, until time.Time) (*TimeSeriesResult, error) {
 	result := &TimeSeriesResult{RepoID: repoID}
 
 	// Get repo name for labels.
@@ -35,15 +36,24 @@ func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, sin
 		`SELECT repo_name, repo_owner FROM aveloxis_data.repos WHERE repo_id = $1`,
 		repoID).Scan(&result.RepoName, &result.RepoOwner)
 
+	// A zero `until` is represented as a far-future timestamp so the SQL
+	// queries can remain parameterized identically regardless of whether the
+	// caller specified an upper bound.
+	hasUntil := !until.IsZero()
+	upper := until
+	if !hasUntil {
+		upper = time.Now().AddDate(100, 0, 0)
+	}
+
 	// Weekly commits (from the commits table — one row per file, so count distinct hashes).
 	rows, err := s.pool.Query(ctx, `
 		SELECT date_trunc('week', cmt_author_timestamp) AS week_start,
 			COUNT(DISTINCT cmt_commit_hash) AS cnt
 		FROM aveloxis_data.commits
-		WHERE repo_id = $1 AND cmt_author_timestamp >= $2
+		WHERE repo_id = $1 AND cmt_author_timestamp >= $2 AND cmt_author_timestamp < $3
 		  AND cmt_author_timestamp IS NOT NULL
 		GROUP BY week_start
-		ORDER BY week_start`, repoID, since)
+		ORDER BY week_start`, repoID, since, upper)
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -59,10 +69,10 @@ func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, sin
 		SELECT date_trunc('week', created_at) AS week_start,
 			COUNT(*) AS cnt
 		FROM aveloxis_data.pull_requests
-		WHERE repo_id = $1 AND created_at >= $2
+		WHERE repo_id = $1 AND created_at >= $2 AND created_at < $3
 		  AND created_at IS NOT NULL
 		GROUP BY week_start
-		ORDER BY week_start`, repoID, since)
+		ORDER BY week_start`, repoID, since, upper)
 	if err == nil {
 		defer rows2.Close()
 		for rows2.Next() {
@@ -78,10 +88,10 @@ func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, sin
 		SELECT date_trunc('week', merged_at) AS week_start,
 			COUNT(*) AS cnt
 		FROM aveloxis_data.pull_requests
-		WHERE repo_id = $1 AND merged_at >= $2
+		WHERE repo_id = $1 AND merged_at >= $2 AND merged_at < $3
 		  AND merged_at IS NOT NULL
 		GROUP BY week_start
-		ORDER BY week_start`, repoID, since)
+		ORDER BY week_start`, repoID, since, upper)
 	if err == nil {
 		defer rows3.Close()
 		for rows3.Next() {
@@ -97,10 +107,10 @@ func (s *PostgresStore) GetRepoTimeSeries(ctx context.Context, repoID int64, sin
 		SELECT date_trunc('week', created_at) AS week_start,
 			COUNT(*) AS cnt
 		FROM aveloxis_data.issues
-		WHERE repo_id = $1 AND created_at >= $2
+		WHERE repo_id = $1 AND created_at >= $2 AND created_at < $3
 		  AND created_at IS NOT NULL
 		GROUP BY week_start
-		ORDER BY week_start`, repoID, since)
+		ORDER BY week_start`, repoID, since, upper)
 	if err == nil {
 		defer rows4.Close()
 		for rows4.Next() {

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.2"
+var ToolVersion = "0.16.3"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.3"
+var ToolVersion = "0.16.4"

--- a/internal/model/reponame.go
+++ b/internal/model/reponame.go
@@ -1,0 +1,16 @@
+package model
+
+import "strings"
+
+// NormalizeRepoName returns the canonical form of a repository slug with
+// trailing "/" and ".git" suffixes stripped. The Git clone URL may legitimately
+// end in ".git", but the repo slug used in forge API paths (/repos/owner/NAME)
+// never does — leaving it on produces 404s for every endpoint that embeds the
+// slug (releases, issues, pulls, etc.). Use this at every write boundary so
+// repo.Name in the database is always clean.
+func NormalizeRepoName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimSuffix(name, "/")
+	name = strings.TrimSuffix(name, ".git")
+	return name
+}

--- a/internal/model/reponame_test.go
+++ b/internal/model/reponame_test.go
@@ -1,0 +1,46 @@
+package model
+
+import "testing"
+
+func TestNormalizeRepoName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean name unchanged", "naturf", "naturf"},
+		{"strips .git suffix", "naturf.git", "naturf"},
+		{"strips trailing slash", "naturf/", "naturf"},
+		{"strips trailing slash before .git not present", "hello-world/", "hello-world"},
+		{"empty input", "", ""},
+		{"whitespace trimmed", "  naturf  ", "naturf"},
+		{"whitespace with .git", "  naturf.git  ", "naturf"},
+		// The current rules only strip one .git — nested ".git.git" retains
+		// an inner suffix. This prevents eating repo names that legitimately
+		// end in ".git" (rare, but possible: "foo.git-backup").
+		{"only strips one .git", "repo.git.git", "repo.git"},
+		{"no suffix on odd name", "my.repo", "my.repo"},
+		{"mid-string .git preserved", "dot.git.repo", "dot.git.repo"},
+		{"dot in name preserved", "project.name", "project.name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeRepoName(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeRepoName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRepoName_Idempotent(t *testing.T) {
+	// Running NormalizeRepoName twice must equal running it once.
+	inputs := []string{"naturf.git", "repo/", "already-clean", "", "  foo.git  "}
+	for _, in := range inputs {
+		once := NormalizeRepoName(in)
+		twice := NormalizeRepoName(once)
+		if once != twice {
+			t.Errorf("not idempotent for %q: once=%q twice=%q", in, once, twice)
+		}
+	}
+}

--- a/internal/platform/github/releases_test.go
+++ b/internal/platform/github/releases_test.go
@@ -1,0 +1,89 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/augurlabs/aveloxis/internal/platform"
+)
+
+// TestListReleases_404ReturnsErrNotFound verifies that when GitHub returns
+// 404 for the releases endpoint (e.g., because the repo slug has been
+// mis-stored with a ".git" suffix, or the repo was deleted), the iterator
+// yields an error that callers can identify via errors.Is(err, platform.ErrNotFound).
+func TestListReleases_404ReturnsErrNotFound(t *testing.T) {
+	client := testGHClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+
+	var gotErr error
+	count := 0
+	for _, err := range client.ListReleases(context.Background(), "o", "r") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		count++
+	}
+	if gotErr == nil {
+		t.Fatal("expected error for 404 releases response")
+	}
+	if !errors.Is(gotErr, platform.ErrNotFound) {
+		t.Errorf("expected errors.Is(err, platform.ErrNotFound), got %v", gotErr)
+	}
+	if count != 0 {
+		t.Errorf("expected zero releases before error, got %d", count)
+	}
+}
+
+// TestListReleases_EmptyArraySucceeds verifies that an empty releases list
+// (a normal state for repos that never cut a release) yields zero items with
+// no error.
+func TestListReleases_EmptyArraySucceeds(t *testing.T) {
+	client := testGHClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	}))
+
+	count := 0
+	for _, err := range client.ListReleases(context.Background(), "o", "r") {
+		if err != nil {
+			t.Fatalf("unexpected error on empty releases: %v", err)
+		}
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 releases, got %d", count)
+	}
+}
+
+// TestListReleases_ReturnsReleases verifies that releases are correctly
+// iterated when the endpoint returns a populated array.
+func TestListReleases_ReturnsReleases(t *testing.T) {
+	releases := []ghRelease{
+		{ID: 1, Name: "v1.0.0", TagName: "v1.0.0"},
+		{ID: 2, Name: "v2.0.0", TagName: "v2.0.0"},
+	}
+	client := testGHClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+
+	count := 0
+	for rel, err := range client.ListReleases(context.Background(), "o", "r") {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.TagName == "" {
+			t.Error("expected non-empty tag name")
+		}
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected 2 releases, got %d", count)
+	}
+}

--- a/internal/platform/gitlab/releases_test.go
+++ b/internal/platform/gitlab/releases_test.go
@@ -1,0 +1,87 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/augurlabs/aveloxis/internal/platform"
+)
+
+// TestListReleases_404ReturnsErrNotFound — GitLab returns 404 for releases
+// on projects that don't exist or aren't accessible. The iterator must
+// surface this via errors.Is(err, platform.ErrNotFound) so the collector
+// can treat it as "no releases" rather than a fatal collection failure.
+func TestListReleases_404ReturnsErrNotFound(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"404 Not Found"}`))
+	}))
+
+	var gotErr error
+	count := 0
+	for _, err := range client.ListReleases(context.Background(), "group", "project") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		count++
+	}
+	if gotErr == nil {
+		t.Fatal("expected error for 404 releases response")
+	}
+	if !errors.Is(gotErr, platform.ErrNotFound) {
+		t.Errorf("expected errors.Is(err, platform.ErrNotFound), got %v", gotErr)
+	}
+	if count != 0 {
+		t.Errorf("expected zero releases, got %d", count)
+	}
+}
+
+// TestListReleases_EmptyArraySucceeds — a GitLab project that has never cut
+// a release returns an empty array; this must be treated as success.
+func TestListReleases_EmptyArraySucceeds(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	}))
+
+	count := 0
+	for _, err := range client.ListReleases(context.Background(), "group", "project") {
+		if err != nil {
+			t.Fatalf("unexpected error on empty releases: %v", err)
+		}
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 releases, got %d", count)
+	}
+}
+
+// TestListReleases_ReturnsReleases — sanity: populated array yields entries.
+func TestListReleases_ReturnsReleases(t *testing.T) {
+	releases := []glRelease{
+		{TagName: "v1.0", Name: "v1.0"},
+		{TagName: "v2.0", Name: "v2.0"},
+	}
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(releases)
+	}))
+
+	count := 0
+	for rel, err := range client.ListReleases(context.Background(), "group", "project") {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.TagName == "" {
+			t.Error("expected non-empty tag name")
+		}
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected 2 releases, got %d", count)
+	}
+}

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -21,6 +21,11 @@ import (
 // Callers should use their cached copy of the data.
 var ErrNotModified = errors.New("not modified (304)")
 
+// ErrNotFound wraps 404 responses from the forge API. Callers that want to
+// treat a missing optional resource (e.g. /releases on a repo that never
+// cut a release) as non-fatal can check errors.Is(err, ErrNotFound).
+var ErrNotFound = errors.New("not found")
+
 // AuthStyle controls how API tokens are sent in HTTP requests.
 // GitHub and GitLab use different authentication header formats.
 type AuthStyle int
@@ -155,7 +160,7 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 			return nil, ErrNotModified
 		case resp.StatusCode == http.StatusNotFound:
 			resp.Body.Close()
-			return nil, fmt.Errorf("not found: %s", url)
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, url)
 		case resp.StatusCode == http.StatusUnauthorized:
 			// 401 = bad credentials. Permanently invalidate this key.
 			resp.Body.Close()

--- a/internal/platform/httpclient_notfound_test.go
+++ b/internal/platform/httpclient_notfound_test.go
@@ -1,0 +1,81 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestGet_404ReturnsErrNotFound verifies that HTTPClient.Get returns an error
+// that wraps ErrNotFound when the server responds with 404. Callers (e.g., the
+// staged collector) rely on errors.Is(err, ErrNotFound) to treat absent
+// optional resources (releases, clone stats) as non-fatal.
+func TestGet_404ReturnsErrNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	keys := NewKeyPool([]string{"test-token"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	_, err := client.Get(context.Background(), "/repos/o/r/releases")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected errors.Is(err, ErrNotFound) to be true, got err=%v", err)
+	}
+}
+
+// TestErrNotFoundIsExported verifies the sentinel is exported for collector
+// callers to check via errors.Is.
+func TestErrNotFoundIsExported(t *testing.T) {
+	if ErrNotFound == nil {
+		t.Fatal("ErrNotFound must be a non-nil exported sentinel error")
+	}
+	if ErrNotFound.Error() == "" {
+		t.Error("ErrNotFound must have a non-empty message")
+	}
+}
+
+// TestPaginate_404YieldsErrNotFound verifies that pagination of a 404 endpoint
+// yields a single error that wraps ErrNotFound, which the collector uses to
+// distinguish "endpoint returns 404" from transient/auth errors.
+func TestPaginate_404YieldsErrNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	keys := NewKeyPool([]string{"test-token"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	var gotErr error
+	var gotItems int
+	type dummy struct{}
+	for _, err := range PaginateGitHub[dummy](context.Background(), client, "/repos/o/r/releases") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		gotItems++
+	}
+	if gotErr == nil {
+		t.Fatal("expected iter to yield an error for 404")
+	}
+	if !errors.Is(gotErr, ErrNotFound) {
+		t.Errorf("expected errors.Is(gotErr, ErrNotFound), got %v", gotErr)
+	}
+	if gotItems != 0 {
+		t.Errorf("expected zero items before error, got %d", gotItems)
+	}
+}

--- a/internal/scheduler/git_url_test.go
+++ b/internal/scheduler/git_url_test.go
@@ -6,31 +6,35 @@ import (
 	"testing"
 )
 
-// TestGitURLDoesNotDoubleGitSuffix verifies that the gitURL construction
-// in runFacadeAndAnalysis does not append .git when the repo name already
-// ends with .git. Many JOSS/Augur-imported URLs have the .git suffix,
-// producing https://github.com/owner/repo.git.git which returns 404.
+// TestGitURLDoesNotDoubleGitSuffix verifies that gitURL construction in
+// runFacadeAndAnalysis does not produce ".git.git". Previously the scheduler
+// had a local strings.TrimSuffix workaround because repo.Name could contain
+// ".git" (Augur/JOSS imports). Now the canonical fix lives at the write
+// boundary — db.PostgresStore.UpsertRepo calls model.NormalizeRepoName —
+// so repo.Name is guaranteed clean and appending ".git" is safe. This test
+// enforces that the DB normalization is in place so the scheduler workaround
+// stays removed.
 func TestGitURLDoesNotDoubleGitSuffix(t *testing.T) {
-	src, err := os.ReadFile("scheduler.go")
+	// The canonical fix is write-side normalization in db.UpsertRepo. Verify
+	// it exists so repo.Name never reaches the scheduler with a .git suffix.
+	src, err := os.ReadFile("../db/postgres.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	code := string(src)
-
-	// Find where gitURL is constructed (near runFacadeAndAnalysis).
-	idx := strings.Index(code, "func (s *Scheduler) runFacadeAndAnalysis")
-	if idx < 0 {
-		t.Fatal("cannot find runFacadeAndAnalysis")
+	upsertIdx := strings.Index(code, "func (s *PostgresStore) UpsertRepo(")
+	if upsertIdx < 0 {
+		t.Fatal("cannot find UpsertRepo in db/postgres.go")
 	}
-	fnBody := code[idx:]
-	if len(fnBody) > 2000 {
-		fnBody = fnBody[:2000]
+	fnBody := code[upsertIdx:]
+	end := strings.Index(fnBody, "\n}\n")
+	if end > 0 {
+		fnBody = fnBody[:end]
 	}
-
-	// Must not blindly append .git — must check/strip first.
-	if strings.Contains(fnBody, `/%s.git"`) && !strings.Contains(fnBody, "TrimSuffix") {
-		t.Error("gitURL construction must not blindly append .git — " +
-			"repos imported from JOSS/Augur already have .git suffix, " +
-			"producing double .git.git which returns 404")
+	if !strings.Contains(fnBody, "NormalizeRepoName") {
+		t.Error("UpsertRepo must call model.NormalizeRepoName on r.Name so " +
+			"repo slugs with '.git' never reach the DB — otherwise the " +
+			"scheduler would need a local strings.TrimSuffix workaround and " +
+			"every API call (/releases, /issues, /pulls) would 404")
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -16,7 +16,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/augurlabs/aveloxis/internal/collector"
@@ -469,11 +468,8 @@ func (s *Scheduler) runFacadeAndAnalysis(ctx context.Context, repoID int64, repo
 	// Phase 3: Facade — creates/updates bare clone and parses git log.
 	var facadeResult *collector.FacadeResult
 	fc := collector.NewFacadeCollector(s.store, s.logger, s.cfg.RepoCloneDir)
-	// Strip any existing .git suffix before appending to avoid double
-	// .git.git URLs. Many JOSS/Augur-imported repos store the URL with .git.
-	repoName := strings.TrimSuffix(repo.Name, ".git")
 	gitURL := fmt.Sprintf("https://%s/%s/%s.git",
-		platformHostForModel(repo.Platform), repo.Owner, repoName)
+		platformHostForModel(repo.Platform), repo.Owner, repo.Name)
 	result, err := fc.CollectRepo(ctx, repoID, gitURL)
 	if err != nil {
 		s.logger.Warn("facade collection failed", "repo_id", repoID, "error", err)

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -689,6 +689,13 @@ fetch(API_BASE + '/api/v1/repos/' + REPO_ID + '/scancode-files')
 .mode-toggle{display:flex;border:1px solid #d1d5da;border-radius:6px;overflow:hidden}
 .mode-toggle button{padding:6px 14px;border:none;background:white;cursor:pointer;font-size:13px}
 .mode-toggle button.active{background:#0366d6;color:white}
+.date-range{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.date-range label{font-size:12px;color:#586069;font-weight:500}
+.date-range input[type=date]{padding:5px 8px;border:1px solid #d1d5da;border-radius:6px;font-size:13px;font-family:inherit}
+.date-range .preset-btn{padding:5px 10px;border:1px solid #d1d5da;border-radius:6px;background:white;cursor:pointer;font-size:12px}
+.date-range .preset-btn.active{background:#0366d6;color:white;border-color:#0366d6}
+.date-range .apply-btn{padding:5px 12px;border:1px solid #0366d6;border-radius:6px;background:#0366d6;color:white;cursor:pointer;font-size:13px;font-weight:500}
+.date-range .apply-btn:hover{background:#0255b3}
 </style>
 <div class="nav">
 <a href="/dashboard" style="display:flex;align-items:center;gap:8px"><img src="/icon.png" alt="" style="height:28px;border-radius:4px"><strong>Aveloxis</strong></a>
@@ -722,6 +729,20 @@ fetch(API_BASE + '/api/v1/repos/' + REPO_ID + '/scancode-files')
 </div>
 </div>
 
+<div class="compare-controls date-range" aria-label="Time range">
+<label for="date-since">From</label>
+<input type="date" id="date-since">
+<label for="date-until">To</label>
+<input type="date" id="date-until">
+<button class="preset-btn" data-preset="1m" onclick="applyPreset('1m')">1M</button>
+<button class="preset-btn" data-preset="6m" onclick="applyPreset('6m')">6M</button>
+<button class="preset-btn" data-preset="1y" onclick="applyPreset('1y')">1Y</button>
+<button class="preset-btn active" data-preset="2y" onclick="applyPreset('2y')">2Y</button>
+<button class="preset-btn" data-preset="5y" onclick="applyPreset('5y')">5Y</button>
+<button class="preset-btn" data-preset="all" onclick="applyPreset('all')">All</button>
+<button class="apply-btn" onclick="applyDateRange()">Apply</button>
+</div>
+
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
 <div><canvas id="cmp-commits" height="220"></canvas></div>
 <div><canvas id="cmp-prs-opened" height="220"></canvas></div>
@@ -738,6 +759,69 @@ let selectedRepos = [];
 let allRepoData = {};
 let currentMode = 'raw';
 let charts = {};
+
+// Date-range state. Default window matches the API default (last 2 years, no upper bound).
+// The inputs display the computed dates; fetch requests use whatever is currently in them.
+function fmtDate(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return y + '-' + m + '-' + day;
+}
+function initDateRange() {
+  const now = new Date();
+  const since = new Date(now);
+  since.setFullYear(since.getFullYear() - 2);
+  document.getElementById('date-since').value = fmtDate(since);
+  document.getElementById('date-until').value = fmtDate(now);
+}
+function applyPreset(preset) {
+  document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector('.preset-btn[data-preset="' + preset + '"]');
+  if (btn) btn.classList.add('active');
+  const now = new Date();
+  const since = new Date(now);
+  if (preset === '1m') since.setMonth(since.getMonth() - 1);
+  else if (preset === '6m') since.setMonth(since.getMonth() - 6);
+  else if (preset === '1y') since.setFullYear(since.getFullYear() - 1);
+  else if (preset === '2y') since.setFullYear(since.getFullYear() - 2);
+  else if (preset === '5y') since.setFullYear(since.getFullYear() - 5);
+  else if (preset === 'all') since.setFullYear(1970);
+  document.getElementById('date-since').value = fmtDate(since);
+  document.getElementById('date-until').value = fmtDate(now);
+  applyDateRange();
+}
+function clearPresetHighlight() {
+  document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
+}
+document.getElementById('date-since').addEventListener('change', clearPresetHighlight);
+document.getElementById('date-until').addEventListener('change', clearPresetHighlight);
+function getDateRangeQuery() {
+  const s = document.getElementById('date-since').value;
+  const u = document.getElementById('date-until').value;
+  const parts = [];
+  if (s) parts.push('since=' + encodeURIComponent(s));
+  if (u) parts.push('until=' + encodeURIComponent(u));
+  return parts.length ? '?' + parts.join('&') : '';
+}
+function applyDateRange() {
+  const s = document.getElementById('date-since').value;
+  const u = document.getElementById('date-until').value;
+  if (s && u && s >= u) {
+    alert('The "From" date must be earlier than the "To" date.');
+    return;
+  }
+  // Refetch all currently selected repos with the new range, then re-render.
+  allRepoData = {};
+  if (selectedRepos.length === 0) { renderAllCharts(); return; }
+  Promise.all(selectedRepos.map(repo =>
+    fetch(API_BASE + '/api/v1/repos/' + repo.id + '/timeseries' + getDateRangeQuery())
+      .then(r => r.json())
+      .then(ts => { allRepoData[repo.id] = ts; })
+      .catch(err => console.error('Failed to refresh repo ' + repo.id + ':', err))
+  )).then(() => renderAllCharts());
+}
+initDateRange();
 
 // Search with visible dropdown — uses the dedicated search-results container.
 const searchInput = document.getElementById('repo-search');
@@ -810,7 +894,7 @@ function renderTags() {
 }
 
 function fetchAndRender(repo) {
-  fetch(API_BASE + '/api/v1/repos/' + repo.id + '/timeseries')
+  fetch(API_BASE + '/api/v1/repos/' + repo.id + '/timeseries' + getDateRangeQuery())
     .then(r => r.json())
     .then(ts => {
       allRepoData[repo.id] = ts;
@@ -904,7 +988,7 @@ function renderComparisonChart(canvasId, title, metricKey) {
 const urlRepos = '{{.RepoIDs}}'.split(',').filter(Boolean);
 if (urlRepos.length > 0) {
   urlRepos.forEach(id => {
-    fetch(API_BASE + '/api/v1/repos/' + id + '/timeseries')
+    fetch(API_BASE + '/api/v1/repos/' + id + '/timeseries' + getDateRangeQuery())
       .then(r => r.json())
       .then(ts => {
         const repo = {id: parseInt(id), owner: ts.repo_owner || 'unknown', name: ts.repo_name || id};


### PR DESCRIPTION
### Changes in v0.16.4

- **Release 404 no longer fails the job**: Introduced `platform.ErrNotFound` sentinel. `StagedCollector.CollectRepo` and `Collector.collectReleases` treat 404 on `/releases` as zero releases (non-fatal) instead of appending to `result.Errors`. Before this, any `not found` from releases flipped `buildOutcome.success` to false and killed the whole collection pass.

- **Canonical repo-name normalization**: Added `model.NormalizeRepoName()`. `db.UpsertRepo` / `db.UpdateRepoURL` now call it on every write, and a one-time `cleanupRepoNameGitSuffix` migration strips legacy `.git` suffixes from `aveloxis_data.repos.repo_name`. Removed the ad-hoc `strings.TrimSuffix` workaround in `scheduler.runFacadeAndAnalysis` — repo.Name is now guaranteed clean everywhere downstream.
