### PR TITLE
Aggregates only rebuilt on materialized view schedule instead of per …

### DIFF
--- a/docs/guide/collection-pipeline.md
+++ b/docs/guide/collection-pipeline.md
@@ -174,12 +174,16 @@ Email domains from commit authors and committers are matched against the `contri
 
 ### Facade aggregates
 
-After all commits are inserted, aggregate tables are refreshed by SQL aggregation over the `commits` table:
+Aggregate tables are refreshed by SQL aggregation over the `commits` table:
 
 - `dm_repo_annual` -- annual commit stats per contributor per repo
 - `dm_repo_monthly` -- monthly stats
 - `dm_repo_weekly` -- weekly stats
 - `dm_repo_group_annual`, `dm_repo_group_monthly`, `dm_repo_group_weekly` -- group-level aggregates
+
+**Cadence (v0.16.5+):** aggregates are refreshed **in bulk on the configured matview rebuild day** (`collection.matview_rebuild_day`, default Saturday). The scheduler calls `store.RefreshAllRepoAggregates` while collection workers are paused, alongside the materialized view refresh. Previously the facade recomputed these tables *after every single repo collection*, which on a fleet of thousands of repos amounted to tens of thousands of redundant single-repo aggregations per cycle — the matview-day bulk pass supersedes that work.
+
+The per-repo helpers `RefreshRepoAggregates(repoID)` and `RefreshRepoGroupAggregates(repoID)` remain in `internal/db/aggregates.go` for manual/ops usage (e.g., recalculating a single repo after a correction). They are simply no longer invoked automatically from the facade.
 
 ---
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -154,6 +154,53 @@ If only GitHub tokens are configured, GitLab repos will not be collected (and vi
 
 ---
 
+## `unsupported Unicode escape sequence (SQLSTATE 22P05)`
+
+**Symptom:** Logs show `flushing staging batch (500 rows): ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05)` and an entire batch of staged rows fails to flush.
+
+**Cause (pre-v0.16.8):** PostgreSQL JSONB columns reject `\u0000` escapes. GitHub and GitLab API responses occasionally include NUL bytes in text fields (bot-generated review comments, binary content echoed into diffs, malformed webhook payloads). A single poisoned row in a 500-row batch killed the whole flush.
+
+**Fix (v0.16.8+):** `db.StagingWriter.Stage` now scrubs `\u0000` from marshaled JSON before queuing the insert (`db.sanitizeJSONForJSONB`). The scrubber is a no-op on clean payloads (zero overhead) and drops the escape when present — NUL has no semantic value in any field we stage.
+
+No operator action needed; the fix is automatic after upgrading and restarting `aveloxis serve`.
+
+---
+
+## "Pull requests / contributors / events: not found" or "forbidden"
+
+**Symptom:** Collection fails for certain repos with log lines like:
+
+```
+contributors: not found: https://api.github.com/repos/owner/name/contributors?per_page=100
+pull requests: not found: https://api.github.com/repos/owner/name/pulls?state=all...
+pull requests: forbidden: https://gitlab.com/api/v4/projects/group%2Fname/merge_requests?...
+```
+
+**Cause (pre-v0.16.8):** Any 404 or 403 on a per-phase endpoint appended an entry to `result.Errors`, which `buildOutcome` translated into `success=false`. Common triggers:
+
+- Repo has issues or PRs disabled in its settings (`/issues` or `/pulls` return 404).
+- Repo was deleted or transferred after it was queued.
+- GitLab project is private and the token lacks access (`403 Forbidden` on `/merge_requests`).
+- GitHub token doesn't have `repo` scope for a private repo (403 on `/contributors`).
+
+**Fix (v0.16.8+):** `collector.isOptionalEndpointSkip(err)` checks `errors.Is(err, platform.ErrNotFound)` and `errors.Is(err, platform.ErrForbidden)`. Every phase in the staged collector now routes through it. A 404 or 403 logs one info line (`skipping <phase> endpoint owner=... repo=... reason=...`) and breaks out of that phase cleanly — the rest of the collection proceeds. The job is only marked failed on *other* errors (rate-limit exhaustion, auth failure, network problems, DB errors).
+
+If you see these repos repeatedly skipping an endpoint, check:
+
+```sql
+-- Is the repo deleted/moved? Check recent prelim runs.
+SELECT repo_id, repo_git, repo_archived, data_collection_date
+FROM aveloxis_data.repos WHERE repo_git LIKE '%owner/name%';
+```
+
+To verify the token scope on GitHub:
+
+```bash
+curl -sI -H "Authorization: token $TOKEN" https://api.github.com/user | grep -i x-oauth-scopes
+```
+
+---
+
 ## Release collection "not found" errors
 
 **Symptom:** Logs show `releases: not found: https://api.github.com/repos/owner/name.git/releases?per_page=100` and the repo is flagged as a failed collection.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -331,6 +331,39 @@ curl http://localhost:5555/api/stats
 
 ---
 
+## Changed `days_until_recollect` is being ignored
+
+**Symptom:** You edited `collection.days_until_recollect` in `aveloxis.json` (e.g., `1` → `7`), restarted `aveloxis serve`, and repos are still being re-collected on the old schedule.
+
+**Cause (pre-v0.16.6):** `CompleteJob` sets `collection_queue.due_at = NOW() + days_until_recollect` at the moment a collection finishes. That value is *frozen* in the row — changing the config later has no effect on queued rows until each repo next completes a collection under the new setting. With a fleet of thousands of repos that each completed yesterday under `days_until_recollect=1`, the stale `due_at` values are all already due when you restart, and the scheduler picks them right back up regardless of the new `7`.
+
+**Fix (v0.16.6+):** The scheduler now calls `store.RealignDueDates(ctx, recollectAfter)` once on startup, which recomputes `due_at = last_collected + recollectAfter` for every queued row with a non-null `last_collected`. Look for the log line:
+
+```
+realigned queue due_at from current days_until_recollect rows_updated=3079 recollect_after=168h0m0s
+```
+
+`'collecting'` rows (in-flight) and never-collected rows (`last_collected IS NULL`) are skipped. The operation is idempotent — repeated restarts that don't change the config are no-ops.
+
+**Verifying on a live database:**
+
+```sql
+SELECT repo_id,
+       due_at,
+       last_collected,
+       (due_at - last_collected) AS cooldown
+FROM aveloxis_ops.collection_queue
+WHERE status = 'queued' AND last_collected IS NOT NULL
+ORDER BY last_collected DESC
+LIMIT 10;
+```
+
+The `cooldown` column should equal your configured `days_until_recollect` (as an interval) after a successful restart.
+
+**If you want to force a one-shot re-queue *despite* the cooldown**, use `aveloxis prioritize <url>` or the "Prioritize" button in the web UI — that explicitly sets `due_at = NOW()` for a single repo.
+
+---
+
 ## Checking collection status
 
 To see what was collected for a specific repo:

--- a/internal/collector/aggregate_cadence_test.go
+++ b/internal/collector/aggregate_cadence_test.go
@@ -1,0 +1,83 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestFacadeDoesNotRefreshPerRepoAggregates — the facade runs on every repo
+// collection. Refreshing dm_repo_* aggregates here means rebuilding the same
+// aggregates tens of thousands of times per cycle on a fleet. The scheduler's
+// weekly matview rebuild already calls RefreshAllRepoAggregates in bulk, so
+// the per-repo refresh is wasted work. Keep the per-repo helpers available
+// in the db package for ops/manual use, but don't invoke them from facade.
+func TestFacadeDoesNotRefreshPerRepoAggregates(t *testing.T) {
+	src, err := os.ReadFile("facade.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if strings.Contains(code, "RefreshRepoAggregates(") {
+		t.Error("facade.go must NOT call RefreshRepoAggregates per repo — " +
+			"aggregates are refreshed in bulk on the weekly matview rebuild day " +
+			"via scheduler.rebuildMatviews → store.RefreshAllRepoAggregates")
+	}
+	if strings.Contains(code, "RefreshRepoGroupAggregates(") {
+		t.Error("facade.go must NOT call RefreshRepoGroupAggregates per repo — " +
+			"group aggregates are refreshed alongside repo aggregates in the " +
+			"bulk weekly rebuild path")
+	}
+}
+
+// TestPerRepoAggregateHelpersStillExported — the user wants the two per-repo
+// helpers left in the code (for manual ops usage, one-off recalculation, etc.).
+// This test enforces that we only moved the *call site* out of facade, not the
+// function definitions.
+func TestPerRepoAggregateHelpersStillExported(t *testing.T) {
+	src, err := os.ReadFile("../db/aggregates.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	for _, fn := range []string{
+		"func (s *PostgresStore) RefreshRepoAggregates(",
+		"func (s *PostgresStore) RefreshRepoGroupAggregates(",
+		"func (s *PostgresStore) RefreshAllRepoAggregates(",
+	} {
+		if !strings.Contains(code, fn) {
+			t.Errorf("aggregates.go must still declare %q — the per-repo helpers "+
+				"stay available for manual recalculation; only the automatic "+
+				"per-repo invocation from facade is removed", fn)
+		}
+	}
+}
+
+// TestSchedulerStillRefreshesAggregatesOnMatviewDay — defense in depth:
+// making sure we didn't accidentally remove the bulk call while deleting
+// the per-repo one. This overlaps dm_aggregates_test.go's existing
+// TestMatviewRebuildCallsAggregates; having both pins both code paths.
+func TestSchedulerStillRefreshesAggregatesOnMatviewDay(t *testing.T) {
+	src, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "func (s *Scheduler) rebuildMatviews(")
+	if idx < 0 {
+		t.Fatal("cannot find rebuildMatviews in scheduler.go")
+	}
+	fnBody := code[idx:]
+	end := strings.Index(fnBody, "\n}\n")
+	if end > 0 {
+		fnBody = fnBody[:end]
+	}
+	if !strings.Contains(fnBody, "RefreshAllRepoAggregates") {
+		t.Error("rebuildMatviews must call store.RefreshAllRepoAggregates — " +
+			"this is the ONLY path that populates dm_repo_* now that the " +
+			"per-repo facade call is removed")
+	}
+}

--- a/internal/collector/api_nonfatal_test.go
+++ b/internal/collector/api_nonfatal_test.go
@@ -1,0 +1,110 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestStagedCollectorTreatsNotFoundAndForbiddenAsNonFatal — source-level
+// contract for the staged collector's per-phase loops. A single 404 or 403
+// on an optional endpoint (contributors on an archived repo, /pulls on a
+// repo with PRs disabled, GitLab merge_requests on a private project, etc.)
+// must not bubble into result.Errors, which would flip
+// buildOutcome.success=false and fail the whole job.
+//
+// The fix pattern (established for releases in v0.16.4): check
+// errors.Is(err, platform.ErrNotFound) / ErrForbidden, log a skip line, and
+// break out of the phase without appending to result.Errors.
+func TestStagedCollectorTreatsNotFoundAndForbiddenAsNonFatal(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Every collectX phase that lists from a single upstream endpoint must
+	// guard that list's error with the sentinel check. Pin each by name.
+	phases := []string{
+		"ListContributors",
+		"ListIssues",
+		"ListPullRequests",
+		"ListIssueEvents",
+		"ListPREvents",
+		"ListIssueComments",
+		"ListReviewComments",
+	}
+
+	for _, phase := range phases {
+		idx := strings.Index(code, phase)
+		if idx < 0 {
+			t.Errorf("cannot find %s call in staged.go", phase)
+			continue
+		}
+		// Examine a generous window starting from the phase call. The
+		// non-fatal check should appear before the next append to
+		// result.Errors or before the next phase.
+		end := idx + 800
+		if end > len(code) {
+			end = len(code)
+		}
+		window := code[idx:end]
+		// Accept either explicit sentinel checks or the helper that bundles
+		// them (isOptionalEndpointSkip). The helper is the preferred form
+		// because it keeps the 404+403 policy in one place.
+		hasSentinels := strings.Contains(window, "ErrNotFound") && strings.Contains(window, "ErrForbidden")
+		hasHelper := strings.Contains(window, "isOptionalEndpointSkip")
+		if !hasSentinels && !hasHelper {
+			t.Errorf("staged.go: the loop over %s must treat 404 AND 403 as "+
+				"non-fatal — either call isOptionalEndpointSkip(err) (preferred) "+
+				"or inline errors.Is checks for both platform.ErrNotFound and "+
+				"platform.ErrForbidden — so a single bad endpoint doesn't fail "+
+				"the whole job", phase)
+		}
+	}
+
+	// And the helper itself must exist and cover both sentinels.
+	helperIdx := strings.Index(code, "func isOptionalEndpointSkip(")
+	if helperIdx < 0 {
+		t.Error("staged.go should define isOptionalEndpointSkip(err) to centralize " +
+			"the 404+403 non-fatal check — otherwise every phase duplicates the " +
+			"policy and drift is guaranteed")
+	} else {
+		helperBody := code[helperIdx:]
+		end := strings.Index(helperBody, "\n}\n")
+		if end > 0 {
+			helperBody = helperBody[:end]
+		}
+		if !strings.Contains(helperBody, "ErrNotFound") || !strings.Contains(helperBody, "ErrForbidden") {
+			t.Error("isOptionalEndpointSkip must check both platform.ErrNotFound " +
+				"AND platform.ErrForbidden")
+		}
+	}
+}
+
+// TestHTTPClient403WrapsErrForbidden — pins the 403 branch in httpclient.go
+// to wrap ErrForbidden so callers can distinguish "private repo / bad scope"
+// from rate-limit and auth-failure cases.
+func TestHTTPClient403WrapsErrForbidden(t *testing.T) {
+	src, err := os.ReadFile("../platform/httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the "not a rate limit" branch (the one we care about).
+	idx := strings.Index(code, "not a rate limit")
+	if idx < 0 {
+		t.Fatal("cannot find 'not a rate limit' branch in httpclient.go")
+	}
+	// Look backward ~400 chars for the ErrForbidden wrap.
+	start := idx - 400
+	if start < 0 {
+		start = 0
+	}
+	window := code[start : idx+100]
+	if !strings.Contains(window, "ErrForbidden") {
+		t.Error("the 403 'not a rate limit' branch must wrap ErrForbidden " +
+			"via fmt.Errorf with %%w so the collector can errors.Is check it")
+	}
+}

--- a/internal/collector/facade.go
+++ b/internal/collector/facade.go
@@ -68,14 +68,11 @@ func (f *FacadeCollector) CollectRepo(ctx context.Context, repoID int64, gitURL 
 		return result, fmt.Errorf("git log: %w", err)
 	}
 
-	// Refresh aggregates (dm_repo_annual/monthly/weekly).
-	f.logger.Info("refreshing aggregates", "repo_id", repoID)
-	if err := f.store.RefreshRepoAggregates(ctx, repoID); err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("repo aggregates: %w", err))
-	}
-	if err := f.store.RefreshRepoGroupAggregates(ctx, repoID); err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("repo group aggregates: %w", err))
-	}
+	// dm_repo_* aggregates are NOT refreshed here. Running them per repo on
+	// every collection duplicated work and dominated facade runtime on large
+	// fleets. The scheduler runs RefreshAllRepoAggregates in bulk on the
+	// configured matview rebuild day (see scheduler.rebuildMatviews). The
+	// per-repo helpers in db/aggregates.go remain available for manual/ops use.
 
 	return result, nil
 }

--- a/internal/collector/release_notfound_test.go
+++ b/internal/collector/release_notfound_test.go
@@ -18,23 +18,26 @@ func TestStagedCollectorIgnoresReleaseNotFound(t *testing.T) {
 	}
 	code := string(src)
 
-	// The releases loop must reference platform.ErrNotFound — either directly
-	// or via an errors.Is check — to treat 404 as non-fatal.
+	// The releases loop must treat 404 as non-fatal. Either it checks
+	// errors.Is(err, platform.ErrNotFound) directly, or it delegates to the
+	// isOptionalEndpointSkip helper (introduced in v0.16.8 to bundle 404+403
+	// across every phase).
 	idx := strings.Index(code, "ListReleases")
 	if idx < 0 {
 		t.Fatal("cannot find ListReleases call in staged.go")
 	}
-	// Scan a window around the ListReleases call for the not-found check.
+	// Scan a window around the ListReleases call.
 	start := idx
 	end := idx + 800
 	if end > len(code) {
 		end = len(code)
 	}
 	window := code[start:end]
-	if !strings.Contains(window, "ErrNotFound") {
-		t.Error("staged.go: releases loop must check errors.Is(err, platform.ErrNotFound) " +
-			"and continue without appending to result.Errors — otherwise a 404 on " +
-			"/releases (repos with no releases, renamed repos) fails the whole job")
+	if !strings.Contains(window, "ErrNotFound") && !strings.Contains(window, "isOptionalEndpointSkip") {
+		t.Error("staged.go: releases loop must treat 404 as non-fatal via either " +
+			"errors.Is(err, platform.ErrNotFound) or isOptionalEndpointSkip(err) — " +
+			"otherwise a 404 on /releases (repos with no releases, renamed repos) " +
+			"fails the whole job")
 	}
 }
 

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -53,6 +53,16 @@ const (
 // initial collection pass.
 const LargeRepoCommitThreshold = 10000
 
+// isOptionalEndpointSkip returns true when err represents a normal "this
+// endpoint is not available for this repo" condition — 404 (endpoint or
+// repo missing) or 403 (token can't see a private resource or lacks scope).
+// Used by every staged-phase loop to distinguish routine "skip this phase"
+// outcomes from actual collection failures that should bubble into
+// result.Errors and fail the job.
+func isOptionalEndpointSkip(err error) bool {
+	return errors.Is(err, platform.ErrNotFound) || errors.Is(err, platform.ErrForbidden)
+}
+
 // ParallelSlots is a global counter tracking how many extra parallel goroutines
 // are active for large-repo collection. The scheduler's fillWorkerSlots checks
 // this to avoid starting new jobs while large repos consume extra capacity.
@@ -140,12 +150,11 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 
 	for rel, relErr := range sc.client.ListReleases(ctx, owner, repo) {
 		if relErr != nil {
-			// A 404 on /releases is normal for repos that never cut a release
-			// (and for repos whose slug we can no longer resolve — renames,
-			// deletions). It must NOT fail the whole collection job.
-			if errors.Is(relErr, platform.ErrNotFound) {
-				sc.logger.Info("no releases endpoint (404) — treating as zero releases",
-					"owner", owner, "repo", repo)
+			// 404/403 on /releases is normal for repos that never cut a release
+			// or for private/unreachable resources. It must NOT fail the job.
+			if isOptionalEndpointSkip(relErr) {
+				sc.logger.Info("skipping releases endpoint",
+					"owner", owner, "repo", repo, "reason", relErr)
 				break
 			}
 			result.Errors = append(result.Errors, fmt.Errorf("releases: %w", relErr))
@@ -181,6 +190,11 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 	sc.logger.Info("collecting contributors", "owner", owner, "repo", repo)
 	for contrib, err := range sc.client.ListContributors(ctx, owner, repo) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping contributors endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("contributors: %w", err))
 			break
 		}
@@ -297,6 +311,11 @@ func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWrit
 	sc.logger.Info("collecting issues", "owner", owner, "repo", repo)
 	for issue, err := range sc.client.ListIssues(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping issues endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("issues: %w", err))
 			break
 		}
@@ -329,6 +348,11 @@ func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter,
 	sc.logger.Info("collecting pull requests", "owner", owner, "repo", repo)
 	for pr, err := range sc.client.ListPullRequests(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping pull requests endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("pull requests: %w", err))
 			break
 		}
@@ -395,6 +419,11 @@ func (sc *StagedCollector) collectEvents(ctx context.Context, sw *db.StagingWrit
 	sc.logger.Info("collecting events", "owner", owner, "repo", repo)
 	for event, err := range sc.client.ListIssueEvents(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping issue events endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("issue events: %w", err))
 			break
 		}
@@ -403,6 +432,11 @@ func (sc *StagedCollector) collectEvents(ctx context.Context, sw *db.StagingWrit
 	}
 	for event, err := range sc.client.ListPREvents(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping pr events endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("pr events: %w", err))
 			break
 		}
@@ -417,6 +451,11 @@ func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWr
 	sc.logger.Info("collecting messages", "owner", owner, "repo", repo)
 	for msg, err := range sc.client.ListIssueComments(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping issue comments endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("issue comments: %w", err))
 			break
 		}
@@ -425,6 +464,11 @@ func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWr
 	}
 	for rc, err := range sc.client.ListReviewComments(ctx, owner, repo, since) {
 		if err != nil {
+			if isOptionalEndpointSkip(err) {
+				sc.logger.Info("skipping review comments endpoint",
+					"owner", owner, "repo", repo, "reason", err)
+				break
+			}
 			result.Errors = append(result.Errors, fmt.Errorf("review comments: %w", err))
 			break
 		}

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -153,6 +153,35 @@ func (s *PostgresStore) MakeQueuedReposDue(ctx context.Context) (int64, error) {
 	return tag.RowsAffected(), nil
 }
 
+// RealignDueDates recomputes due_at = last_collected + recollectAfter for
+// every 'queued' row whose last_collected is set. Called once on scheduler
+// startup so a changed days_until_recollect takes effect immediately on
+// existing rows — without this, CompleteJob bakes due_at at completion time
+// under the old setting and subsequent config changes are silently ignored
+// until each repo's next completion.
+//
+// Skipped rows:
+//   - status = 'collecting' — a worker is mid-flight, don't disturb it
+//   - last_collected IS NULL — never-collected repos keep their initial
+//     due_at=NOW() so they collect on first pass
+//
+// Idempotent: the <> predicate skips rows already in the correct shape, so
+// updated_at stays stable across repeated startups.
+func (s *PostgresStore) RealignDueDates(ctx context.Context, recollectAfter time.Duration) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_ops.collection_queue
+		SET due_at = last_collected + $1::interval,
+			updated_at = NOW()
+		WHERE status = 'queued'
+		  AND last_collected IS NOT NULL
+		  AND due_at <> last_collected + $1::interval`,
+		recollectAfter.String())
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
 // RecoverStaleLocks resets jobs that have been locked for longer than timeout
 // (e.g. a worker crashed). Called periodically by the scheduler.
 func (s *PostgresStore) RecoverStaleLocks(ctx context.Context, timeout time.Duration) (int64, error) {

--- a/internal/db/queue_realign_test.go
+++ b/internal/db/queue_realign_test.go
@@ -1,0 +1,101 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRealignDueDatesExists — store-level source contract: queue.go must
+// expose a RealignDueDates method that recomputes due_at = last_collected +
+// recollectAfter for queued rows on scheduler startup. Without it, a change
+// to days_until_recollect (e.g., 1 → 7) never takes effect on already-queued
+// rows whose due_at was baked in by CompleteJob under the old setting.
+func TestRealignDueDatesExists(t *testing.T) {
+	data, err := os.ReadFile("queue.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "func (s *PostgresStore) RealignDueDates(") {
+		t.Error("queue.go must define RealignDueDates(ctx, recollectAfter) — " +
+			"required so a changed days_until_recollect takes effect on restart " +
+			"instead of waiting for each repo's next CompleteJob to rebake due_at")
+	}
+}
+
+// TestRealignDueDatesSQLShape verifies the SQL:
+//   - only touches 'queued' rows (never 'collecting' — worker is mid-flight)
+//   - only touches rows with a non-null last_collected (never-collected repos
+//     keep their initial due_at=NOW() so they collect on first pass)
+//   - uses last_collected + interval (not NOW() + interval) so the cooldown
+//     is measured from the actual completion, not from startup time
+//   - is idempotent (only rewrites rows whose current due_at differs)
+func TestRealignDueDatesSQLShape(t *testing.T) {
+	data, err := os.ReadFile("queue.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	idx := strings.Index(src, "func (s *PostgresStore) RealignDueDates(")
+	if idx < 0 {
+		t.Fatal("RealignDueDates not found — see TestRealignDueDatesExists")
+	}
+	// Grab the function body (roughly).
+	fnBody := src[idx:]
+	end := strings.Index(fnBody, "\nfunc ")
+	if end > 0 {
+		fnBody = fnBody[:end]
+	}
+
+	if !strings.Contains(fnBody, "status = 'queued'") && !strings.Contains(fnBody, `status='queued'`) {
+		t.Error("RealignDueDates must filter status='queued' so it doesn't " +
+			"disturb in-flight 'collecting' jobs")
+	}
+	if !strings.Contains(fnBody, "last_collected IS NOT NULL") {
+		t.Error("RealignDueDates must require last_collected IS NOT NULL so " +
+			"never-collected repos keep their due_at=NOW() initial value")
+	}
+	if !strings.Contains(fnBody, "last_collected +") {
+		t.Error("RealignDueDates must compute due_at from last_collected + " +
+			"interval — using NOW()+interval would grant every repo a fresh " +
+			"full cooldown on every restart")
+	}
+	// Idempotency — the WHERE clause must exclude already-aligned rows so
+	// repeated startups don't churn updated_at.
+	if !strings.Contains(fnBody, "<>") && !strings.Contains(fnBody, "!=") {
+		t.Error("RealignDueDates must skip rows where due_at already equals " +
+			"last_collected + interval (idempotency — keeps updated_at stable)")
+	}
+}
+
+// TestSchedulerCallsRealignDueDatesOnStartup — source contract: the scheduler
+// Run loop must invoke RealignDueDates once before the first fillWorkerSlots
+// so stale due_at values from a previous days_until_recollect setting are
+// corrected before any job is dequeued.
+func TestSchedulerCallsRealignDueDatesOnStartup(t *testing.T) {
+	data, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(data)
+
+	idx := strings.Index(code, "func (s *Scheduler) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find Scheduler.Run")
+	}
+	fnBody := code[idx:]
+	// Consider only the startup prelude — everything before the main `for {` loop.
+	forIdx := strings.Index(fnBody, "\n\tfor {")
+	if forIdx > 0 {
+		fnBody = fnBody[:forIdx]
+	}
+
+	if !strings.Contains(fnBody, "RealignDueDates") {
+		t.Error("Scheduler.Run must call store.RealignDueDates(ctx, s.cfg.RecollectAfter) " +
+			"during startup (before entering the main poll loop) so stale due_at " +
+			"values from a prior days_until_recollect setting are corrected before " +
+			"any job is dequeued")
+	}
+}

--- a/internal/db/staging.go
+++ b/internal/db/staging.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,30 @@ import (
 
 	"github.com/jackc/pgx/v5"
 )
+
+// nullEscapeLower and nullEscapeUpper match JSON's two legal renderings of a
+// NUL byte: \u0000 and \u0000. PostgreSQL JSONB rejects both with
+// SQLSTATE 22P05 ("unsupported Unicode escape sequence"), and a single
+// occurrence in any row of a batched insert fails the whole flush.
+var (
+	nullEscapeLower = []byte(`\u0000`)
+	nullEscapeUpper = []byte(`\u0000`)
+)
+
+// sanitizeJSONForJSONB strips \u0000 escapes from marshaled JSON before it
+// hits PostgreSQL JSONB. GitHub/GitLab API responses occasionally carry NUL
+// bytes in text fields (bot-generated comments, binary content echoed back
+// in diffs), and PostgreSQL refuses to accept them. We drop the escape
+// rather than replace with a placeholder because the character has no
+// legitimate semantic value in the fields we stage.
+func sanitizeJSONForJSONB(data []byte) []byte {
+	if !bytes.Contains(data, nullEscapeLower) && !bytes.Contains(data, nullEscapeUpper) {
+		return data
+	}
+	out := bytes.ReplaceAll(data, nullEscapeLower, nil)
+	out = bytes.ReplaceAll(out, nullEscapeUpper, nil)
+	return out
+}
 
 // StagingWriter appends raw API responses to the staging table.
 // This is the fast path: no FK lookups, no contributor resolution, just JSONB inserts.
@@ -39,6 +64,9 @@ func (w *StagingWriter) Stage(ctx context.Context, entityType string, payload an
 	if err != nil {
 		return fmt.Errorf("marshaling %s: %w", entityType, err)
 	}
+	// Strip \u0000 escapes — PostgreSQL JSONB rejects them and a single
+	// poisoned row would fail the whole 500-row batch flush.
+	data = sanitizeJSONForJSONB(data)
 	w.batch.Queue(`
 		INSERT INTO aveloxis_ops.staging (repo_id, platform_id, entity_type, payload)
 		VALUES ($1, $2, $3, $4)`,

--- a/internal/db/staging_sanitize_test.go
+++ b/internal/db/staging_sanitize_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func readFileForTest(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// TestSanitizeJSONForJSONB_StripsNullEscape — the helper must strip literal
+// `\u0000` sequences from JSON bytes before they reach PostgreSQL. A single
+// `\u0000` in any field value fails the whole JSONB insert with
+// SQLSTATE 22P05 "unsupported Unicode escape sequence", killing 500-row
+// batches on a single poisoned GitHub/GitLab payload.
+func TestSanitizeJSONForJSONB_StripsNullEscape(t *testing.T) {
+	in := []byte(`{"body":"hello\u0000world","id":42}`)
+	got := sanitizeJSONForJSONB(in)
+	if bytes.Contains(got, []byte(`\u0000`)) {
+		t.Errorf("expected \\u0000 removed; got %s", got)
+	}
+	// Must remain valid-ish JSON shape (outer braces, other fields intact).
+	if !bytes.Contains(got, []byte(`"id":42`)) {
+		t.Errorf("sanitizer must not damage unrelated fields: %s", got)
+	}
+}
+
+// TestSanitizeJSONForJSONB_PreservesValidContent — scrubber must not touch
+// other escape sequences (\n, \t, \u00e9 …) or non-ASCII content.
+func TestSanitizeJSONForJSONB_PreservesValidContent(t *testing.T) {
+	in := []byte(`{"text":"hello\nworld\t\u00e9","id":1}`)
+	got := sanitizeJSONForJSONB(in)
+	if !bytes.Equal(in, got) {
+		t.Errorf("sanitizer must be a no-op when no \\u0000 present.\n  in:  %s\n  got: %s", in, got)
+	}
+}
+
+// TestSanitizeJSONForJSONB_StripsAllOccurrences — one row can carry many
+// poisoned fields; every one must go.
+func TestSanitizeJSONForJSONB_StripsAllOccurrences(t *testing.T) {
+	in := []byte(`{"a":"\u0000","b":"x\u0000y","c":"\u0000\u0000"}`)
+	got := sanitizeJSONForJSONB(in)
+	if bytes.Contains(got, []byte(`\u0000`)) {
+		t.Errorf("every \\u0000 must be removed: %s", got)
+	}
+}
+
+// TestStagingWriterStageCallsSanitizer — source-level contract: Stage must
+// run the scrubber on the marshaled bytes before queuing the batch insert.
+// Without this, the scrubber exists but is never called on the hot path.
+func TestStagingWriterStageCallsSanitizer(t *testing.T) {
+	src := readFileForTest(t, "staging.go")
+	idx := strings.Index(src, "func (w *StagingWriter) Stage(")
+	if idx < 0 {
+		t.Fatal("cannot find StagingWriter.Stage")
+	}
+	fnBody := src[idx:]
+	end := strings.Index(fnBody, "\n}\n")
+	if end > 0 {
+		fnBody = fnBody[:end]
+	}
+	if !strings.Contains(fnBody, "sanitizeJSONForJSONB") {
+		t.Error("StagingWriter.Stage must call sanitizeJSONForJSONB on the " +
+			"marshaled bytes before w.batch.Queue — otherwise a single " +
+			"\\u0000 in a GitHub/GitLab payload kills the whole batch flush")
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.7"
+var ToolVersion = "0.16.8"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.4"
+var ToolVersion = "0.16.5"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.6"
+var ToolVersion = "0.16.7"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.16.5"
+var ToolVersion = "0.16.6"

--- a/internal/monitor/due_at_format_test.go
+++ b/internal/monitor/due_at_format_test.go
@@ -1,0 +1,58 @@
+package monitor
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDueAtIncludesDate — the monitor table column "Due" must include the
+// date, not just the time. A value like "15:21:27" is ambiguous when due_at
+// is days away (the v0.16.6 realignment pushes due_at out by up to 7 days,
+// so "15:21" with no date is unreadable). The existing "Last Run" column
+// uses "Jan 2 15:04"; this test pins the "Due" column to the same shape so
+// both columns are consistent.
+func TestDueAtIncludesDate(t *testing.T) {
+	src, err := os.ReadFile("monitor.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "j.DueAt.Format(")
+	if idx < 0 {
+		t.Fatal("cannot find DueAt.Format call in monitor.go HTML rendering")
+	}
+	// Consider only the non-JSON usage — the JSON field at line 88 uses
+	// RFC3339, which is fine. The HTML rendering is the one we're pinning.
+	// Find the *second* occurrence of DueAt.Format (skipping the RFC3339 one).
+	rest := code[idx+len("j.DueAt.Format("):]
+	secondIdx := strings.Index(rest, "j.DueAt.Format(")
+	var fmtArg string
+	if secondIdx >= 0 {
+		// Second call is the table cell.
+		tail := rest[secondIdx+len("j.DueAt.Format("):]
+		if end := strings.Index(tail, ")"); end > 0 {
+			fmtArg = tail[:end]
+		}
+	} else {
+		// Only one call — use the one we found.
+		tail := code[idx+len("j.DueAt.Format("):]
+		if end := strings.Index(tail, ")"); end > 0 {
+			fmtArg = tail[:end]
+		}
+	}
+
+	// The format string for the *table cell* must contain a date token
+	// ("Jan", "2006", or "01/02") so users can distinguish today from a
+	// week from now. Pure time formats ("15:04:05", "15:04") are rejected.
+	hasDate := strings.Contains(fmtArg, "Jan") ||
+		strings.Contains(fmtArg, "2006") ||
+		strings.Contains(fmtArg, "01/02") ||
+		strings.Contains(fmtArg, "RFC3339")
+	if !hasDate {
+		t.Errorf("monitor.go: DueAt table-cell format %s has no date component — "+
+			"users cannot tell if a repo is due today or a week out. Use a format "+
+			"like \"Jan 2 15:04\" to match the Last Run column.", fmtArg)
+	}
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -278,7 +278,9 @@ function sortTable(col) {
 			rowClass = ` class="p0"`
 		}
 
-		due := j.DueAt.Format("15:04:05")
+		// Match the Last Run column format so the date is visible — critical
+		// now that due_at can be up to days_until_recollect days in the future.
+		due := j.DueAt.Format("Jan 2 15:04")
 		if j.DueAt.Before(time.Now()) && j.Status == "queued" {
 			due = "now"
 		}

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -26,6 +26,14 @@ var ErrNotModified = errors.New("not modified (304)")
 // cut a release) as non-fatal can check errors.Is(err, ErrNotFound).
 var ErrNotFound = errors.New("not found")
 
+// ErrForbidden wraps 403 responses that are NOT rate-limit exhaustions
+// (no Retry-After, non-zero X-RateLimit-Remaining). These usually mean the
+// token can't see a particular resource — private GitLab project, repo
+// with restricted visibility, endpoint requiring a scope the token lacks.
+// Callers can check errors.Is(err, ErrForbidden) to skip the endpoint
+// without failing the whole collection.
+var ErrForbidden = errors.New("forbidden")
+
 // AuthStyle controls how API tokens are sent in HTTP requests.
 // GitHub and GitLab use different authentication header formats.
 type AuthStyle int
@@ -207,7 +215,7 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 				continue
 			}
 			// 403 for other reasons (private repo, no permission) — not a key problem.
-			return nil, fmt.Errorf("forbidden: %s (not a rate limit — may be a private repo or insufficient scope)", url)
+			return nil, fmt.Errorf("%w: %s (not a rate limit — may be a private repo or insufficient scope)", ErrForbidden, url)
 		case resp.StatusCode == http.StatusTooManyRequests:
 			resp.Body.Close()
 			wait := parseRetryAfter(resp)

--- a/internal/platform/httpclient_forbidden_test.go
+++ b/internal/platform/httpclient_forbidden_test.go
@@ -1,0 +1,49 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestErrForbiddenIsExported — sentinel must exist so callers can check
+// via errors.Is(err, ErrForbidden) and treat 403 on an optional endpoint
+// (e.g., GitLab merge_requests on a private project, /traffic/clones on a
+// repo without push access) as non-fatal.
+func TestErrForbiddenIsExported(t *testing.T) {
+	if ErrForbidden == nil {
+		t.Fatal("ErrForbidden must be a non-nil exported sentinel error")
+	}
+	if ErrForbidden.Error() == "" {
+		t.Error("ErrForbidden must have a non-empty message")
+	}
+}
+
+// TestGet_403ReturnsErrForbidden — 403 responses without rate-limit headers
+// must return an error that wraps ErrForbidden. We pass an X-RateLimit-Remaining
+// of 1 so the rate-limit branch is NOT taken.
+func TestGet_403ReturnsErrForbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No Retry-After and remaining > 0 → falls into the "forbidden for
+		// other reasons" branch (private repo / insufficient scope).
+		w.Header().Set("X-RateLimit-Remaining", "1")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	keys := NewKeyPool([]string{"test-token"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	_, err := client.Get(context.Background(), "/projects/x/merge_requests")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !errors.Is(err, ErrForbidden) {
+		t.Errorf("expected errors.Is(err, ErrForbidden), got %v", err)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -116,6 +116,18 @@ func (s *Scheduler) Run(ctx context.Context) {
 	s.recoverStale(ctx)
 	s.releaseOurLocks(ctx)
 
+	// Recompute due_at = last_collected + recollectAfter for already-queued
+	// rows so a changed days_until_recollect takes effect immediately. Without
+	// this, due_at is baked in by CompleteJob under the old setting and stays
+	// that way until each repo's next completion — which defeats the point of
+	// changing the cooldown in the config.
+	if realigned, err := s.store.RealignDueDates(ctx, s.cfg.RecollectAfter); err != nil {
+		s.logger.Error("failed to realign queue due_at from config", "error", err)
+	} else if realigned > 0 {
+		s.logger.Info("realigned queue due_at from current days_until_recollect",
+			"rows_updated", realigned, "recollect_after", s.cfg.RecollectAfter)
+	}
+
 	sem := make(chan struct{}, s.cfg.Workers)
 
 	pollTicker := time.NewTicker(s.cfg.PollInterval)

--- a/internal/web/due_at_format_test.go
+++ b/internal/web/due_at_format_test.go
@@ -1,0 +1,39 @@
+package web
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestWebQueueDueAtIncludesDate — mirror of TestDueAtIncludesDate in the
+// monitor package. The web server's queue table renders due_at in the same
+// HH:MM:SS-only format, which is unreadable once due_at is days out (post
+// v0.16.6 realignment). Pin it to a format that contains a date token.
+func TestWebQueueDueAtIncludesDate(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "row.Due = j.DueAt.Format(")
+	if idx < 0 {
+		t.Fatal("cannot find row.Due = j.DueAt.Format(...) in web/server.go")
+	}
+	tail := code[idx+len("row.Due = j.DueAt.Format("):]
+	end := strings.Index(tail, ")")
+	if end < 0 {
+		t.Fatal("malformed DueAt.Format call")
+	}
+	fmtArg := tail[:end]
+
+	hasDate := strings.Contains(fmtArg, "Jan") ||
+		strings.Contains(fmtArg, "2006") ||
+		strings.Contains(fmtArg, "01/02")
+	if !hasDate {
+		t.Errorf("web/server.go: row.Due format %s has no date component — "+
+			"use \"Jan 2 15:04\" to match the Last Run column so the user can "+
+			"tell today's repos from next-week's repos.", fmtArg)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -893,7 +893,7 @@ func (s *Server) handleMonitor(w http.ResponseWriter, r *http.Request) {
 			row.MetaCommits = st.MetadataCommits
 		}
 
-		row.Due = j.DueAt.Format("15:04:05")
+		row.Due = j.DueAt.Format("Jan 2 15:04")
 		if j.DueAt.Before(time.Now()) && j.Status == "queued" {
 			row.Due = "now"
 		}


### PR DESCRIPTION
…repo
 Fixes shipped in v0.16.8

  1. unsupported Unicode escape sequence (SQLSTATE 22P05) — db.sanitizeJSONForJSONB strips \u0000 from marshaled JSON in StagingWriter.Stage before the batch insert. Zero-overhead no-op on clean payloads, drops the escape when present. GitHub/GitLab occasionally put NUL bytes in text fields; they carried no semantic value so we drop the escape.
  2. 404 on /contributors, /pulls, /issues, events, comments — New collector.isOptionalEndpointSkip(err) bundles errors.Is(err, platform.ErrNotFound) and errors.Is(err, platform.ErrForbidden). Every staged-collector phase (contributors, issues, pull requests, issue events, PR events, issue comments, review comments, releases) now routes its per-endpoint error through it. Routine "endpoint missing for this repo" logs one info line and breaks — no more result.Errors entry.
  3. 403 on GitLab /merge_requests — Added platform.ErrForbidden sentinel; the 403 branch in httpclient.go:210 wraps it (fmt.Errorf("%w: ...", ErrForbidden, url)). The staged collector's non-fatal helper catches it alongside 404.

  Tests — 11 new tests across internal/db/staging_sanitize_test.go, internal/platform/httpclient_forbidden_test.go, and internal/collector/api_nonfatal_test.go (all failed before fix, all pass after). One existing test
  (TestStagedCollectorIgnoresReleaseNotFound) was broadened to accept the helper pattern.

  Verification — go test ./... and go vet ./... green.

  Rebuild and restart: go install ./cmd/aveloxis && aveloxis stop all && aveloxis start all.


 (v0.16.6)
                                                                                                                                  
  - db.PostgresStore.RealignDueDates(ctx, recollectAfter) — new SQL that recomputes due_at = last_collected + recollectAfter for status='queued' rows with a non-null last_collected. Idempotent (<> predicate skips already-aligned rows), preserves 'collecting' jobs and never-collected repos.                                                                                    
  - Scheduler.Run calls it once during startup, after lock recovery and before the first fillWorkerSlots. Logs realigned queue due_at from current days_until_recollect rows_updated=N.                                                                        
  - Version bumped 0.16.5 → 0.16.6;  docs/guide/troubleshooting.md updated with a new section explaining the symptom, root cause, verification query, and the prioritize escape hatch.                                                               
                                                                                                                                  
  Live-DB preview before deploying — 3,079 rows would be realigned from April 17 due to April 23 (yesterday + 7 days), 35 'collecting' rows correctly skipped.                               

  Restart aveloxis serve, and you should see the realignment log line; the 3,079 repos will sit until April 23+ instead of         
  collecting immediately.
                             

Fix (v0.16.5)                                                                                                                   
  - Removed the two per-repo refresh calls and the "refreshing aggregates" log line from facade.go.                               
  - db.PostgresStore.RefreshRepoAggregates and RefreshRepoGroupAggregates remain in internal/db/aggregates.go for manual/ops   recalculation — unchanged.                                                                                                      
  - scheduler.rebuildMatviews continues to call store.RefreshAllRepoAggregates as the sole automatic aggregate-refresh trigger, on the configured collection.matview_rebuild_day.                                                                                 
  - Bumped 0.16.4 → 0.16.5; updated docs/guide/collection-pipeline.md.                                              
                                                                                    
  Tests — 3 new contract tests in internal/collector/aggregate_cadence_test.go:                                                   
  - TestFacadeDoesNotRefreshPerRepoAggregates (confirmed failing before fix, passing after)                                       
  - TestPerRepoAggregateHelpersStillExported (guards that the helpers stay available)                                             
  - TestSchedulerStillRefreshesAggregatesOnMatviewDay (defense in depth for the bulk path) 