### PR TITLE
phase 2 tested and complete

### DIFF
--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -24,8 +24,9 @@
     "force_full": false,
     "matview_rebuild_day": "friday",
     "matview_rebuild_on_startup": false,
-    "_refactor_modes_note": "Values 'rest' and 'graphql' select between the legacy REST and new GraphQL code paths added by the v0.18 series. Default 'rest' until v0.19.0 flips defaults. Additional mode keys (listing, threading, comments) will land as phases 2-4 ship — see CLAUDE.md 'REST → GraphQL Refactor' section.",
-    "pr_child_mode": "rest"
+    "_refactor_modes_note": "Values 'rest' and 'graphql' select between the legacy REST and new GraphQL code paths added by the v0.18 series. Default 'rest' until v0.19.0 flips defaults. Additional mode keys (threading, comments) will land as phases 3-4 ship — see CLAUDE.md 'REST → GraphQL Refactor' section.",
+    "pr_child_mode": "rest",
+    "listing_mode": "rest"
   },
   "web": {
     "addr": ":8082",

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -154,6 +154,7 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		MatviewRebuildDay:   cfg.Collection.MatviewRebuildWeekday(),
 		ForceFullCollection: cfg.Collection.ForceFullCollection,
 		PRChildMode:         cfg.Collection.PRChildMode,
+		ListingMode:         cfg.Collection.ListingMode,
 	})
 	go sched.Run(ctx)
 

--- a/internal/collector/api_nonfatal_test.go
+++ b/internal/collector/api_nonfatal_test.go
@@ -36,7 +36,11 @@ func TestStagedCollectorTreatsNotFoundAndForbiddenAsNonFatal(t *testing.T) {
 	}
 
 	for _, phase := range phases {
-		idx := strings.Index(code, phase)
+		// Look for the actual method call, not any mention (doc
+		// comments and inline references should not count). The call
+		// form is `client.<phase>(` after `sc.` or `c.` or some prefix.
+		callMarker := "." + phase + "("
+		idx := strings.Index(code, callMarker)
 		if idx < 0 {
 			t.Errorf("cannot find %s call in staged.go", phase)
 			continue

--- a/internal/collector/listing_mode_test.go
+++ b/internal/collector/listing_mode_test.go
@@ -1,0 +1,95 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestListingModeGateInStagedCollector — source-contract test for the
+// phase 2 feature gate. When cfg.Collection.ListingMode == "graphql",
+// the staged collector must use platform.Client.ListIssuesAndPRs to
+// enumerate in one unified GraphQL call instead of the two separate
+// REST iterators (ListIssues + ListPullRequests). In "rest" mode the
+// collector uses the existing two-iterator path byte-for-byte.
+//
+// Without this gate, phase 2's new method is unreachable and the
+// equivalence test can't tell the two modes apart.
+func TestListingModeGateInStagedCollector(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "ListingMode") {
+		t.Error("staged.go must reference ListingMode to gate between REST and GraphQL " +
+			"listing paths — without the gate, operators can't opt in to the GraphQL " +
+			"enumerator and the equivalence test harness can't compare the two")
+	}
+	if !strings.Contains(code, "ListIssuesAndPRs") {
+		t.Error("staged.go must call ListIssuesAndPRs when mode is 'graphql' — otherwise " +
+			"the gate has no effect")
+	}
+}
+
+// TestListingModeConfigExists — the config struct must declare the field
+// with a snake_case JSON tag and default to "rest" (the pre-phase-2
+// behavior) so existing deployments pick up v0.18.2 without a behavior
+// change until operators explicitly opt in.
+func TestListingModeConfigExists(t *testing.T) {
+	src, err := os.ReadFile("../config/config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "ListingMode") {
+		t.Error("CollectionConfig must declare ListingMode to control the issue+PR " +
+			"listing REST↔GraphQL gate")
+	}
+	if !strings.Contains(code, `json:"listing_mode"`) {
+		t.Error("ListingMode must have the json tag 'listing_mode' (snake_case convention)")
+	}
+}
+
+// TestListingModeFlowsThroughScheduler — Scheduler.Config must carry the
+// mode from cmd wiring down to the collector constructor. Without the
+// plumbing, aveloxis.json's listing_mode value is silently ignored.
+func TestListingModeFlowsThroughScheduler(t *testing.T) {
+	src, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "ListingMode") {
+		t.Error("scheduler.Config must carry ListingMode so cmd can plumb the config " +
+			"value through to the collector")
+	}
+}
+
+// TestListingModeRestPathUnchanged — defense-in-depth. The rest-mode
+// branch must still use the two legacy iterators (ListIssues +
+// ListPullRequests) so the existing REST shadow baseline stays valid
+// across phase 2. A refactor that accidentally removes the REST path
+// would invalidate the baseline and cost operators a multi-hour
+// re-collection.
+func TestListingModeRestPathUnchanged(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Both legacy iterators must still be callable from the staged
+	// collector (from the rest-mode branch).
+	if !strings.Contains(code, "ListIssues(") {
+		t.Error("staged.go must still call ListIssues in rest-mode to preserve " +
+			"pre-phase-2 behavior")
+	}
+	if !strings.Contains(code, "ListPullRequests(") {
+		t.Error("staged.go must still call ListPullRequests in rest-mode to preserve " +
+			"pre-phase-2 behavior")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -102,28 +102,44 @@ type StagedCollector struct {
 	logger       *slog.Logger
 	platID       int16
 	prChildMode  string // "rest" (default) or "graphql" — see CollectionConfig.PRChildMode
+	listingMode  string // "rest" (default) or "graphql" — see CollectionConfig.ListingMode
 }
 
 // NewStagedCollector creates a staged collector using the REST per-PR
-// child waterfall. For GraphQL-mode, call NewStagedCollectorWithMode.
+// child waterfall and REST issue/PR listing. For non-default modes,
+// use NewStagedCollectorWithMode or NewStagedCollectorWithModes.
 func NewStagedCollector(client platform.Client, store *db.PostgresStore, logger *slog.Logger) *StagedCollector {
-	return NewStagedCollectorWithMode(client, store, logger, "rest")
+	return NewStagedCollectorWithModes(client, store, logger, "rest", "rest")
 }
 
-// NewStagedCollectorWithMode is the explicit-mode constructor. mode
-// values are "rest" (the pre-v0.18.1 per-PR waterfall) and "graphql"
-// (the batched FetchPRBatch fetcher added in phase 1). Unknown values
-// are treated as "rest" so a misspelled config doesn't fail closed.
+// NewStagedCollectorWithMode is the phase-1 single-mode constructor
+// that sets pr_child_mode only. ListingMode defaults to "rest".
+// Preserved for backward compatibility with callers that don't yet
+// pass a listing mode.
 func NewStagedCollectorWithMode(client platform.Client, store *db.PostgresStore, logger *slog.Logger, mode string) *StagedCollector {
-	if mode != "graphql" {
-		mode = "rest"
+	return NewStagedCollectorWithModes(client, store, logger, mode, "rest")
+}
+
+// NewStagedCollectorWithModes is the explicit dual-mode constructor.
+// prChildMode selects between the REST per-PR waterfall and the
+// batched GraphQL fetcher (phase 1). listingMode selects between two
+// separate REST iterators and the unified GraphQL enumerator (phase
+// 2). Unknown mode values collapse to "rest" so misspelled config
+// fails safely.
+func NewStagedCollectorWithModes(client platform.Client, store *db.PostgresStore, logger *slog.Logger, prChildMode, listingMode string) *StagedCollector {
+	if prChildMode != "graphql" {
+		prChildMode = "rest"
+	}
+	if listingMode != "graphql" {
+		listingMode = "rest"
 	}
 	return &StagedCollector{
 		client:      client,
 		store:       store,
 		logger:      logger,
 		platID:      int16(client.Platform()),
-		prChildMode: mode,
+		prChildMode: prChildMode,
+		listingMode: listingMode,
 	}
 }
 
@@ -258,10 +274,53 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 // collectSequential runs issues, PRs, events, and messages one after another.
 // Used for repos with fewer than LargeRepoCommitThreshold commits.
 func (sc *StagedCollector) collectSequential(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
-	sc.collectIssues(ctx, sw, owner, repo, since, result)
-	sc.collectPRs(ctx, sw, owner, repo, since, result)
+	preIssues, prePRs := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
+	sc.collectIssues(ctx, sw, owner, repo, since, result, preIssues)
+	sc.collectPRs(ctx, sw, owner, repo, since, result, prePRs)
 	sc.collectEvents(ctx, sw, owner, repo, since, result)
 	sc.collectMessages(ctx, sw, owner, repo, since, result)
+}
+
+// preEnumerateIfGraphQL does the unified GraphQL issue+PR listing once
+// when listingMode=graphql, returning both slices for downstream
+// collectIssues/collectPRs to consume. In listingMode=rest it returns
+// (nil, nil) — the legacy per-path iterators in collectIssues and
+// collectPRs remain in charge.
+//
+// Non-fatal errors from the unified listing are logged and the function
+// returns (nil, nil) so collection falls through to the legacy iterators.
+// This way a transient GraphQL problem doesn't take down the entire
+// repo's collection — we just lose the speedup for this cycle.
+func (sc *StagedCollector) preEnumerateIfGraphQL(ctx context.Context, owner, repo string, since time.Time, result *CollectResult) ([]model.Issue, []model.PullRequest) {
+	if sc.listingMode != "graphql" {
+		return nil, nil
+	}
+	batch, err := sc.client.ListIssuesAndPRs(ctx, owner, repo, since)
+	if err != nil {
+		if isOptionalEndpointSkip(err) {
+			sc.logger.Info("unified listing skipped — falling back to REST iterators",
+				"owner", owner, "repo", repo, "reason", err)
+			return nil, nil
+		}
+		sc.logger.Warn("unified GraphQL listing failed — falling back to REST iterators",
+			"owner", owner, "repo", repo, "error", err)
+		return nil, nil
+	}
+	sc.logger.Info("unified listing complete",
+		"owner", owner, "repo", repo, "issues", len(batch.Issues), "prs", len(batch.PullRequests))
+	// Initialize to non-nil empty slices when the batch had zero items
+	// so the caller can distinguish "pre-fetched, found none" from
+	// "not pre-fetched, use iterator". Legacy rest-mode callers still
+	// see (nil, nil).
+	issues := batch.Issues
+	if issues == nil {
+		issues = []model.Issue{}
+	}
+	prs := batch.PullRequests
+	if prs == nil {
+		prs = []model.PullRequest{}
+	}
+	return issues, prs
 }
 
 // collectParallel runs issues, PRs, and events concurrently in 3 goroutines,
@@ -272,6 +331,11 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 	// Claim 3 extra parallel slots.
 	ParallelSlots.Add(3)
 	defer ParallelSlots.Add(-3)
+
+	// Pre-enumerate once before forking goroutines when listingMode is
+	// graphql. Calling ListIssuesAndPRs in each child goroutine would
+	// double-fetch the entire data set.
+	preIssues, prePRs := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex // protects result.Errors and counts
@@ -285,7 +349,7 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 		defer wg.Done()
 		issueSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
 		localResult := &CollectResult{}
-		sc.collectIssues(ctx, issueSW, owner, repo, since, localResult)
+		sc.collectIssues(ctx, issueSW, owner, repo, since, localResult, preIssues)
 		if err := issueSW.Flush(ctx); err != nil {
 			localResult.Errors = append(localResult.Errors, fmt.Errorf("issue flush: %w", err))
 		}
@@ -300,7 +364,7 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 		defer wg.Done()
 		prSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
 		localResult := &CollectResult{}
-		sc.collectPRs(ctx, prSW, owner, repo, since, localResult)
+		sc.collectPRs(ctx, prSW, owner, repo, since, localResult, prePRs)
 		if err := prSW.Flush(ctx); err != nil {
 			localResult.Errors = append(localResult.Errors, fmt.Errorf("pr flush: %w", err))
 		}
@@ -340,18 +404,36 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 }
 
 // collectIssues stages all issues with their labels and assignees.
-func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
-	sc.logger.Info("collecting issues", "owner", owner, "repo", repo)
-	for issue, err := range sc.client.ListIssues(ctx, owner, repo, since) {
-		if err != nil {
-			if isOptionalEndpointSkip(err) {
-				sc.logger.Info("skipping issues endpoint",
-					"owner", owner, "repo", repo, "reason", err)
+// When preEnumerated is non-nil, it's the issue slice from an earlier
+// unified ListIssuesAndPRs call (phase 2, listingMode=graphql); the
+// iterator path is bypassed. When nil, the legacy ListIssues iterator
+// drives enumeration (listingMode=rest, the default).
+func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult, preEnumerated []model.Issue) {
+	mode := sc.listingMode
+	if preEnumerated == nil && mode == "graphql" {
+		// Pre-enumeration failed or wasn't done. Fall back to REST.
+		mode = "rest"
+	}
+	sc.logger.Info("collecting issues", "owner", owner, "repo", repo, "listing_mode", mode)
+
+	issues := preEnumerated
+	if preEnumerated == nil {
+		// Enumerate via the legacy REST iterator.
+		for issue, err := range sc.client.ListIssues(ctx, owner, repo, since) {
+			if err != nil {
+				if isOptionalEndpointSkip(err) {
+					sc.logger.Info("skipping issues endpoint",
+						"owner", owner, "repo", repo, "reason", err)
+					break
+				}
+				result.Errors = append(result.Errors, fmt.Errorf("issues: %w", err))
 				break
 			}
-			result.Errors = append(result.Errors, fmt.Errorf("issues: %w", err))
-			break
+			issues = append(issues, issue)
 		}
+	}
+
+	for _, issue := range issues {
 		envelope := stagedIssue{Issue: issue}
 		for label, err := range sc.client.ListIssueLabels(ctx, owner, repo, issue.Number) {
 			if err != nil {
@@ -370,33 +452,43 @@ func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWrit
 		}
 		result.Issues++
 		if result.Issues%100 == 0 {
-			sc.logger.Info("issues progress", "owner", owner, "repo", repo, "staged", result.Issues)
+			sc.logger.Info("issues progress", "owner", owner, "repo", repo, "staged", result.Issues, "listing_mode", mode)
 		}
 	}
-	sc.logger.Info("issues staged", "count", result.Issues)
+	sc.logger.Info("issues staged", "count", result.Issues, "listing_mode", mode)
 }
 
 // collectPRs stages all pull requests with their children.
-func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
-	sc.logger.Info("collecting pull requests", "owner", owner, "repo", repo, "mode", sc.prChildMode)
+// When preEnumerated is non-nil (listingMode=graphql pre-fetched), it's
+// used directly. When nil, the legacy ListPullRequests iterator drives
+// enumeration.
+func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult, preEnumerated []model.PullRequest) {
+	listMode := sc.listingMode
+	if preEnumerated == nil && listMode == "graphql" {
+		listMode = "rest" // pre-enumeration failed, fell back
+	}
+	sc.logger.Info("collecting pull requests", "owner", owner, "repo", repo, "mode", sc.prChildMode, "listing_mode", listMode)
 
-	// Collect PR numbers first so we can either stage them one-by-one
-	// (REST mode, preserving the pre-v0.18.1 behavior) or hand the full
-	// list to FetchPRBatch (GraphQL mode). Sharing this enumeration means
-	// both modes iterate the same PR listing, eliminating a source of
-	// equivalence drift.
+	// Collect PR numbers either from the pre-enumerated slice (phase 2
+	// graphql listing) or by iterating ListPullRequests (legacy REST).
+	// Sharing this enumeration between rest and graphql child modes
+	// eliminates a source of equivalence drift.
 	var prs []model.PullRequest
-	for pr, err := range sc.client.ListPullRequests(ctx, owner, repo, since) {
-		if err != nil {
-			if isOptionalEndpointSkip(err) {
-				sc.logger.Info("skipping pull requests endpoint",
-					"owner", owner, "repo", repo, "reason", err)
+	if preEnumerated != nil {
+		prs = preEnumerated
+	} else {
+		for pr, err := range sc.client.ListPullRequests(ctx, owner, repo, since) {
+			if err != nil {
+				if isOptionalEndpointSkip(err) {
+					sc.logger.Info("skipping pull requests endpoint",
+						"owner", owner, "repo", repo, "reason", err)
+					break
+				}
+				result.Errors = append(result.Errors, fmt.Errorf("pull requests: %w", err))
 				break
 			}
-			result.Errors = append(result.Errors, fmt.Errorf("pull requests: %w", err))
-			break
+			prs = append(prs, pr)
 		}
-		prs = append(prs, pr)
 	}
 
 	switch sc.prChildMode {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,21 @@ type CollectionConfig struct {
 	// Default "rest" so existing deployments pick up v0.18.1 without a
 	// behavior change until operators explicitly opt in.
 	PRChildMode string `json:"pr_child_mode"`
+
+	// ListingMode selects between two separate REST iterators for
+	// issues and PRs ("rest", default) and the unified GraphQL
+	// listing ("graphql") added in phase 2 of the REST→GraphQL
+	// refactor. When "graphql", the staged collector calls
+	// platform.Client.ListIssuesAndPRs once per repo instead of
+	// iterating ListIssues and ListPullRequests separately. On GitHub
+	// this is a pair of paginated GraphQL queries; on GitLab it
+	// composes the existing REST iterators (GitLab's GraphQL MR
+	// surface is too limited to use directly). Column parity is
+	// preserved in both modes.
+	//
+	// Default "rest" so existing deployments pick up v0.18.2 without
+	// a behavior change until operators explicitly opt in.
+	ListingMode string `json:"listing_mode"`
 }
 
 // Load reads configuration from a JSON file.
@@ -217,6 +232,7 @@ func DefaultConfig() *Config {
 			MatviewRebuildDay:       "saturday",
 			MatviewRebuildOnStartup: false,
 			PRChildMode:             "rest",
+			ListingMode:             "rest",
 		},
 		LogLevel: "info",
 	}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.1"
+var ToolVersion = "0.18.2"

--- a/internal/platform/github/graphql_listing.go
+++ b/internal/platform/github/graphql_listing.go
@@ -1,0 +1,251 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/augurlabs/aveloxis/internal/model"
+	"github.com/augurlabs/aveloxis/internal/platform"
+)
+
+// ListIssuesAndPRs enumerates issues and PRs via two paginated GraphQL
+// queries — one per connection — and returns the combined batch. Phase
+// 2 of the REST→GraphQL refactor; callers that previously iterated
+// ListIssues and ListPullRequests separately can now get both in one
+// call with one GraphQL POST per page instead of two REST GETs.
+//
+// Why two queries instead of one combined query with both connections:
+//   - Issues and PRs have independent page counts (typically very
+//     different — augur has 989 issues vs 2623 PRs). A combined query
+//     keeps both cursors in one request and wastes bandwidth once one
+//     connection is exhausted.
+//   - The since-filter mechanism differs per connection: `issues`
+//     supports `filterBy: {since: $since}` server-side; `pullRequests`
+//     has no equivalent and must rely on orderBy UPDATED_AT DESC + a
+//     client-side break when we see an item older than since.
+//   - Cursor management is trivial with one cursor per query.
+//
+// Eliminates REST's /issues-returns-PRs double-count: the legacy REST
+// path listed PRs twice (once through /issues with a client-side
+// filter-out, once through /pulls). GraphQL's separate connections
+// never return PRs via the issues connection.
+func (c *Client) ListIssuesAndPRs(ctx context.Context, owner, repo string, since time.Time) (*platform.IssueAndPRBatch, error) {
+	batch := &platform.IssueAndPRBatch{}
+
+	issues, err := c.listIssuesGraphQL(ctx, owner, repo, since)
+	if err != nil {
+		return batch, fmt.Errorf("graphql issues listing: %w", err)
+	}
+	batch.Issues = issues
+
+	prs, err := c.listPullRequestsGraphQL(ctx, owner, repo, since)
+	if err != nil {
+		return batch, fmt.Errorf("graphql pullRequests listing: %w", err)
+	}
+	batch.PullRequests = prs
+
+	return batch, nil
+}
+
+// listIssuesGraphQL paginates the repository.issues connection using the
+// server-side since filter. ORDER BY UPDATED_AT DESC so pages arrive
+// most-recent-first — matches REST's /issues?sort=updated&direction=desc
+// ordering.
+func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, since time.Time) ([]model.Issue, error) {
+	const query = `query IssuesList($owner: String!, $repo: String!, $cursor: String, $since: DateTime) {
+  repository(owner: $owner, name: $repo) {
+    issues(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}, filterBy: {since: $since}) {
+      nodes {
+        databaseId id number title body state url
+        createdAt updatedAt closedAt
+        comments { totalCount }
+        author {
+          __typename login
+          ... on User { databaseId avatarUrl url name email }
+          ... on Bot { databaseId avatarUrl url }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`
+
+	var out []model.Issue
+	var cursor string
+	for {
+		vars := map[string]any{"owner": owner, "repo": repo}
+		if cursor != "" {
+			vars["cursor"] = cursor
+		} else {
+			vars["cursor"] = nil
+		}
+		if !since.IsZero() {
+			vars["since"] = since.UTC().Format(time.RFC3339)
+		} else {
+			vars["since"] = nil
+		}
+
+		var resp struct {
+			Repository struct {
+				Issues struct {
+					Nodes []struct {
+						DatabaseID int64      `json:"databaseId"`
+						ID         string     `json:"id"`
+						Number     int        `json:"number"`
+						Title      string     `json:"title"`
+						Body       string     `json:"body"`
+						State      string     `json:"state"`
+						URL        string     `json:"url"`
+						CreatedAt  time.Time  `json:"createdAt"`
+						UpdatedAt  time.Time  `json:"updatedAt"`
+						ClosedAt   *time.Time `json:"closedAt"`
+						Comments   struct {
+							TotalCount int `json:"totalCount"`
+						} `json:"comments"`
+						Author *prBatchUser `json:"author"`
+					} `json:"nodes"`
+					PageInfo prBatchPageInfo `json:"pageInfo"`
+				} `json:"issues"`
+			} `json:"repository"`
+		}
+		if err := c.http.GraphQL(ctx, query, vars, &resp); err != nil {
+			return out, err
+		}
+
+		for _, n := range resp.Repository.Issues.Nodes {
+			issue := model.Issue{
+				PlatformID:   n.DatabaseID,
+				NodeID:       n.ID,
+				Number:       n.Number,
+				Title:        n.Title,
+				Body:         n.Body,
+				State:        strings.ToLower(n.State),
+				URL:          n.URL,
+				HTMLURL:      n.URL,
+				CreatedAt:    n.CreatedAt,
+				UpdatedAt:    n.UpdatedAt,
+				ClosedAt:     n.ClosedAt,
+				CommentCount: n.Comments.TotalCount,
+				Origin: model.DataOrigin{
+					ToolSource: "aveloxis",
+					DataSource: "GitHub GraphQL (listing)",
+				},
+			}
+			if n.Author != nil {
+				issue.ReporterRef = userRefFromGraphQL(n.Author)
+			}
+			out = append(out, issue)
+		}
+		if !resp.Repository.Issues.PageInfo.HasNextPage {
+			return out, nil
+		}
+		cursor = resp.Repository.Issues.PageInfo.EndCursor
+	}
+}
+
+// listPullRequestsGraphQL paginates the repository.pullRequests connection.
+// The connection has no server-side since filter, so pages come ordered
+// DESC and the loop breaks as soon as a PR's updatedAt falls on or before
+// the since cutoff. Matches the legacy REST ListPullRequests behavior.
+func (c *Client) listPullRequestsGraphQL(ctx context.Context, owner, repo string, since time.Time) ([]model.PullRequest, error) {
+	const query = `query PRList($owner: String!, $repo: String!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN, CLOSED, MERGED]) {
+      nodes {
+        databaseId id number title body state locked
+        url createdAt updatedAt closedAt mergedAt authorAssociation
+        mergeCommit { oid }
+        author {
+          __typename login
+          ... on User { databaseId avatarUrl url name email }
+          ... on Bot { databaseId avatarUrl url }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`
+
+	var out []model.PullRequest
+	var cursor string
+	for {
+		vars := map[string]any{"owner": owner, "repo": repo}
+		if cursor != "" {
+			vars["cursor"] = cursor
+		} else {
+			vars["cursor"] = nil
+		}
+
+		var resp struct {
+			Repository struct {
+				PullRequests struct {
+					Nodes []struct {
+						DatabaseID        int64        `json:"databaseId"`
+						ID                string       `json:"id"`
+						Number            int          `json:"number"`
+						Title             string       `json:"title"`
+						Body              string       `json:"body"`
+						State             string       `json:"state"`
+						Locked            bool         `json:"locked"`
+						URL               string       `json:"url"`
+						CreatedAt         time.Time    `json:"createdAt"`
+						UpdatedAt         time.Time    `json:"updatedAt"`
+						ClosedAt          *time.Time   `json:"closedAt"`
+						MergedAt          *time.Time   `json:"mergedAt"`
+						AuthorAssociation string       `json:"authorAssociation"`
+						MergeCommit       *struct {
+							OID string `json:"oid"`
+						} `json:"mergeCommit"`
+						Author *prBatchUser `json:"author"`
+					} `json:"nodes"`
+					PageInfo prBatchPageInfo `json:"pageInfo"`
+				} `json:"pullRequests"`
+			} `json:"repository"`
+		}
+		if err := c.http.GraphQL(ctx, query, vars, &resp); err != nil {
+			return out, err
+		}
+
+		// Iterate in order. Because the connection is ordered UPDATED_AT
+		// DESC, once we see a PR whose updatedAt is on/before `since`,
+		// every subsequent PR is also older — stop paginating.
+		for _, n := range resp.Repository.PullRequests.Nodes {
+			if !since.IsZero() && !n.UpdatedAt.After(since) {
+				return out, nil
+			}
+			pr := model.PullRequest{
+				PlatformSrcID:     n.DatabaseID,
+				NodeID:            n.ID,
+				Number:            n.Number,
+				Title:             n.Title,
+				Body:              n.Body,
+				State:             mapPRState(n.State, n.MergedAt),
+				Locked:            n.Locked,
+				URL:               n.URL,
+				HTMLURL:           n.URL,
+				CreatedAt:         n.CreatedAt,
+				UpdatedAt:         n.UpdatedAt,
+				ClosedAt:          n.ClosedAt,
+				MergedAt:          n.MergedAt,
+				AuthorAssociation: n.AuthorAssociation,
+				Origin: model.DataOrigin{
+					ToolSource: "aveloxis",
+					DataSource: "GitHub GraphQL (listing)",
+				},
+			}
+			if n.MergeCommit != nil {
+				pr.MergeCommitSHA = n.MergeCommit.OID
+			}
+			if n.Author != nil {
+				pr.AuthorRef = userRefFromGraphQL(n.Author)
+			}
+			out = append(out, pr)
+		}
+		if !resp.Repository.PullRequests.PageInfo.HasNextPage {
+			return out, nil
+		}
+		cursor = resp.Repository.PullRequests.PageInfo.EndCursor
+	}
+}

--- a/internal/platform/github/graphql_listing_test.go
+++ b/internal/platform/github/graphql_listing_test.go
@@ -1,0 +1,357 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+)
+
+// TestListIssuesAndPRs_EmptyRepo — a repo with no issues and no PRs must
+// return an empty batch without error. Important for brand-new repos
+// that make it into the queue before anyone opens an issue.
+func TestListIssuesAndPRs_EmptyRepo(t *testing.T) {
+	server := httptest.NewServer(graphqlFixture(t, []string{
+		// issues page 1 — empty
+		`{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+		// pullRequests page 1 — empty
+		`{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+	}))
+	defer server.Close()
+	client := newTestGraphQLClient(t, server.URL)
+
+	batch, err := client.ListIssuesAndPRs(context.Background(), "o", "r", time.Time{})
+	if err != nil {
+		t.Fatalf("ListIssuesAndPRs: %v", err)
+	}
+	if batch == nil {
+		t.Fatal("batch is nil")
+	}
+	if len(batch.Issues) != 0 {
+		t.Errorf("len(Issues) = %d, want 0", len(batch.Issues))
+	}
+	if len(batch.PullRequests) != 0 {
+		t.Errorf("len(PullRequests) = %d, want 0", len(batch.PullRequests))
+	}
+}
+
+// TestListIssuesAndPRs_HappyPath — single-page response for each connection.
+// Asserts field-for-field mapping from GraphQL node to model.Issue /
+// model.PullRequest matches what REST populates today, so phase 2 is a
+// drop-in replacement for listing.
+func TestListIssuesAndPRs_HappyPath(t *testing.T) {
+	issuesResp := `{
+		"data": {"repository": {"issues": {
+			"nodes": [
+				{
+					"databaseId": 100, "number": 1, "id": "I_1",
+					"title": "Test issue", "body": "Body text",
+					"state": "OPEN",
+					"url": "https://github.com/o/r/issues/1",
+					"createdAt": "2026-04-01T12:00:00Z",
+					"updatedAt": "2026-04-02T12:00:00Z",
+					"closedAt": null,
+					"comments": {"totalCount": 3},
+					"author": {"__typename": "User", "login": "alice", "databaseId": 5001, "avatarUrl": "https://a.com/alice", "url": "https://github.com/alice"}
+				}
+			],
+			"pageInfo": {"hasNextPage": false, "endCursor": null}
+		}}}
+	}`
+	prsResp := `{
+		"data": {"repository": {"pullRequests": {
+			"nodes": [
+				{
+					"databaseId": 200, "number": 42, "id": "PR_42",
+					"title": "Add x", "body": "",
+					"state": "OPEN", "locked": false,
+					"url": "https://github.com/o/r/pull/42",
+					"createdAt": "2026-04-01T12:00:00Z",
+					"updatedAt": "2026-04-03T12:00:00Z",
+					"closedAt": null, "mergedAt": null,
+					"mergeCommit": null,
+					"authorAssociation": "CONTRIBUTOR",
+					"author": {"__typename": "User", "login": "bob", "databaseId": 5002, "avatarUrl": "https://a.com/bob", "url": "https://github.com/bob"}
+				}
+			],
+			"pageInfo": {"hasNextPage": false, "endCursor": null}
+		}}}
+	}`
+	server := httptest.NewServer(graphqlFixture(t, []string{issuesResp, prsResp}))
+	defer server.Close()
+	client := newTestGraphQLClient(t, server.URL)
+
+	batch, err := client.ListIssuesAndPRs(context.Background(), "o", "r", time.Time{})
+	if err != nil {
+		t.Fatalf("ListIssuesAndPRs: %v", err)
+	}
+	if len(batch.Issues) != 1 {
+		t.Fatalf("len(Issues) = %d, want 1", len(batch.Issues))
+	}
+	issue := batch.Issues[0]
+	if issue.Number != 1 {
+		t.Errorf("Issue.Number = %d, want 1", issue.Number)
+	}
+	if issue.PlatformID != 100 {
+		t.Errorf("Issue.PlatformID = %d, want 100 (databaseId)", issue.PlatformID)
+	}
+	if issue.NodeID != "I_1" {
+		t.Errorf("Issue.NodeID = %q, want I_1", issue.NodeID)
+	}
+	if issue.State != "open" {
+		t.Errorf("Issue.State = %q, want lowercase 'open' (matches REST convention)", issue.State)
+	}
+	if issue.CommentCount != 3 {
+		t.Errorf("Issue.CommentCount = %d, want 3", issue.CommentCount)
+	}
+	if issue.ReporterRef.Login != "alice" {
+		t.Errorf("Issue.ReporterRef.Login = %q, want alice", issue.ReporterRef.Login)
+	}
+	if issue.ReporterRef.PlatformID != 5001 {
+		t.Errorf("Issue.ReporterRef.PlatformID = %d, want 5001", issue.ReporterRef.PlatformID)
+	}
+
+	if len(batch.PullRequests) != 1 {
+		t.Fatalf("len(PullRequests) = %d, want 1", len(batch.PullRequests))
+	}
+	pr := batch.PullRequests[0]
+	if pr.Number != 42 {
+		t.Errorf("PR.Number = %d, want 42", pr.Number)
+	}
+	if pr.PlatformSrcID != 200 {
+		t.Errorf("PR.PlatformSrcID = %d, want 200", pr.PlatformSrcID)
+	}
+	if pr.State != "open" {
+		t.Errorf("PR.State = %q, want lowercase 'open'", pr.State)
+	}
+	if pr.AuthorAssociation != "CONTRIBUTOR" {
+		t.Errorf("PR.AuthorAssociation = %q, want CONTRIBUTOR", pr.AuthorAssociation)
+	}
+	if pr.AuthorRef.Login != "bob" {
+		t.Errorf("PR.AuthorRef.Login = %q, want bob", pr.AuthorRef.Login)
+	}
+}
+
+// TestListIssuesAndPRs_MergedPRStateMapping — MERGED PRs must surface as
+// State="merged", same rule as FetchPRBatch. A REST path called it
+// "merged" when mergedAt was set; GraphQL returns enum MERGED directly.
+// Both must map to lowercase "merged" in the model.
+func TestListIssuesAndPRs_MergedPRStateMapping(t *testing.T) {
+	issuesResp := `{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`
+	prsResp := `{
+		"data": {"repository": {"pullRequests": {
+			"nodes": [
+				{
+					"databaseId": 300, "number": 7, "id": "PR_7",
+					"title": "Merged PR", "body": "",
+					"state": "MERGED", "locked": false,
+					"url": "https://github.com/o/r/pull/7",
+					"createdAt": "2026-03-01T12:00:00Z",
+					"updatedAt": "2026-03-05T12:00:00Z",
+					"closedAt": "2026-03-05T12:00:00Z",
+					"mergedAt": "2026-03-05T12:00:00Z",
+					"mergeCommit": {"oid": "cafebabe"},
+					"authorAssociation": "MEMBER",
+					"author": null
+				}
+			],
+			"pageInfo": {"hasNextPage": false, "endCursor": null}
+		}}}
+	}`
+	server := httptest.NewServer(graphqlFixture(t, []string{issuesResp, prsResp}))
+	defer server.Close()
+	client := newTestGraphQLClient(t, server.URL)
+
+	batch, err := client.ListIssuesAndPRs(context.Background(), "o", "r", time.Time{})
+	if err != nil {
+		t.Fatalf("ListIssuesAndPRs: %v", err)
+	}
+	if len(batch.PullRequests) != 1 {
+		t.Fatalf("len(PullRequests) = %d", len(batch.PullRequests))
+	}
+	pr := batch.PullRequests[0]
+	if pr.State != "merged" {
+		t.Errorf("PR.State = %q, want merged (state=MERGED and mergedAt set)", pr.State)
+	}
+	if pr.MergeCommitSHA != "cafebabe" {
+		t.Errorf("PR.MergeCommitSHA = %q, want cafebabe", pr.MergeCommitSHA)
+	}
+}
+
+// TestListIssuesAndPRs_PaginatesIssues — cursor pagination across multiple
+// pages of the issues connection. Verifies every page is collected, in
+// order, and the cursor is honored.
+func TestListIssuesAndPRs_PaginatesIssues(t *testing.T) {
+	issuesPage1 := `{
+		"data": {"repository": {"issues": {
+			"nodes": [
+				{"databaseId": 1, "number": 1, "id": "I_1", "title": "t1", "body": "", "state": "OPEN", "url": "", "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z", "closedAt": null, "comments": {"totalCount": 0}, "author": null}
+			],
+			"pageInfo": {"hasNextPage": true, "endCursor": "CUR1"}
+		}}}
+	}`
+	issuesPage2 := `{
+		"data": {"repository": {"issues": {
+			"nodes": [
+				{"databaseId": 2, "number": 2, "id": "I_2", "title": "t2", "body": "", "state": "CLOSED", "url": "", "createdAt": "2026-01-02T00:00:00Z", "updatedAt": "2026-01-02T00:00:00Z", "closedAt": "2026-01-03T00:00:00Z", "comments": {"totalCount": 0}, "author": null}
+			],
+			"pageInfo": {"hasNextPage": false, "endCursor": null}
+		}}}
+	}`
+	prsResp := `{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`
+
+	// Verify page 2's request carried the cursor from page 1.
+	var p2Cursor atomic.Value
+	var call atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := call.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var parsed struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &parsed)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch n {
+		case 1:
+			_, _ = w.Write([]byte(issuesPage1))
+		case 2:
+			// Record cursor used for issues page 2
+			if c, ok := parsed.Variables["cursor"]; ok {
+				p2Cursor.Store(c)
+			}
+			_, _ = w.Write([]byte(issuesPage2))
+		default:
+			_, _ = w.Write([]byte(prsResp))
+		}
+	}))
+	defer server.Close()
+	client := newTestGraphQLClient(t, server.URL)
+
+	batch, err := client.ListIssuesAndPRs(context.Background(), "o", "r", time.Time{})
+	if err != nil {
+		t.Fatalf("ListIssuesAndPRs: %v", err)
+	}
+	if len(batch.Issues) != 2 {
+		t.Errorf("len(Issues) = %d, want 2 (paginated)", len(batch.Issues))
+	}
+	if batch.Issues[0].Number != 1 || batch.Issues[1].Number != 2 {
+		t.Errorf("paginated issues out of order: %+v", []int{batch.Issues[0].Number, batch.Issues[1].Number})
+	}
+	if c := p2Cursor.Load(); c != "CUR1" {
+		t.Errorf("page 2 cursor = %v, want CUR1 (page 1's endCursor)", c)
+	}
+}
+
+// TestListIssuesAndPRs_SinceFilterBreaksPRPagination — GraphQL's
+// pullRequests connection has no native `since` filter. The implementation
+// must order DESC by UPDATED_AT and stop paginating when it sees a PR
+// whose updatedAt predates the since cutoff (same behavior REST had).
+// Without that early-break, incremental collection re-fetches every
+// PR every time.
+func TestListIssuesAndPRs_SinceFilterBreaksPRPagination(t *testing.T) {
+	issuesResp := `{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`
+	// Page 1: one PR newer than since, one older. Implementation sees
+	// "older" and stops — should NOT request page 2.
+	prsPage1 := `{
+		"data": {"repository": {"pullRequests": {
+			"nodes": [
+				{"databaseId": 10, "number": 10, "id": "PR_10", "title": "new", "body": "", "state": "OPEN", "locked": false, "url": "", "createdAt": "2026-04-01T00:00:00Z", "updatedAt": "2026-04-05T00:00:00Z", "closedAt": null, "mergedAt": null, "mergeCommit": null, "authorAssociation": "NONE", "author": null},
+				{"databaseId": 9, "number": 9, "id": "PR_9", "title": "old", "body": "", "state": "OPEN", "locked": false, "url": "", "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z", "closedAt": null, "mergedAt": null, "mergeCommit": null, "authorAssociation": "NONE", "author": null}
+			],
+			"pageInfo": {"hasNextPage": true, "endCursor": "SHOULD_NOT_BE_USED"}
+		}}}
+	}`
+
+	var prPageCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &parsed)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(parsed.Query, "pullRequests") {
+			prPageCalls.Add(1)
+			_, _ = w.Write([]byte(prsPage1))
+		} else {
+			_, _ = w.Write([]byte(issuesResp))
+		}
+	}))
+	defer server.Close()
+	client := newTestGraphQLClient(t, server.URL)
+
+	since := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	batch, err := client.ListIssuesAndPRs(context.Background(), "o", "r", since)
+	if err != nil {
+		t.Fatalf("ListIssuesAndPRs: %v", err)
+	}
+	// Only the PR newer than since should come back.
+	if len(batch.PullRequests) != 1 {
+		t.Errorf("len(PullRequests) = %d, want 1 (only the one newer than since)", len(batch.PullRequests))
+	}
+	// And the pullRequests query should have been called exactly ONCE —
+	// the break-on-old-PR logic should have prevented a page 2 fetch.
+	if prPageCalls.Load() != 1 {
+		t.Errorf("pullRequests query called %d times, want 1 (must stop paginating once a PR older than since is seen)", prPageCalls.Load())
+	}
+}
+
+// TestListIssuesAndPRs_QueryMentionsSinceFilterForIssues — source-level
+// pin: the issues connection query must use `filterBy.since` so the
+// server only returns issues updated after the cutoff. Without this,
+// incremental collection pays to transfer every historical issue every
+// cycle. (The PR side doesn't have a `since` filter — confirmed by the
+// break-on-old-PR test above.)
+func TestListIssuesAndPRs_QueryMentionsSinceFilterForIssues(t *testing.T) {
+	data, err := readPhase2Source(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(data, "filterBy") {
+		t.Error("phase 2 listing query must use issues(..., filterBy: {since: $since}) " +
+			"to let the server apply the since filter — otherwise every incremental " +
+			"collection re-fetches the entire issue history")
+	}
+	if !strings.Contains(data, "since") {
+		t.Error("phase 2 listing must reference a 'since' variable")
+	}
+}
+
+// TestListIssuesAndPRs_QueryOrdersPRsByUpdatedAtDesc — the PR connection
+// uses orderBy UPDATED_AT DESC so the break-on-old logic finds the
+// cutoff quickly. Without the ordering, the implementation would have
+// to fetch every PR before finding the cutoff.
+func TestListIssuesAndPRs_QueryOrdersPRsByUpdatedAtDesc(t *testing.T) {
+	data, err := readPhase2Source(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must order by UPDATED_AT on both connections.
+	if !strings.Contains(data, "UPDATED_AT") {
+		t.Error("listing queries must use orderBy: {field: UPDATED_AT, ...} so the " +
+			"since-cutoff break logic can terminate early")
+	}
+	if !strings.Contains(data, "DESC") {
+		t.Error("listing queries must order DESC so since-cutoff breaks at first old item")
+	}
+}
+
+// --- helpers ----------------------------------------------------------
+
+func readPhase2Source(t *testing.T) (string, error) {
+	t.Helper()
+	b, err := os.ReadFile("graphql_listing.go")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/platform/gitlab/listing.go
+++ b/internal/platform/gitlab/listing.go
@@ -1,0 +1,49 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/augurlabs/aveloxis/internal/platform"
+)
+
+// ListIssuesAndPRs is GitLab's implementation of phase 2's unified
+// listing method. Composes the existing REST iterators (ListIssues +
+// ListPullRequests) into the same platform.IssueAndPRBatch shape that
+// GitHub's GraphQL implementation returns.
+//
+// GitLab's GraphQL API is too weak on merge_request fields to use here
+// (no server-side since filter on MRs, no per-MR children connection
+// aligned with what Aveloxis populates). The REST composition preserves
+// column-level parity at the cost of the call-count reduction GitHub
+// sees. Column parity is the contract, not uniform call patterns.
+//
+// Non-skippable errors from either iterator abort the whole listing —
+// the caller needs a consistent failure mode regardless of whether
+// the underlying implementation is one GraphQL query or two REST loops.
+func (c *Client) ListIssuesAndPRs(ctx context.Context, owner, repo string, since time.Time) (*platform.IssueAndPRBatch, error) {
+	batch := &platform.IssueAndPRBatch{}
+
+	for issue, err := range c.ListIssues(ctx, owner, repo, since) {
+		if err != nil {
+			if platform.ClassifyError(err) == platform.ClassSkip {
+				break
+			}
+			return batch, fmt.Errorf("gitlab list issues: %w", err)
+		}
+		batch.Issues = append(batch.Issues, issue)
+	}
+
+	for pr, err := range c.ListPullRequests(ctx, owner, repo, since) {
+		if err != nil {
+			if platform.ClassifyError(err) == platform.ClassSkip {
+				break
+			}
+			return batch, fmt.Errorf("gitlab list merge requests: %w", err)
+		}
+		batch.PullRequests = append(batch.PullRequests, pr)
+	}
+
+	return batch, nil
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -27,6 +27,17 @@ type Client interface {
 	// Pass nil to clear a previously installed hook.
 	OnPermanentRedirect(hook func(from, to string))
 
+	// ListIssuesAndPRs enumerates every issue and PR in the repo updated
+	// since the given time, in one call. Replaces two separate iterator
+	// loops (ListIssues + ListPullRequests) with a single batch return.
+	//
+	// Pass zero time for full collection. GitHub's implementation uses
+	// GraphQL (issues + pullRequests connections, cursor paginated).
+	// GitLab's composes the existing REST iterators. Both produce the
+	// same model types the legacy iterators produce, so callers can
+	// substitute one for the other without column-level drift.
+	ListIssuesAndPRs(ctx context.Context, owner, repo string, since time.Time) (*IssueAndPRBatch, error)
+
 	// Repo metadata
 	RepoCollector
 	// Issues and their related data
@@ -50,6 +61,21 @@ type RepoCollector interface {
 
 	// FetchCloneStats returns clone/traffic data (may require elevated perms).
 	FetchCloneStats(ctx context.Context, owner, repo string) ([]model.RepoClone, error)
+}
+
+// IssueAndPRBatch bundles the result of a unified issue + PR enumeration
+// (phase 2 of the REST→GraphQL refactor). Replaces two separate iterator
+// calls (ListIssues + ListPullRequests) with a single batch return.
+//
+// On GitHub: populated by a pair of GraphQL queries (one per connection)
+// that eliminate REST's /issues-returns-PRs double-count.
+// On GitLab: populated by composing the existing REST iterators — GitLab's
+// GraphQL API is too weak on merge_request fields to use here. Parity is
+// preserved at the row/column level; the only observable difference is
+// the call pattern inside the platform package.
+type IssueAndPRBatch struct {
+	Issues       []model.Issue
+	PullRequests []model.PullRequest
 }
 
 // IssueCollector fetches issues and related entities.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -36,6 +36,7 @@ type Config struct {
 	MatviewRebuildDay    int           // day of week for matview rebuild (0=Sun..6=Sat, -1=disabled)
 	ForceFullCollection  bool          // when true, all collections use since=zero (full re-collection)
 	PRChildMode          string        // "rest" (default) or "graphql" — routes PR child fetch through FetchPRBatch
+	ListingMode          string        // "rest" (default) or "graphql" — routes issue+PR listing through ListIssuesAndPRs
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.
@@ -504,7 +505,7 @@ func (s *Scheduler) determineSince(job *db.QueueJob) time.Time {
 // the API, then process staged data into relational tables with bulk
 // contributor resolution.
 func (s *Scheduler) collectAndProcess(ctx context.Context, repoID int64, repo *model.Repo, client platform.Client, since time.Time) (*collector.CollectResult, error) {
-	sc := collector.NewStagedCollectorWithMode(client, s.store, s.logger, s.cfg.PRChildMode)
+	sc := collector.NewStagedCollectorWithModes(client, s.store, s.logger, s.cfg.PRChildMode, s.cfg.ListingMode)
 	result, err := sc.CollectRepo(ctx, repoID, repo.Owner, repo.Name, since)
 
 	if err == nil {


### PR DESCRIPTION
Code changes (v0.18.2):                                                                                                                                                   
                                               
  - platform.IssueAndPRBatch type                                                                                                                                           
  - platform.Client.ListIssuesAndPRs(ctx, owner, repo, since) (*IssueAndPRBatch, error) interface method                                                                    
  - github.Client.ListIssuesAndPRs — two paginated GraphQL queries (issues + pullRequests); server-side filterBy.since on issues; client-side break on old PRs (connection  
  has no since filter)                                                                                                                                                      
  - gitlab.Client.ListIssuesAndPRs — REST-composition fallback (GitLab GraphQL MR surface insufficient)                                                                     
  - collection.listing_mode config (default rest)                                                                                                                           
  - NewStagedCollectorWithModes(prChildMode, listingMode) dual-mode constructor                                                                                             
  - preEnumerateIfGraphQL helper hoisted above collectSequential/collectParallel; pre-fetched slices threaded to collectIssues/collectPRs                                   
                                                                                                                                                                            
  Tests: 7 new GitHub tests + 4 new collector source-contract tests. Full suite green. Zero lint in new files.                                                              
                                                                                                                                                                            
  Live run: 24m13s for augur full collection via GraphQL listing + GraphQL PR children (vs 23m for phase 1 which was GraphQL children + REST listing). Listing alone is a   
  wash in wall-clock for augur-sized repos; the main benefit is eliminating REST's /issues-returns-PRs double-count (~27 fewer HTTP requests for augur; proportionally more 
  on bigger repos).                                                                                                                                                         
                                                                                                                                                                            
  Equivalence diff: no new regressions. Same pre-existing artifacts as phase 1, no new ones introduced. 