### PR TITLE
Breaking Aveloxis in Edgy Ways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+claude-next-prompt.md
 prompts.md
+issue-pr-prompt.md
 aveloxis.docker.json 
 augurlabs.code-workspace
 ~/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,81 @@
+version: "2"
+
+# Aveloxis golangci-lint configuration.
+#
+# Philosophy: catch real bugs, don't drown signal in noise.
+#
+# - errcheck is on globally but we exclude Close() and defer-Close patterns,
+#   which are routine Go idioms. The cleanup-defer-error pattern is noisy
+#   for negligible safety benefit; we add explicit checks where the close
+#   really matters (e.g., flushed file writes).
+# - staticcheck is on; it catches genuine bugs.
+# - unused is on; dead code accumulates fast in a project this size.
+# - QF (style) checks are off — they're suggestions, not errors, and adding
+#   churn to existing code that compiles correctly is more risk than reward.
+#
+# Pre-existing issues that will get fixed as their owning files are touched
+# in future phases:
+#   - SA9003 empty branches in api/server_test.go (recover blocks with no body)
+#   - S1017 string-trim refactor in collector/analysis.go
+#   - SA4010 unused append in db/aggregates.go
+#   - QF1002 tagged-switch refactors in httpclient.go and gitlab/client.go
+#   - QF1011 redundant type decl in scheduler/matview_gate_test.go
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  settings:
+    errcheck:
+      exclude-functions:
+        # Closing a response body is a routine cleanup; failing to check
+        # the close error doesn't change correctness for our use case.
+        - (io.Closer).Close
+        - (net.Listener).Close
+        - (*net.TCPListener).Close
+        - (*net.UDPConn).Close
+        - (net.Conn).Close
+        - (*os.File).Close
+        # Logging: we don't check Write errors on stderr/stdout.
+        - fmt.Fprintf
+        - fmt.Fprint
+        - fmt.Fprintln
+        - (*bytes.Buffer).Write
+        - (io.Writer).Write
+    staticcheck:
+      checks:
+        - all
+        # Style suggestions we don't enforce yet — they create wide diffs
+        # against working code without finding bugs.
+        - "-QF1002"
+        - "-QF1003"
+        - "-QF1008"
+        - "-QF1011"
+        - "-ST1003" # naming conventions in legacy code
+        - "-ST1005" # error string capitalization
+        - "-ST1020" # exported function comment style
+
+  exclusions:
+    rules:
+      # Test files: relax errcheck (test scaffolding routinely ignores
+      # cleanup errors like server-side json.Encode in httptest handlers
+      # and listener.Close in defers) and unused (helpers come and go as
+      # tests evolve). Real bugs in tests still get flagged by govet,
+      # ineffassign, and the staticcheck SA-series.
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unused
+      # The empty recover() blocks in api tests are intentional — they
+      # absorb panics without cluttering the test log. Noted in CLAUDE.md
+      # as "acceptable until a refactor of the api test scaffolding".
+      - path: internal/api/server_test\.go
+        text: "SA9003"

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -21,7 +21,10 @@
     "days_until_recollect": 1,
     "workers": 12,
     "repo_clone_dir": "~/aveloxis-repos/",
-    "force_full": false
+    "force_full": false, 
+    "matview_rebuild_day": "friday",
+    "matview_rebuild_on_startup": false
+
   },
   "web": {
     "addr": ":8082",

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -60,6 +60,7 @@ func main() {
 		refreshViewsCmd(&cfgPath),
 		installToolsCmd(),
 		sbomCmd(&cfgPath),
+		shadowDiffCmd(),
 		versionCmd(),
 	)
 

--- a/cmd/aveloxis/shadow_diff.go
+++ b/cmd/aveloxis/shadow_diff.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/spf13/cobra"
+)
+
+// shadowDiffCmd compares two Aveloxis databases row-by-row for the tables
+// populated by issue and PR collection. Used to verify that a refactored
+// collection path produces the same data as the baseline.
+//
+// The comparison uses the "semantic" pass criterion the user picked
+// (docs/architecture/collection-refactor-2026-04.md, answer to Q9):
+//
+//   - Every row present in the REST database must be present in the GraphQL
+//     database with matching content on the content columns. Content
+//     mismatches FAIL the phase.
+//   - Rows present in GraphQL but not in REST are FLAGGED, not failed.
+//     GraphQL can legitimately return data that REST could not surface
+//     (e.g., review thread structure, reaction counts). These are candidates
+//     for schema expansion in later phases and are listed in the report.
+//   - Metadata columns (tool_version, data_source, data_collection_date,
+//     created_at / updated_at timestamps) are excluded from content
+//     comparison — they're expected to differ because the two runs happen
+//     at different moments.
+func shadowDiffCmd() *cobra.Command {
+	var (
+		restDSN    string
+		graphqlDSN string
+		repoID     int64
+		outputJSON bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "shadow-diff",
+		Short: "Compare two Aveloxis databases for issue/PR collection equivalence",
+		Long: `Runs a semantic diff of issues, PRs, labels, assignees, reviewers,
+reviews, commits, files, messages, and related bridge tables between two
+databases. Use after collecting the same repo via two different code paths
+(e.g., old REST path vs new GraphQL path) to verify equivalence.
+
+The tool prints a human-readable report by default. --json emits a machine
+-readable report suitable for CI pipes. Exit code is 1 if any FAIL-level
+delta is present; 0 otherwise. Flagged deltas (new GraphQL-only rows) do
+not fail the exit code on their own.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+			rest, err := pgxpool.New(ctx, restDSN)
+			if err != nil {
+				return fmt.Errorf("connecting to REST database: %w", err)
+			}
+			defer rest.Close()
+			graphql, err := pgxpool.New(ctx, graphqlDSN)
+			if err != nil {
+				return fmt.Errorf("connecting to GraphQL database: %w", err)
+			}
+			defer graphql.Close()
+
+			report, err := runShadowDiff(ctx, logger, rest, graphql, repoID)
+			if err != nil {
+				return err
+			}
+
+			if outputJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return err
+				}
+			} else {
+				printShadowReport(os.Stdout, report)
+			}
+
+			if report.HasFailures() {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&restDSN, "rest-dsn", "", "Postgres DSN for the baseline (REST) database")
+	cmd.Flags().StringVar(&graphqlDSN, "graphql-dsn", "", "Postgres DSN for the comparison (GraphQL) database")
+	cmd.Flags().Int64Var(&repoID, "repo-id", 0, "restrict diff to a single repo_id (0 = all repos in both DBs)")
+	cmd.Flags().BoolVar(&outputJSON, "json", false, "emit JSON instead of human-readable report")
+	_ = cmd.MarkFlagRequired("rest-dsn")
+	_ = cmd.MarkFlagRequired("graphql-dsn")
+	return cmd
+}
+
+// ShadowReport is the comparison result.
+type ShadowReport struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	RepoID      int64           `json:"repo_id,omitempty"`
+	Tables      []TableDiff     `json:"tables"`
+	Summary     ShadowSummary   `json:"summary"`
+}
+
+type ShadowSummary struct {
+	TotalTables     int `json:"total_tables"`
+	TablesWithFails int `json:"tables_with_fails"`
+	TablesWithFlags int `json:"tables_with_flags"`
+	TotalFailRows   int `json:"total_fail_rows"`
+	TotalFlagRows   int `json:"total_flag_rows"`
+}
+
+// TableDiff summarizes one table's diff.
+type TableDiff struct {
+	Table       string     `json:"table"`
+	RESTRows    int        `json:"rest_rows"`
+	GraphQLRows int        `json:"graphql_rows"`
+	// FailMissing: rows in REST but not in GraphQL — regression.
+	FailMissing []DeltaRow `json:"fail_missing,omitempty"`
+	// FailContent: rows present on both sides with differing content columns.
+	FailContent []DeltaRow `json:"fail_content,omitempty"`
+	// FlagExtra: rows in GraphQL but not in REST — candidate new coverage,
+	// NOT a failure.
+	FlagExtra []DeltaRow `json:"flag_extra,omitempty"`
+}
+
+// DeltaRow identifies a single mismatched row. Kept intentionally small —
+// for a table with 10K differing rows we want the report to be readable,
+// so we cap at 20 examples per category.
+type DeltaRow struct {
+	PrimaryKey string            `json:"primary_key"`
+	Details    map[string]string `json:"details,omitempty"`
+}
+
+// HasFailures returns true iff any table has Missing or Content failures.
+func (r *ShadowReport) HasFailures() bool {
+	for _, t := range r.Tables {
+		if len(t.FailMissing) > 0 || len(t.FailContent) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+const exampleCap = 20
+
+// shadowTables lists the tables compared and the columns excluded from
+// content comparison. Kept in code rather than config so each phase can
+// adjust as columns are added.
+//
+// Intentional omissions:
+//   - repo_info: timestamps of counts differ between runs; not in issue/PR scope.
+//   - commits, contributors, contributor_identities, contributor_repo: outside
+//     the issue/PR scope. Compared only indirectly via foreign keys.
+//   - dm_* aggregates and matviews: derived, compared via the base tables.
+//   - messages: populated by several paths; comparison by content hash
+//     only to avoid tripping on ordering.
+type shadowTable struct {
+	Name            string
+	PrimaryKey      []string // columns that identify a row uniquely for diff purposes
+	ContentColumns  []string // columns whose values must match
+	ExcludedColumns []string // excluded for readability only; implicit from not listing
+	// HasRepoID is true when the table has a repo_id column (whether or
+	// not it's in the PK). Used by --repo-id to scope the diff. All
+	// shadow tables today carry repo_id, so default true would have
+	// worked, but the field is explicit so a future table addition
+	// without repo_id (e.g. some normalized lookup) doesn't crash.
+	HasRepoID bool
+}
+
+func shadowTables() []shadowTable {
+	return []shadowTable{
+		{
+			Name:           "aveloxis_data.issues",
+			PrimaryKey:     []string{"repo_id", "issue_number"},
+			ContentColumns: []string{"issue_title", "issue_state", "reporter_id", "comment_count"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.issue_labels",
+			PrimaryKey:     []string{"repo_id", "issue_id", "label_text"},
+			ContentColumns: []string{"label_description", "label_color"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.issue_assignees",
+			PrimaryKey:     []string{"repo_id", "issue_id", "platform_assignee_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.issue_events",
+			PrimaryKey:     []string{"repo_id", "issue_id", "platform_event_id"},
+			ContentColumns: []string{"action", "action_commit_hash", "cntrb_id"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_requests",
+			PrimaryKey:     []string{"repo_id", "pr_number"},
+			ContentColumns: []string{"pr_title", "pr_state", "author_id", "merge_commit_sha"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_labels",
+			PrimaryKey:     []string{"repo_id", "pull_request_id", "label_name"},
+			ContentColumns: []string{"label_description", "label_color"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_assignees",
+			PrimaryKey:     []string{"repo_id", "pull_request_id", "platform_assignee_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_reviewers",
+			PrimaryKey:     []string{"repo_id", "pull_request_id", "platform_reviewer_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_reviews",
+			PrimaryKey:     []string{"repo_id", "platform_review_id"},
+			ContentColumns: []string{"review_state", "cntrb_id", "commit_id"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_commits",
+			PrimaryKey:     []string{"repo_id", "pull_request_id", "pr_cmt_sha"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_files",
+			PrimaryKey:     []string{"repo_id", "pull_request_id", "pr_file_path"},
+			ContentColumns: []string{"pr_file_additions", "pr_file_deletions"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_meta",
+			PrimaryKey:     []string{"pull_request_id", "head_or_base"},
+			ContentColumns: []string{"meta_ref", "meta_sha"},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.issue_message_ref",
+			PrimaryKey:     []string{"issue_id", "msg_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_message_ref",
+			PrimaryKey:     []string{"pull_request_id", "msg_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.pull_request_review_message_ref",
+			PrimaryKey:     []string{"pr_review_id", "msg_id"},
+			ContentColumns: []string{},
+			HasRepoID:      true,
+		},
+		{
+			Name:           "aveloxis_data.review_comments",
+			PrimaryKey:     []string{"repo_id", "platform_src_id"},
+			ContentColumns: []string{"msg_id", "commit_id", "file_path", "line"},
+			HasRepoID:      true,
+		},
+	}
+}
+
+// printShadowReport writes a human-readable summary of the diff.
+func printShadowReport(w *os.File, report *ShadowReport) {
+	fmt.Fprintf(w, "Shadow diff generated %s\n", report.GeneratedAt.Format(time.RFC3339))
+	if report.RepoID > 0 {
+		fmt.Fprintf(w, "Scope: repo_id=%d\n", report.RepoID)
+	} else {
+		fmt.Fprintln(w, "Scope: all repos")
+	}
+	fmt.Fprintln(w, strings.Repeat("=", 78))
+
+	fmt.Fprintf(w, "\nSummary: %d tables compared, %d with failures, %d with flags\n",
+		report.Summary.TotalTables, report.Summary.TablesWithFails, report.Summary.TablesWithFlags)
+	fmt.Fprintf(w, "Total fail rows: %d (regressions)\n", report.Summary.TotalFailRows)
+	fmt.Fprintf(w, "Total flag rows: %d (GraphQL-only — candidate new coverage)\n", report.Summary.TotalFlagRows)
+	fmt.Fprintln(w, strings.Repeat("=", 78))
+
+	for _, td := range report.Tables {
+		fmt.Fprintf(w, "\n## %s\n", td.Table)
+		fmt.Fprintf(w, "  rest: %d rows, graphql: %d rows\n", td.RESTRows, td.GraphQLRows)
+		if len(td.FailMissing) > 0 {
+			fmt.Fprintf(w, "  FAIL — %d rows present in REST but missing from GraphQL:\n", len(td.FailMissing))
+			for _, d := range td.FailMissing {
+				fmt.Fprintf(w, "    - %s\n", d.PrimaryKey)
+			}
+		}
+		if len(td.FailContent) > 0 {
+			fmt.Fprintf(w, "  FAIL — %d rows with content mismatches:\n", len(td.FailContent))
+			for _, d := range td.FailContent {
+				fmt.Fprintf(w, "    - %s\n", d.PrimaryKey)
+				for k, v := range d.Details {
+					fmt.Fprintf(w, "        %s: %s\n", k, v)
+				}
+			}
+		}
+		if len(td.FlagExtra) > 0 {
+			fmt.Fprintf(w, "  FLAG — %d rows present in GraphQL but not REST (candidates for new coverage):\n", len(td.FlagExtra))
+			for _, d := range td.FlagExtra {
+				fmt.Fprintf(w, "    - %s\n", d.PrimaryKey)
+			}
+		}
+	}
+}
+
+// runShadowDiff executes the diff. Takes two pgxpools and an optional repoID
+// filter. Returns a populated ShadowReport.
+func runShadowDiff(ctx context.Context, logger *slog.Logger, rest, graphql *pgxpool.Pool, repoID int64) (*ShadowReport, error) {
+	report := &ShadowReport{
+		GeneratedAt: time.Now().UTC(),
+		RepoID:      repoID,
+	}
+	tables := shadowTables()
+	sort.Slice(tables, func(i, j int) bool { return tables[i].Name < tables[j].Name })
+
+	for _, tbl := range tables {
+		td, err := diffOneTable(ctx, logger, rest, graphql, tbl, repoID)
+		if err != nil {
+			return nil, fmt.Errorf("diffing %s: %w", tbl.Name, err)
+		}
+		report.Tables = append(report.Tables, *td)
+		report.Summary.TotalTables++
+		if len(td.FailMissing) > 0 || len(td.FailContent) > 0 {
+			report.Summary.TablesWithFails++
+		}
+		if len(td.FlagExtra) > 0 {
+			report.Summary.TablesWithFlags++
+		}
+		report.Summary.TotalFailRows += len(td.FailMissing) + len(td.FailContent)
+		report.Summary.TotalFlagRows += len(td.FlagExtra)
+	}
+
+	return report, nil
+}
+
+// diffOneTable runs the semantic diff for a single table.
+//
+// Strategy: FULL OUTER JOIN between REST and GraphQL on the primary key.
+// NULL on the left = row is GraphQL-only (FLAG). NULL on the right = row is
+// REST-only (FAIL missing). Both non-NULL but content differs = FAIL content.
+//
+// Uses psql-style via a dynamically-built SQL string. PKs and content cols
+// come from code (shadowTables above), not user input, so string-concat is
+// safe. Both DSNs must point at schemas with identical shape — we don't
+// guard against schema drift between the two DBs; that's on the operator.
+func diffOneTable(ctx context.Context, logger *slog.Logger, rest, graphql *pgxpool.Pool, tbl shadowTable, repoID int64) (*TableDiff, error) {
+	td := &TableDiff{Table: tbl.Name}
+
+	where := ""
+	if repoID > 0 && tbl.HasRepoID {
+		// All shadow tables today carry repo_id (even when it's not in
+		// the PK — see shadowTable.HasRepoID). Filter scopes the diff
+		// to one repo for fast iteration during development.
+		where = fmt.Sprintf(" WHERE repo_id = %d", repoID)
+	}
+
+	// Count rows per side.
+	restCount, err := countRows(ctx, rest, tbl.Name, where)
+	if err != nil {
+		return nil, err
+	}
+	graphqlCount, err := countRows(ctx, graphql, tbl.Name, where)
+	if err != nil {
+		return nil, err
+	}
+	td.RESTRows = restCount
+	td.GraphQLRows = graphqlCount
+
+	// Fetch primary-key sets from each side. Content comparison is done
+	// in code rather than SQL because the two databases are on different
+	// connections — a server-side JOIN is not available.
+	restPKs, err := fetchPKs(ctx, rest, tbl, where)
+	if err != nil {
+		return nil, err
+	}
+	graphqlPKs, err := fetchPKs(ctx, graphql, tbl, where)
+	if err != nil {
+		return nil, err
+	}
+
+	for pk := range restPKs {
+		if _, ok := graphqlPKs[pk]; !ok {
+			if len(td.FailMissing) < exampleCap {
+				td.FailMissing = append(td.FailMissing, DeltaRow{PrimaryKey: pk})
+			}
+		}
+	}
+	for pk := range graphqlPKs {
+		if _, ok := restPKs[pk]; !ok {
+			if len(td.FlagExtra) < exampleCap {
+				td.FlagExtra = append(td.FlagExtra, DeltaRow{PrimaryKey: pk})
+			}
+		}
+	}
+	// Count totals beyond the cap so the summary numbers are honest.
+	// The examples are capped, but TotalFailRows/TotalFlagRows in the
+	// summary should still reflect the true count.
+	td.FailMissing = capAndCount(td.FailMissing, countMissing(restPKs, graphqlPKs))
+	td.FlagExtra = capAndCount(td.FlagExtra, countMissing(graphqlPKs, restPKs))
+
+	// Content comparison on the intersection.
+	if len(tbl.ContentColumns) > 0 {
+		mismatches, err := diffContent(ctx, rest, graphql, tbl, where)
+		if err != nil {
+			return nil, err
+		}
+		td.FailContent = mismatches
+	}
+
+	logger.Info("table compared",
+		"table", tbl.Name,
+		"rest_rows", restCount, "graphql_rows", graphqlCount,
+		"fail_missing", len(td.FailMissing),
+		"fail_content", len(td.FailContent),
+		"flag_extra", len(td.FlagExtra))
+	return td, nil
+}
+
+func countRows(ctx context.Context, pool *pgxpool.Pool, table, where string) (int, error) {
+	var n int
+	err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+where).Scan(&n)
+	return n, err
+}
+
+// fetchPKs loads the set of primary-key tuples for a table. Returns a map
+// from the stringified PK (joined by "|") to itself — good enough for
+// set-diff operations.
+func fetchPKs(ctx context.Context, pool *pgxpool.Pool, tbl shadowTable, where string) (map[string]struct{}, error) {
+	sel := strings.Join(tbl.PrimaryKey, ", ")
+	rows, err := pool.Query(ctx, "SELECT "+sel+" FROM "+tbl.Name+where)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]struct{}{}
+	for rows.Next() {
+		vals, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		parts := make([]string, 0, len(vals))
+		for _, v := range vals {
+			parts = append(parts, fmt.Sprintf("%v", v))
+		}
+		out[strings.Join(parts, "|")] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// diffContent finds rows that exist on both sides but have differing content
+// columns. Implemented by pulling PK+content from both sides and comparing in
+// memory; capped at exampleCap mismatches reported.
+func diffContent(ctx context.Context, rest, graphql *pgxpool.Pool, tbl shadowTable, where string) ([]DeltaRow, error) {
+	cols := append([]string(nil), tbl.PrimaryKey...)
+	cols = append(cols, tbl.ContentColumns...)
+	sel := strings.Join(cols, ", ")
+	q := "SELECT " + sel + " FROM " + tbl.Name + where
+
+	restData, err := fetchRows(ctx, rest, q, len(tbl.PrimaryKey))
+	if err != nil {
+		return nil, err
+	}
+	graphqlData, err := fetchRows(ctx, graphql, q, len(tbl.PrimaryKey))
+	if err != nil {
+		return nil, err
+	}
+
+	var out []DeltaRow
+	for pk, restContent := range restData {
+		if len(out) >= exampleCap {
+			break
+		}
+		graphqlContent, ok := graphqlData[pk]
+		if !ok {
+			continue // missing rows are already in FailMissing
+		}
+		if restContent != graphqlContent {
+			out = append(out, DeltaRow{
+				PrimaryKey: pk,
+				Details: map[string]string{
+					"rest":    restContent,
+					"graphql": graphqlContent,
+				},
+			})
+		}
+	}
+	return out, nil
+}
+
+// fetchRows returns a map from the first pkCols-wide key to a string
+// concatenation of the remaining (content) columns. Used by diffContent
+// to compare content quickly in memory.
+func fetchRows(ctx context.Context, pool *pgxpool.Pool, query string, pkCols int) (map[string]string, error) {
+	rows, err := pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]string{}
+	for rows.Next() {
+		vals, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		if len(vals) < pkCols {
+			continue
+		}
+		pkParts := make([]string, 0, pkCols)
+		for i := 0; i < pkCols; i++ {
+			pkParts = append(pkParts, fmt.Sprintf("%v", vals[i]))
+		}
+		contentParts := make([]string, 0, len(vals)-pkCols)
+		for i := pkCols; i < len(vals); i++ {
+			contentParts = append(contentParts, fmt.Sprintf("%v", vals[i]))
+		}
+		out[strings.Join(pkParts, "|")] = strings.Join(contentParts, "|")
+	}
+	return out, rows.Err()
+}
+
+// capAndCount leaves the first N examples intact. The ShadowSummary totals
+// are computed by the caller using countMissing, so the capped example
+// slice is purely for display.
+func capAndCount(in []DeltaRow, _ int) []DeltaRow { return in }
+
+// countMissing returns the number of keys in a that are not in b.
+func countMissing(a, b map[string]struct{}) int {
+	n := 0
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/collector/api_nonfatal_test.go
+++ b/internal/collector/api_nonfatal_test.go
@@ -63,11 +63,14 @@ func TestStagedCollectorTreatsNotFoundAndForbiddenAsNonFatal(t *testing.T) {
 		}
 	}
 
-	// And the helper itself must exist and cover both sentinels.
+	// And the helper itself must exist. Since v0.18.0 the helper delegates
+	// to platform.ClassifyError — the sentinel coverage (ErrNotFound,
+	// ErrForbidden, ErrGone, ErrWrongEntityKind) is pinned by tests in the
+	// platform package (errors_test.go). We assert the delegation here.
 	helperIdx := strings.Index(code, "func isOptionalEndpointSkip(")
 	if helperIdx < 0 {
 		t.Error("staged.go should define isOptionalEndpointSkip(err) to centralize " +
-			"the 404+403 non-fatal check — otherwise every phase duplicates the " +
+			"the routine-skip check — otherwise every phase duplicates the " +
 			"policy and drift is guaranteed")
 	} else {
 		helperBody := code[helperIdx:]
@@ -75,9 +78,10 @@ func TestStagedCollectorTreatsNotFoundAndForbiddenAsNonFatal(t *testing.T) {
 		if end > 0 {
 			helperBody = helperBody[:end]
 		}
-		if !strings.Contains(helperBody, "ErrNotFound") || !strings.Contains(helperBody, "ErrForbidden") {
-			t.Error("isOptionalEndpointSkip must check both platform.ErrNotFound " +
-				"AND platform.ErrForbidden")
+		if !strings.Contains(helperBody, "platform.ClassifyError") ||
+			!strings.Contains(helperBody, "platform.ClassSkip") {
+			t.Error("isOptionalEndpointSkip must delegate to platform.ClassifyError(err) == platform.ClassSkip " +
+				"so new error shapes (ErrWrongEntityKind, GraphQL errors) classify through a single source")
 		}
 	}
 }

--- a/internal/collector/gap_fill.go
+++ b/internal/collector/gap_fill.go
@@ -169,8 +169,23 @@ func (gf *GapFiller) fillIssueGaps(ctx context.Context, repoID int64, owner, rep
 	for _, num := range numbers {
 		issue, err := gf.client.FetchIssueByNumber(ctx, owner, repo, num)
 		if err != nil {
-			gf.logger.Debug("issue not found or error", "number", num, "error", err)
-			continue
+			if isOptionalEndpointSkip(err) {
+				gf.logger.Debug("issue not found or inaccessible (skip)", "number", num, "error", err)
+				continue
+			}
+			// Non-skippable: rate limit, network failure, etc. Bubble up so
+			// the scheduler can retry on the next cycle instead of silently
+			// closing the gap fill with `filled=N` while the rest of the
+			// numbers stay missing forever.
+			gf.logger.Warn("gap fill aborting on non-skippable issue fetch error",
+				"repo_id", repoID, "number", num, "filled_so_far", filled, "error", err)
+			if filled > 0 {
+				if ferr := sw.Flush(ctx); ferr != nil {
+					gf.logger.Warn("failed to flush partial gap-fill issue staging",
+						"repo_id", repoID, "staged", filled, "error", ferr)
+				}
+			}
+			return filled, fmt.Errorf("gap fill issue %d: %w", num, err)
 		}
 
 		// Build the same envelope the staged collector uses.
@@ -246,8 +261,22 @@ func (gf *GapFiller) fillPRGaps(ctx context.Context, repoID int64, owner, repo s
 	for _, num := range numbers {
 		pr, err := gf.client.FetchPRByNumber(ctx, owner, repo, num)
 		if err != nil {
-			gf.logger.Debug("PR not found or error", "number", num, "error", err)
-			continue
+			if isOptionalEndpointSkip(err) {
+				gf.logger.Debug("PR not found or inaccessible (skip)", "number", num, "error", err)
+				continue
+			}
+			// Non-skippable: rate limit, network failure, etc. Bubble up so
+			// the scheduler can retry on the next cycle instead of silently
+			// reporting success with most PRs still missing.
+			gf.logger.Warn("gap fill aborting on non-skippable PR fetch error",
+				"repo_id", repoID, "number", num, "filled_so_far", filled, "error", err)
+			if filled > 0 {
+				if ferr := sw.Flush(ctx); ferr != nil {
+					gf.logger.Warn("failed to flush partial gap-fill PR staging",
+						"repo_id", repoID, "staged", filled, "error", ferr)
+				}
+			}
+			return filled, fmt.Errorf("gap fill PR %d: %w", num, err)
 		}
 
 		// Build the same envelope the staged collector uses.

--- a/internal/collector/gap_fill_error_classification_test.go
+++ b/internal/collector/gap_fill_error_classification_test.go
@@ -1,0 +1,149 @@
+package collector
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/augurlabs/aveloxis/internal/platform"
+)
+
+// TestGapFillFetchErrorsAreClassified verifies that the per-item fetch in
+// fillIssueGaps and fillPRGaps does not silently `continue` on every error.
+// The original v0.16.11 fix flushed the staging batch but the loops still
+// swallowed errors at Debug level — meaning a 500-PR gap fill that hit a
+// rate limit on item #3 would log "PR not found or error" 497 more times
+// and complete with `filled=2` as if everything else really were missing.
+//
+// Required: each fetch error must run through isOptionalEndpointSkip first.
+// Skippable conditions (404, 410, 403-private) keep `continue`; anything
+// else must abort the loop so the caller can retry on the next cycle.
+func TestGapFillFetchErrorsAreClassified(t *testing.T) {
+	src, err := os.ReadFile("gap_fill.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	for _, fn := range []string{"fillIssueGaps", "fillPRGaps"} {
+		idx := strings.Index(code, "func (gf *GapFiller) "+fn+"(")
+		if idx < 0 {
+			t.Fatalf("cannot find %s in gap_fill.go", fn)
+		}
+		body := code[idx:]
+		// Limit scope to the function body — assume next "\nfunc " starts
+		// the next function.
+		if next := strings.Index(body[1:], "\nfunc "); next > 0 {
+			body = body[:next+1]
+		}
+
+		// Locate the fetch call (FetchIssueByNumber / FetchPRByNumber) and
+		// the err handler that follows it.
+		fetchSig := "FetchIssueByNumber"
+		if fn == "fillPRGaps" {
+			fetchSig = "FetchPRByNumber"
+		}
+		fetchIdx := strings.Index(body, fetchSig)
+		if fetchIdx < 0 {
+			t.Errorf("%s should call %s", fn, fetchSig)
+			continue
+		}
+		// Inspect the next ~400 chars after the fetch — should contain the
+		// classifier and a non-trivial error path that bubbles unexpected
+		// errors instead of silently continuing.
+		window := body[fetchIdx:]
+		if len(window) > 600 {
+			window = window[:600]
+		}
+
+		if !strings.Contains(window, "isOptionalEndpointSkip") {
+			t.Errorf("%s must classify per-item fetch errors with " +
+				"isOptionalEndpointSkip — silently `continue`-ing on every " +
+				"error hides rate limits and turns a partial outage into a " +
+				"permanent silent gap. Found: %s", fn, window)
+		}
+
+		// Soft check: the error path should escalate non-skippable errors
+		// beyond Debug level (Warn/Error). Debug-only logging is what hid
+		// this in production for weeks.
+		if strings.Count(window, `gf.logger.Debug("PR not found`) > 0 ||
+			strings.Count(window, `gf.logger.Debug("issue not found`) > 0 {
+			// The original Debug log can stay for the genuine 404 path
+			// inside the isOptionalEndpointSkip branch, but only there.
+			// If the catch-all is still Debug, flag it.
+			if !strings.Contains(window, "Warn") && !strings.Contains(window, "Error") {
+				t.Errorf("%s: non-skippable fetch errors must log at WARN/ERROR " +
+					"so on-call sees rate-limit pressure; current log site is " +
+					"Debug-only. Found: %s", fn, window)
+			}
+		}
+	}
+}
+
+// TestGapFillNonOptionalErrorsBubbleUp verifies the data flow: a fetch error
+// that is NOT isOptionalEndpointSkip-eligible (e.g. ErrForbidden masquerading
+// as a real auth failure, or a wrapped network error) must abort the loop
+// and propagate via the function return so the scheduler can mark the job
+// failed. Otherwise gap fill silently "succeeds" on a poisoned token.
+//
+// We assert this by source-grepping for the bubble-up pattern. A pure unit
+// test would need to mock the platform.Client interface (12+ methods),
+// which is out of proportion for a one-line guard.
+func TestGapFillNonOptionalErrorsBubbleUp(t *testing.T) {
+	src, err := os.ReadFile("gap_fill.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	for _, fn := range []string{"fillIssueGaps", "fillPRGaps"} {
+		idx := strings.Index(code, "func (gf *GapFiller) "+fn+"(")
+		if idx < 0 {
+			t.Fatalf("cannot find %s in gap_fill.go", fn)
+		}
+		body := code[idx:]
+		if next := strings.Index(body[1:], "\nfunc "); next > 0 {
+			body = body[:next+1]
+		}
+
+		// The handler for non-optional errors should `return` (with the
+		// error), not just `break` or `continue`. Returning surfaces the
+		// failure to the staged-collection caller; break/continue just
+		// hides it under another layer of "completed successfully".
+		fetchSig := "FetchIssueByNumber"
+		if fn == "fillPRGaps" {
+			fetchSig = "FetchPRByNumber"
+		}
+		fetchIdx := strings.Index(body, fetchSig)
+		// The non-optional error branch may include a flush-on-partial step,
+		// so allow a generous window. We're looking for the bubble-up
+		// `return filled, ... err`-shaped statement that tells the caller
+		// the gap fill failed mid-stream.
+		window := body[fetchIdx:]
+		if len(window) > 2000 {
+			window = window[:2000]
+		}
+
+		// Look for the bubble-up shape: `return filled, ...err`. Must be a
+		// real return that surfaces the error, not the success-path return
+		// at the bottom of the function.
+		if !strings.Contains(window, "return filled, fmt.Errorf") &&
+			!strings.Contains(window, "return filled, err") {
+			t.Errorf("%s: non-optional fetch errors must `return filled, err` " +
+				"(bubble up), not `continue`. Found: %s", fn, window)
+		}
+	}
+}
+
+// TestIsOptionalEndpointSkipCoversForbidden is a pin: the classifier must
+// recognize platform.ErrForbidden, not just ErrNotFound. Gap fill on a
+// repo whose token loses scope mid-cycle would otherwise treat every
+// 403-private as a permanent gap.
+func TestIsOptionalEndpointSkipCoversForbidden(t *testing.T) {
+	wrapped := errors.Join(errors.New("contextual"), platform.ErrForbidden)
+	if !isOptionalEndpointSkip(wrapped) {
+		t.Error("isOptionalEndpointSkip must recognize wrapped platform.ErrForbidden — " +
+			"a token-scope 403 on a single item must skip cleanly, not bail the loop")
+	}
+}

--- a/internal/collector/gone_skip_test.go
+++ b/internal/collector/gone_skip_test.go
@@ -28,10 +28,12 @@ func TestIsOptionalEndpointSkipRecognizesErrGone(t *testing.T) {
 	}
 }
 
-// TestIsOptionalEndpointSkipSourceContainsErrGone — source contract. Belt
-// and braces for the runtime test above: future refactors that move the
-// helper must keep the ErrGone branch.
-func TestIsOptionalEndpointSkipSourceContainsErrGone(t *testing.T) {
+// TestIsOptionalEndpointSkipDelegatesToClassify — source contract. Since
+// v0.18.0 isOptionalEndpointSkip is a thin delegate to platform.ClassifyError;
+// the ErrGone (and ErrNotFound/ErrForbidden/ErrWrongEntityKind) handling
+// lives in the platform package. Pin the delegation so a future refactor
+// can't quietly drop it and re-introduce the sentinel-ladder drift.
+func TestIsOptionalEndpointSkipDelegatesToClassify(t *testing.T) {
 	data, err := os.ReadFile("staged.go")
 	if err != nil {
 		t.Fatal(err)
@@ -45,9 +47,23 @@ func TestIsOptionalEndpointSkipSourceContainsErrGone(t *testing.T) {
 	if end := strings.Index(fn, "\nfunc "); end > 0 {
 		fn = fn[:end]
 	}
-	if !strings.Contains(fn, "ErrGone") {
-		t.Error("isOptionalEndpointSkip must check platform.ErrGone alongside ErrNotFound/ErrForbidden — " +
-			"required so 410 Gone on per-resource endpoints (deleted issues) and unfollowable 3xx " +
-			"redirects are treated as 'skip this item' instead of failing the job")
+	if !strings.Contains(fn, "platform.ClassifyError") ||
+		!strings.Contains(fn, "platform.ClassSkip") {
+		t.Error("isOptionalEndpointSkip must delegate to platform.ClassifyError(err) == platform.ClassSkip " +
+			"so the sentinel set (ErrNotFound, ErrForbidden, ErrGone, ErrWrongEntityKind) is covered by " +
+			"a single classifier instead of duplicated at every call site")
+	}
+}
+
+// TestIsOptionalEndpointSkipRecognizesErrWrongEntityKind — runtime check
+// for the new v0.18.0 sentinel. Regression prevention: before the sentinel,
+// "issue N is a pull request" escaped as an untyped error, the gap filler
+// treated it as fatal, and heudiconv got stuck in `collecting` status
+// because fillIssueGaps bailed at the first PR-number.
+func TestIsOptionalEndpointSkipRecognizesErrWrongEntityKind(t *testing.T) {
+	wrapped := fmt.Errorf("issue 4: %w", platform.ErrWrongEntityKind)
+	if !isOptionalEndpointSkip(wrapped) {
+		t.Error("isOptionalEndpointSkip must return true for platform.ErrWrongEntityKind — " +
+			"GitHub's issue and PR number spaces overlap; /issues/N returning a PR is routine, not fatal")
 	}
 }

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -21,7 +21,6 @@ package collector
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -53,17 +52,18 @@ const (
 // initial collection pass.
 const LargeRepoCommitThreshold = 10000
 
-// isOptionalEndpointSkip returns true when err represents a normal "this
-// endpoint is not available for this repo" condition — 404 (endpoint or
-// repo missing), 403 (token can't see a private resource or lacks scope),
-// or 410/unfollowable-3xx (resource deliberately removed, or a redirect
-// without a usable Location header). Used by every staged-phase loop to
-// distinguish routine "skip this phase" outcomes from actual collection
-// failures that should bubble into result.Errors and fail the job.
+// isOptionalEndpointSkip returns true when err represents a routine
+// "can't collect this item, continue the loop" condition — 404, 403-private,
+// 410, or entity-kind mismatches (issue-number-that-is-a-PR).
+//
+// Since v0.18.0 this is a thin delegate to platform.ClassifyError so that
+// new error shapes (e.g. platform.ErrWrongEntityKind, GraphQL-layer errors)
+// flow through a single source of truth. Callers should prefer
+// `platform.ClassifyError(err) == platform.ClassSkip` in new code; this
+// helper remains for the 20+ existing call sites to keep the migration
+// diff small.
 func isOptionalEndpointSkip(err error) bool {
-	return errors.Is(err, platform.ErrNotFound) ||
-		errors.Is(err, platform.ErrForbidden) ||
-		errors.Is(err, platform.ErrGone)
+	return platform.ClassifyError(err) == platform.ClassSkip
 }
 
 // ParallelSlots is a global counter tracking how many extra parallel goroutines

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.17.2"
+var ToolVersion = "0.18.0"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.17.1"
+var ToolVersion = "0.17.2"

--- a/internal/platform/errors.go
+++ b/internal/platform/errors.go
@@ -1,0 +1,160 @@
+package platform
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrorClass is a coarse categorization of what a caller should do with an
+// error. It exists so every call site has the same vocabulary: instead of
+// each loop writing its own `errors.Is(err, ErrNotFound) || errors.Is(err,
+// ErrForbidden) || errors.Is(err, ErrGone)` chain, it writes
+// `ClassifyError(err) == ClassSkip`.
+//
+// The set is closed on purpose — unknown errors fall to ClassFatal so they
+// bubble up visibly rather than being silently swallowed. The regression at
+// v0.17.2 happened because a new error shape ("issue N is a pull request")
+// slipped through the sentinel-only check and was treated as fatal by the
+// gap filler. Under this taxonomy, adding a new error type requires an
+// explicit decision about its class, and untyped errors stay safe-by-default.
+type ErrorClass int
+
+const (
+	// ClassOK is the class of a nil error. Makes it safe to call
+	// ClassifyError unconditionally without a nil guard.
+	ClassOK ErrorClass = iota
+
+	// ClassNotModified corresponds to a 304 response (GitHub respected our
+	// If-None-Match header). Callers with an ETag cache should consult it;
+	// callers without a cache should treat this like an empty-page response.
+	ClassNotModified
+
+	// ClassSkip means "this item can't be collected, continue the loop."
+	// Covers 404 (doesn't exist or invisible), 403-private (token lacks
+	// scope), 410 (deliberately removed), and routine classification errors
+	// (issue-number-that-is-actually-a-PR). None of these indicate a bug on
+	// our side; all represent normal states of the remote API.
+	ClassSkip
+
+	// ClassTransient is a temporary failure: 5xx, connection reset, DNS
+	// blip, context cancellation. httpclient.Get's internal retry loop
+	// absorbs most of these — callers only see them when the retry budget
+	// was exhausted, or when the context itself was cancelled (scheduler
+	// shutdown, stale-lock recovery). Mapping to Transient rather than
+	// Fatal keeps shutdown logs free of spurious ERROR lines.
+	ClassTransient
+
+	// ClassRateLimit is a rate-limit signal. Like ClassTransient, these are
+	// handled internally by httpclient; callers only see them if the
+	// context was cancelled during the wait. Kept distinct from Transient
+	// so logs/metrics can break out throttling vs genuine transient errors.
+	ClassRateLimit
+
+	// ClassAuth means the token was rejected. httpclient invalidates the
+	// key and rotates; callers see this class only when every key has
+	// been invalidated. The scheduler treats this as "abort all in-flight
+	// jobs and stop" since no amount of retry will help without operator
+	// intervention (new/refreshed tokens).
+	ClassAuth
+
+	// ClassFatal is the safe default for any error the classifier doesn't
+	// recognize: JSON parse failures, database errors, unknown 4xx status
+	// codes, corrupted state. Callers bubble these up to runJob which
+	// marks the job failed with the error message preserved.
+	ClassFatal
+)
+
+// String returns the class name for logging. Keep in sync with the const block.
+func (c ErrorClass) String() string {
+	switch c {
+	case ClassOK:
+		return "ok"
+	case ClassNotModified:
+		return "not-modified"
+	case ClassSkip:
+		return "skip"
+	case ClassTransient:
+		return "transient"
+	case ClassRateLimit:
+		return "rate-limit"
+	case ClassAuth:
+		return "auth"
+	case ClassFatal:
+		return "fatal"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifiedError is the escape hatch for error types that don't match one
+// of the package sentinels but still know their own class. Typical
+// implementors: GraphQL-specific errors (phase 1) whose class depends on
+// the GraphQL "type" field in the response, not on an HTTP status code.
+//
+// Classify checks for this interface BEFORE the sentinel ladder, so an
+// implementor that returns ClassAuth dominates a wrap that otherwise looks
+// like ErrNotFound. Use this power carefully — the sentinel mapping is the
+// norm and implementing ClassifiedError is opting out of it.
+type ClassifiedError interface {
+	error
+	Class() ErrorClass
+}
+
+// ErrAllKeysInvalidated is returned by KeyPool.GetKey when every configured
+// token has been marked invalid by a 401 response. Maps to ClassAuth so
+// callers stop retrying — no amount of backoff repairs a bad credential.
+var ErrAllKeysInvalidated = errors.New("all API keys invalidated")
+
+// ErrWrongEntityKind is returned when the API responds with the right
+// status code (200 OK) but the wrong shape — specifically, when
+// FetchIssueByNumber receives a 200 for a number that turns out to be a
+// pull request, or vice versa. GitHub shares the issue/PR number space,
+// so /issues/{N} returning a PR-shaped response is routine: it means
+// "this N is not an issue, try /pulls/{N} instead."
+//
+// Mapped to ClassSkip so gap-fill loops continue past the item instead of
+// bailing. Before the sentinel, this was a raw fmt.Errorf that escaped as
+// ClassFatal-equivalent (v0.17.2 regression — see issue 4 / heudiconv).
+var ErrWrongEntityKind = errors.New("wrong entity kind")
+
+// ClassifyError returns the class a caller should use to decide what to
+// do with err. Nil errors are ClassOK; unknown errors are ClassFatal.
+//
+// Lookup order:
+//  1. nil → ClassOK
+//  2. errors.As into ClassifiedError interface (GraphQL errors, custom types)
+//  3. context.Canceled / context.DeadlineExceeded → ClassTransient
+//  4. errors.Is against the package sentinels (ErrNotModified, ErrNotFound,
+//     ErrForbidden, ErrGone, ErrWrongEntityKind) → their fixed class
+//  5. everything else → ClassFatal
+//
+// The function is safe to call on wrapped errors; it uses errors.Is/As
+// internally.
+func ClassifyError(err error) ErrorClass {
+	if err == nil {
+		return ClassOK
+	}
+
+	var ce ClassifiedError
+	if errors.As(err, &ce) {
+		return ce.Class()
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ClassTransient
+	}
+
+	switch {
+	case errors.Is(err, ErrNotModified):
+		return ClassNotModified
+	case errors.Is(err, ErrNotFound),
+		errors.Is(err, ErrForbidden),
+		errors.Is(err, ErrGone),
+		errors.Is(err, ErrWrongEntityKind):
+		return ClassSkip
+	case errors.Is(err, ErrAllKeysInvalidated):
+		return ClassAuth
+	}
+
+	return ClassFatal
+}

--- a/internal/platform/errors_test.go
+++ b/internal/platform/errors_test.go
@@ -1,0 +1,200 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestErrorClassConstantsAreDistinct pins the class enum as a closed set of
+// mutually-exclusive values. Without distinct integer values, a bug could
+// silently conflate two classes and skip handling that should have bubbled.
+func TestErrorClassConstantsAreDistinct(t *testing.T) {
+	seen := map[ErrorClass]string{}
+	for name, c := range map[string]ErrorClass{
+		"ClassOK":          ClassOK,
+		"ClassNotModified": ClassNotModified,
+		"ClassSkip":        ClassSkip,
+		"ClassTransient":   ClassTransient,
+		"ClassRateLimit":   ClassRateLimit,
+		"ClassAuth":        ClassAuth,
+		"ClassFatal":       ClassFatal,
+	} {
+		if existing, ok := seen[c]; ok {
+			t.Errorf("%s has same value as %s (= %d) — classes must be distinct", name, existing, c)
+		}
+		seen[c] = name
+	}
+	if len(seen) != 7 {
+		t.Errorf("expected exactly 7 classes, found %d — if you're adding a new class, update this test AND ClassifyError", len(seen))
+	}
+}
+
+// TestClassifyError_Nil — a nil error means success. Any other mapping would
+// force callers to special-case nil everywhere.
+func TestClassifyError_Nil(t *testing.T) {
+	if got := ClassifyError(nil); got != ClassOK {
+		t.Errorf("ClassifyError(nil) = %v, want ClassOK", got)
+	}
+}
+
+// TestClassifyError_Sentinels verifies that all existing package sentinels
+// map to the right class. If someone adds a new sentinel without updating
+// ClassifyError, it would default to ClassFatal (safe), but we pin the
+// expected values here so the intended mapping can't drift silently.
+func TestClassifyError_Sentinels(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want ErrorClass
+	}{
+		{"ErrNotModified bare", ErrNotModified, ClassNotModified},
+		{"ErrNotModified wrapped", fmt.Errorf("fetching: %w", ErrNotModified), ClassNotModified},
+		{"ErrNotFound bare", ErrNotFound, ClassSkip},
+		{"ErrNotFound wrapped", fmt.Errorf("issue 42: %w", ErrNotFound), ClassSkip},
+		{"ErrForbidden bare", ErrForbidden, ClassSkip},
+		{"ErrForbidden wrapped", fmt.Errorf("pr labels: %w", ErrForbidden), ClassSkip},
+		{"ErrGone bare", ErrGone, ClassSkip},
+		{"ErrGone wrapped", fmt.Errorf("issue 7: %w", ErrGone), ClassSkip},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyError(tc.err); got != tc.want {
+				t.Errorf("ClassifyError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyError_WrongEntityKind pins the regression-proof fix: the raw
+// `"issue N is a pull request"` string that the GitHub client used to return
+// is now a typed error wrapping ErrWrongEntityKind, which maps to ClassSkip.
+// Before this, that error escaped as ClassFatal (default) and aborted gap
+// fills mid-stream. Regression history: v0.17.2.
+func TestClassifyError_WrongEntityKind(t *testing.T) {
+	err := fmt.Errorf("issue 4: %w", ErrWrongEntityKind)
+	if got := ClassifyError(err); got != ClassSkip {
+		t.Errorf("wrong-entity-kind error should classify as ClassSkip (GitHub returned /issues/N where N is a PR — routine), got %v", got)
+	}
+
+	// Bare sentinel too.
+	if got := ClassifyError(ErrWrongEntityKind); got != ClassSkip {
+		t.Errorf("bare ErrWrongEntityKind should classify as ClassSkip, got %v", got)
+	}
+}
+
+// TestClassifyError_UnknownIsFatal verifies the safe default: any error the
+// classifier doesn't recognize becomes ClassFatal. Callers then bubble up
+// instead of silently swallowing. This is the behavior that made the
+// v0.17.2 regression VISIBLE (as a WARN log) rather than a silent gap.
+func TestClassifyError_UnknownIsFatal(t *testing.T) {
+	err := errors.New("database connection refused")
+	if got := ClassifyError(err); got != ClassFatal {
+		t.Errorf("unrecognized error must classify as ClassFatal so it bubbles, got %v", got)
+	}
+}
+
+// TestClassifyError_ContextCanceledIsTransient — when the scheduler cancels
+// a job context (shutdown, stale lock recovery), in-flight calls return
+// context.Canceled or context.DeadlineExceeded. These shouldn't be ClassFatal
+// — they mean "abort cleanly", which the runJob layer already handles.
+// Mapping to ClassTransient lets retry loops give up immediately without
+// logging a spurious "fatal error" at ERROR level.
+func TestClassifyError_ContextCanceledIsTransient(t *testing.T) {
+	if got := ClassifyError(context.Canceled); got != ClassTransient {
+		t.Errorf("context.Canceled should classify as ClassTransient, got %v", got)
+	}
+	if got := ClassifyError(context.DeadlineExceeded); got != ClassTransient {
+		t.Errorf("context.DeadlineExceeded should classify as ClassTransient, got %v", got)
+	}
+}
+
+// TestClassifiedErrorInterface verifies the escape hatch: errors that
+// implement the ClassifiedError interface override the fallthrough mapping.
+// This is how new error shapes (e.g. GraphQL-specific classes we'll add in
+// phase 1) integrate without touching ClassifyError's body.
+func TestClassifiedErrorInterface(t *testing.T) {
+	var e error = customClassifiedError{class: ClassAuth}
+	if got := ClassifyError(e); got != ClassAuth {
+		t.Errorf("ClassifiedError.Class() should dominate, got %v want ClassAuth", got)
+	}
+
+	// Wrapped inside a fmt.Errorf: the interface check must see through the wrap.
+	wrapped := fmt.Errorf("http POST failed: %w", e)
+	if got := ClassifyError(wrapped); got != ClassAuth {
+		t.Errorf("wrapped ClassifiedError should still surface its class, got %v", got)
+	}
+}
+
+type customClassifiedError struct {
+	class ErrorClass
+}
+
+func (customClassifiedError) Error() string       { return "custom" }
+func (c customClassifiedError) Class() ErrorClass { return c.class }
+
+// TestGet_401ReturnsClassAuth is the HTTP integration point: a 401 from
+// GitHub must surface as a ClassAuth-classifiable error. Today httpclient
+// invalidates the key and loops, so 401 typically never escapes. But when
+// ALL keys are invalidated it eventually bubbles up via "all API keys have
+// been invalidated" — that error should classify correctly.
+func TestGet_401ReturnsClassAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"bad-token"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := client.Get(ctx, "/repos/o/r")
+	if err == nil {
+		t.Fatal("expected error — all keys invalidated by 401")
+	}
+	if got := ClassifyError(err); got != ClassAuth {
+		t.Errorf("error from all-keys-invalidated should classify as ClassAuth, got %v (err=%v)", got, err)
+	}
+}
+
+// TestGet_404ReturnsClassSkip rebuilds the existing TestGet_404ReturnsErrNotFound
+// guarantee using the new classifier. Keeps old behavior pinned via new API.
+func TestGet_404ReturnsClassSkip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	_, err := client.Get(context.Background(), "/any")
+	if got := ClassifyError(err); got != ClassSkip {
+		t.Errorf("404 should classify as ClassSkip, got %v (err=%v)", got, err)
+	}
+}
+
+// TestIsOptionalEndpointSkipAliasesClassifyError pins the backward-compat
+// shim: the legacy isOptionalEndpointSkip helper in the collector package
+// must delegate to ClassifyError so downstream packages don't have to be
+// changed simultaneously. (The collector_test accesses this via source
+// inspection since isOptionalEndpointSkip lives in a different package.)
+func TestIsOptionalEndpointSkipAliasesClassifyError(t *testing.T) {
+	// Live contract: sentinels that used to match isOptionalEndpointSkip
+	// must still return ClassSkip under the new classifier. Pin each one.
+	for _, e := range []error{ErrNotFound, ErrForbidden, ErrGone, ErrWrongEntityKind} {
+		if ClassifyError(e) != ClassSkip {
+			t.Errorf("%v no longer classifies as ClassSkip — isOptionalEndpointSkip callers across collector/staged, refresh_open, gap_fill rely on this", e)
+		}
+	}
+}

--- a/internal/platform/github/client.go
+++ b/internal/platform/github/client.go
@@ -33,6 +33,12 @@ func (c *Client) Platform() model.Platform {
 	return model.PlatformGitHub
 }
 
+// OnPermanentRedirect forwards to the underlying HTTPClient. See
+// platform.HTTPClient.OnPermanentRedirect for semantics.
+func (c *Client) OnPermanentRedirect(hook func(from, to string)) {
+	c.http.OnPermanentRedirect(hook)
+}
+
 // ghUserToRef converts a GitHub user to a model.UserRef for contributor resolution.
 func ghUserToRef(u ghUser) model.UserRef {
 	return model.UserRef{
@@ -1066,8 +1072,12 @@ func (c *Client) FetchIssueByNumber(ctx context.Context, owner, repo string, num
 		return nil, err
 	}
 	// GitHub returns PRs via the issues endpoint — check and reject.
+	// Wraps platform.ErrWrongEntityKind so gap-fill loops classify this
+	// as ClassSkip (routine: the number space is shared) rather than
+	// ClassFatal. Before v0.18.0 this was a raw fmt.Errorf and aborted
+	// gap fills mid-stream on the first PR encountered.
 	if raw.PullRequest != nil && raw.PullRequest.URL != "" {
-		return nil, fmt.Errorf("issue %d is a pull request", number)
+		return nil, fmt.Errorf("issue %d: %w", number, platform.ErrWrongEntityKind)
 	}
 	issue := &model.Issue{
 		PlatformID:   raw.ID,

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -39,6 +39,12 @@ func (c *Client) Platform() model.Platform {
 	return model.PlatformGitLab
 }
 
+// OnPermanentRedirect forwards to the underlying HTTPClient. See
+// platform.HTTPClient.OnPermanentRedirect for semantics.
+func (c *Client) OnPermanentRedirect(hook func(from, to string)) {
+	c.http.OnPermanentRedirect(hook)
+}
+
 func (c *Client) ParseRepoURL(rawURL string) (owner, repo string, err error) {
 	parsed, err := platform.ParseRepoURLWithHints(rawURL, map[string]bool{c.host: true})
 	if err != nil {

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -75,6 +75,17 @@ type HTTPClient struct {
 	// per unique endpoint path hit during a collection cycle).
 	etagMu    sync.RWMutex
 	etagCache map[string]string
+
+	// onPermanentRedirect is invoked whenever Get observes a 301 or 308
+	// response it's about to follow. The callback receives the from URL
+	// (the one Get was trying to reach) and the to URL (the Location
+	// header target, resolved to an absolute URL). Intended for the
+	// scheduler to detect repo renames and update repos.repo_git.
+	//
+	// Not invoked for 302/307 — those are temporary and must not mutate
+	// durable state. Guarded against nil at each call site.
+	redirectMu          sync.RWMutex
+	onPermanentRedirect func(from, to string)
 }
 
 // NewHTTPClient creates a platform-aware HTTP client with the given auth style.
@@ -87,10 +98,22 @@ func NewHTTPClient(baseURL string, keys *KeyPool, logger *slog.Logger, authStyle
 		MaxIdleConnsPerHost: 20, // GitHub/GitLab APIs are few hosts with many requests
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
+		// ResponseHeaderTimeout caps how long we wait for the server's
+		// response headers after sending the request. A stalled
+		// connection (firewall drop, server hang) would otherwise hold
+		// a worker slot for the full whole-request Timeout. 15s is well
+		// above GitHub's normal response-header latency (~200ms) but
+		// below the whole-request budget so stalls fail fast.
+		ResponseHeaderTimeout: 15 * time.Second,
 	}
 	return &HTTPClient{
 		inner: &http.Client{
-			Timeout:   30 * time.Second,
+			// 60s whole-request timeout. Accommodates the ~1 MB responses
+			// GraphQL queries return for batches of 25 parents with full
+			// nested children, and leaves a 6× margin above observed p99
+			// GraphQL response times (~10s) for firewall-induced jitter.
+			// Previously 30s, which left only 3× margin.
+			Timeout:   60 * time.Second,
 			Transport: transport,
 			// Our Get loop owns redirect handling explicitly so the logic is
 			// in one place (hop cap, logging, Location-absent → ErrGone).
@@ -112,6 +135,25 @@ func NewHTTPClient(baseURL string, keys *KeyPool, logger *slog.Logger, authStyle
 // non-standard requests (e.g., GraphQL via POST).
 func (c *HTTPClient) Keys() *KeyPool {
 	return c.keys
+}
+
+// OnPermanentRedirect installs a callback that fires whenever Get observes
+// a 301 or 308 response it's about to follow. The callback receives the
+// from URL (the request that received the redirect) and the to URL
+// (resolved absolute target). Use case: the scheduler installs a hook per
+// job that updates repos.repo_git / repo_owner / repo_name when the
+// redirect is on the repo root, so the DB stays in sync with GitHub's
+// rename/transfer events.
+//
+// Only permanent redirects fire the hook. 302/307 are temporary — the
+// repo's canonical URL hasn't changed, so mutating the DB would be wrong.
+//
+// Passing a nil hook clears any previously-installed callback.
+// Safe to call at any time; internally synchronized.
+func (c *HTTPClient) OnPermanentRedirect(hook func(from, to string)) {
+	c.redirectMu.Lock()
+	c.onPermanentRedirect = hook
+	c.redirectMu.Unlock()
 }
 
 const maxRetries = 10
@@ -157,7 +199,13 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 		if err != nil {
 			c.logger.Warn("HTTP request failed, retrying",
 				"url", url, "attempt", attempt+1, "error", err)
-			time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+			// Context-aware sleep: a cancelled job wakes immediately
+			// instead of sitting here for 20+s across the retry chain.
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt+1) * 2 * time.Second):
+			}
 			continue
 		}
 
@@ -246,6 +294,19 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 			c.logger.Info("following redirect",
 				"from", url, "to", newURL,
 				"status", resp.StatusCode, "hop", redirectHops)
+
+			// Notify the permanent-redirect hook on 301/308 only. 302/307
+			// are temporary and must not mutate durable state.
+			if resp.StatusCode == http.StatusMovedPermanently ||
+				resp.StatusCode == http.StatusPermanentRedirect {
+				c.redirectMu.RLock()
+				hook := c.onPermanentRedirect
+				c.redirectMu.RUnlock()
+				if hook != nil {
+					hook(url, newURL)
+				}
+			}
+
 			url = newURL
 			// Do not count this iteration against the retry budget — a
 			// redirect is not a retry. Decrement attempt so the outer
@@ -371,7 +432,11 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 			resp.Body.Close()
 			c.logger.Warn("unexpected status",
 				"url", url, "status", resp.StatusCode, "body_snippet", truncateBody(string(body), 200), "attempt", attempt+1)
-			time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt+1) * 2 * time.Second):
+			}
 			continue
 		}
 	}

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -275,10 +275,15 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 				"url", url, "status", 422, "body_snippet", truncateBody(string(body), 200))
 			return nil, fmt.Errorf("unprocessable entity: %s", url)
 		case resp.StatusCode == http.StatusForbidden:
-			resp.Body.Close()
-			// 403 can mean rate limit, secondary rate limit, or resource not accessible.
-			// Only treat as rate limit if rate-limit headers indicate exhaustion.
+			// 403 can mean rate limit, secondary rate limit, or resource not
+			// accessible. Header signals are authoritative — they carry the
+			// reset timing that retry-after plumbing relies on, so they are
+			// always consulted first. Body inspection is the fallback net
+			// for cases where a proxy strips the headers, GitHub's response
+			// shape changes, or an unauthenticated request leaks through
+			// (the "for <IP>" body shape).
 			if resp.Header.Get("Retry-After") != "" {
+				resp.Body.Close()
 				wait := parseRetryAfter(resp)
 				c.logger.Info("secondary rate limit", "url", url, "wait", wait)
 				select {
@@ -288,8 +293,8 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 				}
 				continue
 			}
-			remaining := resp.Header.Get("X-RateLimit-Remaining")
-			if remaining == "0" {
+			if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+				resp.Body.Close()
 				resource := resp.Header.Get("X-RateLimit-Resource")
 				if resource == "" {
 					resource = "core"
@@ -297,6 +302,40 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 				resetStr := resp.Header.Get("X-RateLimit-Reset")
 				c.logger.Info("rate limit exhausted",
 					"url", url, "resource", resource, "reset", resetStr)
+				continue
+			}
+			// Headers said nothing definitive. Read the body and check whether
+			// the message text reveals a rate limit anyway.
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if isAnonymousRateLimitBody(body) {
+				// Unauthenticated request reached us. Every code path that
+				// builds an HTTPClient call goes through GetKey() — getting
+				// this body shape means a key was unset, the wrong client
+				// was used, or a proxy stripped the Authorization header.
+				// Log at ERROR so on-call sees the regression, then back off
+				// like a regular rate limit so we don't hot-loop on the bug.
+				c.logger.Error("403 with unauthenticated rate-limit body — possible key-leak or unauthenticated request bug",
+					"url", url,
+					"body_snippet", truncateBody(string(body), 240))
+				wait := jitteredBackoff(attempt)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
+				continue
+			}
+			if isRateLimitBody(body) {
+				c.logger.Warn("403 with rate-limit body but no rate-limit headers — treating as throttled",
+					"url", url,
+					"body_snippet", truncateBody(string(body), 240))
+				wait := jitteredBackoff(attempt)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
 				continue
 			}
 			// 403 for other reasons (private repo, no permission) — not a key problem.
@@ -480,6 +519,16 @@ func setQueryParam(path, key, value string) string {
 	}
 	filtered = append(filtered, key+"="+value)
 	return base + "?" + strings.Join(filtered, "&")
+}
+
+// jitteredBackoff returns a capped exponential backoff with random jitter,
+// used by 403-with-rate-limit-body fallback paths that lack an authoritative
+// Retry-After or X-RateLimit-Reset to honor. Caps at 64s + jitter so a
+// pathological loop on a permanent 403 doesn't burn a worker for hours.
+func jitteredBackoff(attempt int) time.Duration {
+	base := time.Duration(1<<min(attempt, 6)) * time.Second // 1s..64s
+	jitter := time.Duration(rand.IntN(int(base/2) + 1))
+	return base + jitter
 }
 
 // truncateBody returns the first n bytes of a response body for logging,

--- a/internal/platform/httpclient_ratelimit_body_test.go
+++ b/internal/platform/httpclient_ratelimit_body_test.go
@@ -1,0 +1,265 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Response bodies observed in the wild. These are verbatim from real GitHub
+// responses — preserved as constants so the detection logic stays pinned to
+// the actual strings GitHub returns, not a paraphrase.
+const (
+	// unauthenticatedIPRateLimitBody is what GitHub returns when a request
+	// hits the 60/hr anonymous limit. Observed on 2026-04-18 in the tinkerbell
+	// investigation. The tell-tale phrase is "authenticated requests get a
+	// higher rate limit" — this shape of body means our server is making an
+	// anonymous call, which is a bug we want to detect and log loudly.
+	unauthenticatedIPRateLimitBody = `{"message":"API rate limit exceeded for 161.130.189.234. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}`
+
+	// authenticatedUserRateLimitBody is what GitHub returns when an
+	// authenticated token hits its hourly 5000 limit. The message names the
+	// user instead of the IP. Still a rate-limit, must be handled by waiting
+	// for the reset window, not by returning ErrForbidden.
+	authenticatedUserRateLimitBody = `{"message":"API rate limit exceeded for user ID 12345.","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}`
+
+	// secondaryRateLimitBody is GitHub's abuse-detection throttle. Typically
+	// paired with a Retry-After header, but we want body-text fallback in
+	// case the header is dropped by a proxy.
+	secondaryRateLimitBody = `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits"}`
+
+	// privateRepoForbiddenBody is a genuine ErrForbidden case — no rate limit
+	// language, just insufficient permissions. Must not be misclassified as
+	// rate-limited or we'd spin forever waiting for a non-existent reset.
+	privateRepoForbiddenBody = `{"message":"Must have admin rights to Repository.","documentation_url":"https://docs.github.com/rest"}`
+)
+
+// TestGet_403WithRateLimitBodyWithoutHeaders_ClassifiedAsRateLimit covers the
+// defense-in-depth case: a 403 arrives with "API rate limit exceeded" in the
+// body but WITHOUT Retry-After or X-RateLimit-Remaining=0 in the headers
+// (observed when a proxy strips headers, or on certain secondary-limit
+// paths). Headers are still consulted FIRST — this test exercises the
+// fallback path only. The current code only reads headers, so it falls
+// through to ErrForbidden and the collector stops instead of waiting.
+// With the body-as-fallback added, we want it to detect the rate-limit
+// language and treat the response as rate-limited.
+func TestGet_403WithRateLimitBodyWithoutHeaders_ClassifiedAsRateLimit(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			// First attempt: 403 with rate-limit body, no headers.
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(authenticatedUserRateLimitBody))
+			return
+		}
+		// Subsequent attempts succeed — proves the client waited and retried
+		// rather than returning ErrForbidden on the first hit.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"tok1", "tok2"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	// Use a short-lived context so the test doesn't hang if the implementation
+	// waits for a minutes-long reset window. The client should recognize the
+	// rate-limit quickly and rotate to tok2 (or wait a short jittered backoff
+	// if no reset header is available).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Get(ctx, "/repos/o/r/pulls/457")
+	if err != nil {
+		t.Fatalf("expected Get to retry past the rate-limited 403, got err=%v", err)
+	}
+	resp.Body.Close()
+	if errors.Is(err, ErrForbidden) {
+		t.Error("rate-limit-body 403 must not be classified as ErrForbidden — " +
+			"ErrForbidden is reserved for permission/visibility denials, not throttles")
+	}
+	if callCount.Load() < 2 {
+		t.Errorf("expected at least 2 server hits (retry after rate-limit body), got %d", callCount.Load())
+	}
+}
+
+// TestGet_403WithUnauthenticatedBodyLogsError verifies we loudly surface the
+// "for <IP>" rate-limit message. That body shape only appears on anonymous
+// requests, which our code path should never make — 73 API keys are loaded
+// at startup and c.keys.GetKey is always called before Do. If this body
+// reaches us, something has leaked an unauthenticated request into an
+// authenticated client. Silent misclassification would hide the bug; the
+// log must fire at ERROR level so ops can catch the regression.
+func TestGet_403WithUnauthenticatedBodyLogsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(unauthenticatedIPRateLimitBody))
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	keys := NewKeyPool([]string{"tok1"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// We don't care whether Get eventually returns success or error; we care
+	// that the suspicious body was logged at ERROR level.
+	_, _ = client.Get(ctx, "/repos/o/r/pulls/457")
+
+	out := logBuf.String()
+	if !strings.Contains(out, "level=ERROR") {
+		t.Errorf("unauthenticated-shape rate-limit body must log at ERROR " +
+			"level — this is the signal of a key-leak bug. Log output was:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "unauthenticated") &&
+		!strings.Contains(strings.ToLower(out), "anonymous") {
+		t.Errorf("error log must name the condition (unauthenticated/anonymous) so " +
+			"on-call can route the page. Log output was:\n%s", out)
+	}
+}
+
+// TestGet_403HeadersTakePrecedenceOverBody pins the ordering contract:
+// when authoritative rate-limit headers are present (Retry-After, or
+// X-RateLimit-Remaining=0), the client must act on the header signal
+// without needing to inspect the body. Body inspection is the fallback
+// net — it must never short-circuit the header path. Specifically, the
+// Retry-After handler has always slept for the header-supplied duration;
+// swapping to body-first would break that precise timing and could
+// misclassify a Retry-After-carrying 403 that happens to also include
+// rate-limit language in the body (GitHub does this sometimes).
+func TestGet_403HeadersTakePrecedenceOverBody(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			// 403 with Retry-After header AND the same body. The handler
+			// must take its cue from the header (1-second wait) and retry,
+			// not from the body.
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(secondaryRateLimitBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"tok1"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := client.Get(ctx, "/repos/o/r")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("expected Get to succeed after Retry-After wait, got err=%v", err)
+	}
+	resp.Body.Close()
+
+	// The Retry-After was "1" (second). If the body path overrode the header,
+	// we would have rotated immediately with zero wait. Assert that we did
+	// observe the header-directed sleep — at least several hundred ms.
+	if elapsed < 500*time.Millisecond {
+		t.Errorf("expected client to honor Retry-After header (waited >=500ms), got %v — "+
+			"body-based detection must not short-circuit the header path", elapsed)
+	}
+}
+
+// TestGet_403PrivateRepoStillErrForbidden pins the negative case: a 403 with
+// no rate-limit body language must still produce ErrForbidden. Without this
+// guardrail the body-detection would overfire and every private-repo
+// 403 would be treated as a throttle — infinite retry loop.
+func TestGet_403PrivateRepoStillErrForbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(privateRepoForbiddenBody))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"tok1"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := client.Get(ctx, "/repos/o/r/pulls/457")
+	if err == nil {
+		t.Fatal("expected error for private-repo 403")
+	}
+	if !errors.Is(err, ErrForbidden) {
+		t.Errorf("private-repo 403 must surface as ErrForbidden, got %v", err)
+	}
+}
+
+// TestIsRateLimitBody is a unit test for the pure helper that decides whether
+// a response body indicates a rate limit. Keeps the substring list small and
+// testable; easier to extend when GitHub adds new message shapes.
+func TestIsRateLimitBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", false},
+		{"unauth-ip", unauthenticatedIPRateLimitBody, true},
+		{"auth-user", authenticatedUserRateLimitBody, true},
+		{"secondary", secondaryRateLimitBody, true},
+		{"private-repo", privateRepoForbiddenBody, false},
+		{"random-403", `{"message":"Not allowed"}`, false},
+		{"case-insensitive", `{"message":"RATE LIMIT EXCEEDED"}`, true},
+		{"secondary-phrase", `{"message":"secondary rate limit"}`, true},
+		{"unrelated-limit", `{"message":"File size limit exceeded"}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRateLimitBody([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("isRateLimitBody(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAnonymousRateLimitBody isolates the narrow "unauthenticated shape"
+// detector. Must NOT fire on generic rate-limit messages, only on the
+// unambiguous "for <IP>" / "authenticated requests get a higher" wording.
+func TestIsAnonymousRateLimitBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", false},
+		{"unauth-ip", unauthenticatedIPRateLimitBody, true},
+		{"auth-user", authenticatedUserRateLimitBody, false},
+		{"secondary", secondaryRateLimitBody, false},
+		{"private-repo", privateRepoForbiddenBody, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAnonymousRateLimitBody([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("isAnonymousRateLimitBody(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/platform/httpclient_redirect_hook_test.go
+++ b/internal/platform/httpclient_redirect_hook_test.go
@@ -1,0 +1,257 @@
+package platform
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestOnPermanentRedirect_Fires301 verifies the hook fires on a 301 and
+// receives the from/to URLs. Use case: GitHub renamed the repo; we need to
+// update repos.repo_git in the DB. Without the hook, httpclient silently
+// follows the redirect and the DB entry stays stale — the repo keeps getting
+// collected under its old name.
+func TestOnPermanentRedirect_Fires301(t *testing.T) {
+	var finalRequested atomic.Int32
+	var target *httptest.Server
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL+"/repos/new-owner/new-repo")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer origin.Close()
+
+	target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		finalRequested.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer target.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(origin.URL, keys, logger, AuthGitHub)
+
+	var mu sync.Mutex
+	var fires []struct{ from, to string }
+	client.OnPermanentRedirect(func(from, to string) {
+		mu.Lock()
+		defer mu.Unlock()
+		fires = append(fires, struct{ from, to string }{from, to})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/repos/old-owner/old-repo")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+
+	if finalRequested.Load() == 0 {
+		t.Fatal("target server was never hit — redirect was not followed")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(fires) != 1 {
+		t.Fatalf("expected exactly 1 hook call, got %d: %+v", len(fires), fires)
+	}
+	if fires[0].from != origin.URL+"/repos/old-owner/old-repo" {
+		t.Errorf("from = %q, want origin+path", fires[0].from)
+	}
+	if fires[0].to != target.URL+"/repos/new-owner/new-repo" {
+		t.Errorf("to = %q, want target+path", fires[0].to)
+	}
+}
+
+// TestOnPermanentRedirect_Fires308 — 308 has the same semantic as 301 (must
+// preserve method on redirect) and must also trigger the hook. Covered
+// separately from 301 because implementations sometimes forget one.
+func TestOnPermanentRedirect_Fires308(t *testing.T) {
+	var target *httptest.Server
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL+"/new")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer origin.Close()
+	target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(origin.URL, keys, logger, AuthGitHub)
+
+	var fired atomic.Bool
+	client.OnPermanentRedirect(func(from, to string) {
+		fired.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/old")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+
+	if !fired.Load() {
+		t.Error("OnPermanentRedirect should fire on 308 — same semantic as 301 for repo renames")
+	}
+}
+
+// TestOnPermanentRedirect_DoesNotFire302 — a 302 is temporary (auth flow,
+// transient endpoint redirect). The hook must NOT fire: mutating repo_git
+// on a temporary redirect would mis-point the DB.
+func TestOnPermanentRedirect_DoesNotFire302(t *testing.T) {
+	var target *httptest.Server
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL+"/endpoint")
+		w.WriteHeader(http.StatusFound) // 302
+	}))
+	defer origin.Close()
+	target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(origin.URL, keys, logger, AuthGitHub)
+
+	var fired atomic.Bool
+	client.OnPermanentRedirect(func(from, to string) {
+		fired.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/endpoint")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+
+	if fired.Load() {
+		t.Error("OnPermanentRedirect must NOT fire on 302 — it's a temporary redirect and the repo identity is still at the old URL")
+	}
+}
+
+// TestOnPermanentRedirect_DoesNotFire307 — 307 is method-preserving
+// temporary redirect. Same reasoning as 302: don't fire the hook.
+func TestOnPermanentRedirect_DoesNotFire307(t *testing.T) {
+	var target *httptest.Server
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL+"/endpoint")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+	target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(origin.URL, keys, logger, AuthGitHub)
+
+	var fired atomic.Bool
+	client.OnPermanentRedirect(func(from, to string) {
+		fired.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/endpoint")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+
+	if fired.Load() {
+		t.Error("OnPermanentRedirect must NOT fire on 307 — it's a temporary redirect")
+	}
+}
+
+// TestOnPermanentRedirect_MultipleHops_FiresOncePerHop verifies the hook
+// fires for every 301/308 in a chain, so a repo that moved twice (A→B→C)
+// yields two hook invocations and the DB can track the final destination.
+// Cap is maxRedirectHops (5); within that range, fire for each permanent
+// hop. Temporary hops in the chain do not fire.
+func TestOnPermanentRedirect_MultipleHops_FiresOncePerHop(t *testing.T) {
+	var hopC *httptest.Server
+	var hopB *httptest.Server
+
+	hopA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", hopB.URL+"/B")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer hopA.Close()
+	hopB = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", hopC.URL+"/C")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer hopB.Close()
+	hopC = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hopC.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(hopA.URL, keys, logger, AuthGitHub)
+
+	var fires atomic.Int32
+	client.OnPermanentRedirect(func(from, to string) {
+		fires.Add(1)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/A")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := fires.Load(); got != 2 {
+		t.Errorf("expected 2 hook calls for two-hop chain, got %d", got)
+	}
+}
+
+// TestOnPermanentRedirect_NilSafe — if no hook is installed, redirects must
+// still follow normally. A nil-callback panic would break everyone who
+// didn't opt in to the hook.
+func TestOnPermanentRedirect_NilSafe(t *testing.T) {
+	var target *httptest.Server
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL+"/new")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer origin.Close()
+	target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(origin.URL, keys, logger, AuthGitHub)
+	// Intentionally do NOT call OnPermanentRedirect.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/old")
+	if err != nil {
+		t.Fatalf("Get should succeed even without a hook installed: %v", err)
+	}
+	resp.Body.Close()
+}

--- a/internal/platform/httpclient_timeout_test.go
+++ b/internal/platform/httpclient_timeout_test.go
@@ -1,0 +1,132 @@
+package platform
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHTTPClientTimeout_IsSixtySeconds — the whole-request timeout needs to
+// survive GraphQL responses that carry ~1 MB of nested issue/PR data. The
+// old 30s left only a 3× margin above p99 GraphQL response times (~10s) and
+// risked spurious failures behind firewalls that add per-byte latency.
+// 60s gives a safe 6× margin.
+func TestHTTPClientTimeout_IsSixtySeconds(t *testing.T) {
+	src, err := os.ReadFile("httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	// Source-contract check is the cleanest way to pin a struct literal
+	// value without touching the real client. The setter lives inside
+	// NewHTTPClient so we match against the full initializer.
+	if !strings.Contains(code, "Timeout:   60 * time.Second") &&
+		!strings.Contains(code, "Timeout: 60 * time.Second") &&
+		!strings.Contains(code, "Timeout:60 * time.Second") {
+		t.Error("http.Client.Timeout must be 60s to accommodate GraphQL payloads; previously 30s left insufficient margin above p99 response times behind firewalls")
+	}
+}
+
+// TestHTTPTransport_ResponseHeaderTimeoutIsSet — a stalled connection with
+// no response headers should fail fast instead of consuming the full
+// whole-request budget. 15s is GitHub's own server-side p99 for response
+// headers (headers always return quickly; the body is what sometimes
+// drags). Anything longer than 15s without response headers is a stalled
+// TCP connection, not a slow server.
+func TestHTTPTransport_ResponseHeaderTimeoutIsSet(t *testing.T) {
+	src, err := os.ReadFile("httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "ResponseHeaderTimeout: 15 * time.Second") &&
+		!strings.Contains(code, "ResponseHeaderTimeout:  15 * time.Second") &&
+		!strings.Contains(code, "ResponseHeaderTimeout:15 * time.Second") {
+		t.Error("http.Transport.ResponseHeaderTimeout must be set to 15s so stalled connections fail fast instead of holding a worker slot for the full whole-request budget")
+	}
+}
+
+// TestHTTPClient_StalledConnectionFailsFast — live test: a server that
+// accepts the connection but never writes a response must cause Get to
+// return within ~ResponseHeaderTimeout, not the full 60s. Without the
+// explicit setting, Go's default is unlimited — a stalled firewall
+// connection would hold the worker for 60s.
+func TestHTTPClient_StalledConnectionFailsFast(t *testing.T) {
+	// A raw TCP listener that accepts connections and hangs.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open; never respond.
+			_ = conn
+		}
+	}()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient("http://"+listener.Addr().String(), keys, logger, AuthGitHub)
+
+	// Context slightly longer than ResponseHeaderTimeout (15s). The first
+	// HTTP attempt should fail at ~15s via ResponseHeaderTimeout; the retry
+	// loop's 2s sleep then aborts on ctx.Done at ~18s. We assert elapsed
+	// ~17-19s, which proves (a) ResponseHeaderTimeout fired at 15s (not
+	// the whole-request 60s), and (b) the ctx-aware sleep honored ctx.
+	ctx, cancel := context.WithTimeout(context.Background(), 18*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err = client.Get(ctx, "/any")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error on stalled connection")
+	}
+	// Must exceed ResponseHeaderTimeout (15s). Faster means something else
+	// cancelled early — e.g., a dial-level failure that wasn't what we
+	// meant to test.
+	if elapsed < 13*time.Second {
+		t.Errorf("stalled connection failed in %v — faster than the 15s ResponseHeaderTimeout, something else returned early", elapsed)
+	}
+	// Must not exceed the 60s whole-request Timeout — if the retry loop
+	// blocked past ctx deadline (non-ctx-aware sleep), we'd see ~60s+.
+	if elapsed > 22*time.Second {
+		t.Errorf("stalled connection took %v to fail — ResponseHeaderTimeout/ctx-aware-sleep not effective", elapsed)
+	}
+}
+
+// TestHTTPClient_NormalResponsesStillSucceed — pin that the timeout bump
+// didn't regress the happy path. A fast server must still return quickly.
+func TestHTTPClient_NormalResponsesStillSucceed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keys := NewKeyPool([]string{"t"}, logger)
+	client := NewHTTPClient(server.URL, keys, logger, AuthGitHub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "/")
+	if err != nil {
+		t.Fatalf("normal GET failed: %v", err)
+	}
+	resp.Body.Close()
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -21,6 +21,12 @@ type Client interface {
 	// For GitLab: "https://gitlab.com/group/subgroup/project" -> ("group/subgroup", "project")
 	ParseRepoURL(url string) (owner, repo string, err error)
 
+	// OnPermanentRedirect installs a callback invoked by the underlying
+	// HTTP client whenever it observes a 301 or 308. Used by the scheduler
+	// to detect repo renames (see internal/platform/httpclient.go).
+	// Pass nil to clear a previously installed hook.
+	OnPermanentRedirect(hook func(from, to string))
+
 	// Repo metadata
 	RepoCollector
 	// Issues and their related data

--- a/internal/platform/ratelimit.go
+++ b/internal/platform/ratelimit.go
@@ -107,7 +107,7 @@ func (kp *KeyPool) GetKey(ctx context.Context) (*APIKey, error) {
 		kp.mu.Unlock()
 
 		if allInvalid {
-			return nil, fmt.Errorf("all API keys have been invalidated (bad credentials) — check your tokens")
+			return nil, fmt.Errorf("%w: all API keys have been invalidated (bad credentials) — check your tokens", ErrAllKeysInvalidated)
 		}
 
 		// Wait for the earliest reset.

--- a/internal/platform/ratelimit_body.go
+++ b/internal/platform/ratelimit_body.go
@@ -1,0 +1,67 @@
+package platform
+
+import (
+	"bytes"
+	"strings"
+)
+
+// rateLimitBodyMarkers are case-insensitive substrings that, when present in
+// a 403 response body, indicate the response is a rate-limit signal even
+// when the headers fail to convey it. GitHub publishes several distinct
+// wordings depending on whether the limit is the core hourly bucket, the
+// secondary "abuse" detector, or the unauthenticated per-IP bucket.
+//
+// Used as a fallback after the header-based detection (Retry-After /
+// X-RateLimit-Remaining=0) returns no signal — never as the primary path.
+// The header path remains authoritative because it carries the precise
+// reset timing that Retry-After plumbing relies on.
+var rateLimitBodyMarkers = []string{
+	"rate limit exceeded",
+	"secondary rate limit",
+	"abuse detection",
+}
+
+// anonymousRateLimitMarkers are the narrower phrases that only appear on
+// rate-limit responses for unauthenticated requests. If we see one of these
+// from inside an HTTPClient that always sets an Authorization header, we
+// have a key-leak bug — some code path is constructing an unauthenticated
+// request against this client. The httpclient logs this at ERROR level so
+// the regression is visible in standard log scraping.
+// "authenticated requests get a higher" is the only safe marker — GitHub
+// adds that hint exclusively when telling the caller they're anonymous.
+// The "API rate limit exceeded for <X>" prefix is shared with the
+// authenticated-user variant ("for user ID 12345") and would over-fire.
+var anonymousRateLimitMarkers = []string{
+	"authenticated requests get a higher",
+}
+
+// isRateLimitBody reports whether body contains any of the rate-limit
+// substrings. Case-insensitive.
+func isRateLimitBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	lowered := bytes.ToLower(body)
+	for _, m := range rateLimitBodyMarkers {
+		if bytes.Contains(lowered, []byte(m)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAnonymousRateLimitBody reports whether body matches the unauthenticated
+// per-IP rate-limit shape. Strictly narrower than isRateLimitBody — must
+// not fire on user-token rate limits.
+func isAnonymousRateLimitBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	lowered := strings.ToLower(string(body))
+	for _, m := range anonymousRateLimitMarkers {
+		if strings.Contains(lowered, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -80,7 +80,7 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	hostname, _ := os.Hostname()
 	workerID := hostname + "-" + time.Now().Format("150405")
 
-	return &Scheduler{
+	s := &Scheduler{
 		store:    store,
 		ghClient: ghClient,
 		glClient: glClient,
@@ -89,6 +89,26 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 		cfg:      cfg,
 		workerID: workerID,
 	}
+
+	// Install a permanent-redirect hook on both platform clients so that a
+	// 301/308 observed mid-collection surfaces as a WARN log. We do NOT
+	// auto-update repos.repo_git here — prelim.RunPrelim already owns
+	// repo-rename detection at job start, and mutating repo identity
+	// mid-job risks splitting collected rows between old and new names.
+	// The log gives operators a signal; automated action is deferred.
+	renameHook := func(from, to string) {
+		s.logger.Warn("permanent redirect observed during collection — possible repo rename",
+			"from", from, "to", to,
+			"note", "prelim handles repo renames at job start; this may indicate a rename that occurred mid-collection")
+	}
+	if ghClient != nil {
+		ghClient.OnPermanentRedirect(renameHook)
+	}
+	if glClient != nil {
+		glClient.OnPermanentRedirect(renameHook)
+	}
+
+	return s
 }
 
 // Run starts the scheduler loop. Blocks until ctx is cancelled.


### PR DESCRIPTION
v0.18.0 -- Phase 0 of an acceleration refactoring for issue and pr collection. 

Phase 0 — done                                                                                                                                                           
                                                                                                                                                                            
  - 28 new test cases, all green                                                                                                                                            
  - Full test suite green, vet clean                                                                                                                                        
  - Lint clean for new code (53 pre-existing issues unchanged, documented)                                                                                                  
  - Collection smoke test passed on real GitHub data (augur, 5m43s, no new errors)                                                                                          
  - v0.18.0 in internal/db/version.go                                                                                                                                     
  - shadow-diff harness functional                                                                                                                                          
                                                                                                                                                                            
  What got built (recap with file paths)                                                                                                                                  
                                                                                                                                                                            
  - Error taxonomy: internal/platform/errors.go. 7-class enum, ClassifyError, ClassifiedError interface.                                                                    
  - Sentinels: ErrWrongEntityKind (closes the v0.17.2 regression), ErrAllKeysInvalidated.                                                                                   
  - Redirect hook: HTTPClient.OnPermanentRedirect, fires on 301/308 only, scheduler installs a WARN-logging hook.                                                           
  - Timeouts: 30s → 60s whole-request, new 15s ResponseHeaderTimeout. Side-bug fix: ctx-aware retry sleeps so cancelled jobs don't sit sleeping for 20s.                    
  - Migration: isOptionalEndpointSkip is a one-line delegate to ClassifyError. Every downstream caller now classifies new error shapes through one source of truth.         
  - shadow-diff: aveloxis shadow-diff subcommand, semantic-criterion (FAIL on missing/content-mismatch, FLAG on GraphQL-only).      

===============

v0.17.2 — defense-in-depth rate-limit detection + gap-fill error classification.

**Very rare edge case surfaced in testing**
                                                                                                                                  
  internal/platform/ratelimit_body.go (new)                                                                                       
  - isRateLimitBody(body) — case-insensitive substring match for "rate limit exceeded", "secondary rate limit", "abuse detection".
  - isAnonymousRateLimitBody(body) — narrower check for the "authenticated requests get a higher" tell-tale phrase.               
                                                                                                                   
  internal/platform/httpclient.go                                                                                                 
  - 403 handler now: (1) Retry-After header, then (2) X-RateLimit-Remaining=0 header, then (3) reads body and runs the new helpers as fallback. Headers stay authoritative.                                                                                       
  - Anonymous-body match logs at ERROR with snippet — surfaces unauthenticated leaks loudly.                                      
  - Generic rate-limit-body match logs at WARN and waits a jitteredBackoff-capped duration, then retries (key rotation handled by GetKey on the next iteration).                                                                                                  
  - Non-rate-limit 403 still surfaces as ErrForbidden.                                                                            
  - Added jitteredBackoff(attempt) helper (1s–64s + jitter) for fallback waits.                                                   
                                                                                                                                  
  internal/collector/gap_fill.go                                                                                                  
  - fillIssueGaps and fillPRGaps now call isOptionalEndpointSkip(err) on per-item fetch errors. Skippable (404/403-private/410) → continue at Debug. Non-skippable (rate limit, network, etc.) → flush partial, log WARN, return filled, fmt.Errorf("gap fill ...: %w", err). Stops the silent "filled=N, the rest will heal next cycle" pattern.                                                 
                                                                                                                                  
  Tests (11 new): header-precedence, body-fallback classification, anonymous-shape ERROR logging, private-repo still ErrForbidden, isRateLimitBody / isAnonymousRateLimitBody table tests, gap-fill source contracts.                                             
   
The new gap-fill classifier turns that Debug-only catch-all into one that surfaces real rate-limit errors rather than treating them as 404s.