### PR TITLE
Feat/2 server optimization: Instructions for OSX and Other Two Server Setups

### DIFF
--- a/HIGHVOLUME.md
+++ b/HIGHVOLUME.md
@@ -1,0 +1,23 @@
+        
+- internal/db/prepared_stmt_retry.go — isStalePreparedStatement classifier, sendBatchWithRetry wrapper, appendKeepaliveParams helper, and the keepaliveParams constant    
+
+(all three defenses in one file so the retry policy is easy to find and change together).                                                                                 
+
+- internal/db/prepared_stmt_retry_test.go — 6 tests covering the classifier, the wrapper's source contract, and the staging-flush wiring.                                 
+                                                                                                                                                                        
+Modified:                                                                                                                                                                 
+- internal/db/postgres.go — NewPostgresStore calls appendKeepaliveParams(connString) before pgxpool.ParseConfig; DefaultQueryExecMode flipped back to                     
+QueryExecModeCacheStatement; comment carries the full v0.18.10→v0.18.14 incident trail with reversion triggers.                                                           
+- internal/db/staging.go — StagingWriter.Flush now calls sendBatchWithRetry instead of pool.SendBatch.                                                                    
+- internal/db/pool_test.go — TestPoolUsesCacheStatement (flipped from TestPoolUsesDescribeCache), plus 3 new keepalive tests (TestPoolAppendsKeepaliveParams source       
+contract, TestAppendKeepaliveParams_URLForm, _Idempotent, _KeywordForm runtime behavior).                                                                                 
+- docs/guide/troubleshooting.md — new section on SQLSTATE 26000, workers=40 recommendation for Mac deployments, reversion steps.                                          
+- internal/db/version.go — bumped to 0.18.14.                                                                                                                             
+                                                                                                                                                                        
+What to watch after deploying:                                                                                                                                            
+                                                                                                                                                                        
+1. Grep your log for prepared statement cache miss on SendBatch — that's the retry firing. A few per hour is expected and benign. A few per minute means keepalives aren't
+tight enough (tune per the doc) or workers need to drop. 
+2. Staging throughput should visibly improve — CacheStatement eliminates the per-query Parse+plan you were paying on every INSERT.                                        
+3. Consider dropping workers from 80 to 40 in aveloxis.json for the reason documented: each worker now does more DB throughput, and your Mac's network stack was the      
+self-inflicted bottleneck. 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -677,6 +677,23 @@ If the service outage is prolonged, the repo will fail after 10 retries and be r
 
 ---
 
+## `prepared statement "stmtcache_..." does not exist (SQLSTATE 26000)`
+
+**Symptom:** Log shows sporadic `ERROR: prepared statement "stmtcache_<hash>" does not exist (SQLSTATE 26000)` on staging flushes, followed a few lines later by `prepared statement cache miss on SendBatch — retrying once`.
+
+**Cause:** pgx's per-connection prepared-statement cache diverged from the server backend. A TCP connection between the aveloxis host and the Postgres host was silently replaced under heavy client load (NIC buffer pressure, kernel scheduling jitter, etc.) faster than the configured keepalive / idle-cycle could detect.
+
+**Solution:** No action needed on single occurrences -- v0.18.14 added a transparent single-shot retry on SQLSTATE 26000. The retry picks up a fresh connection from the pool, pgx re-prepares the statement, and the batch succeeds.
+
+**If you see sustained 26000s surviving the retry**, something more systemic is wrong. Investigate in this order:
+
+1. **Check your worker count.** On Mac-based deployments, `"workers": 80` can stress the kernel network stack hard enough to induce TCP instability. Try `"workers": 40` in `aveloxis.json` -- each worker does more DB throughput now that `CacheStatement` reuses plans, so 40 workers with `CacheStatement` is roughly equivalent to 80 workers with the older `CacheDescribe` from the DB's perspective, with dramatically less packet pressure on the client.
+2. **Ping the DB host under load.** Run `ping -i 1 <db-host>` while `aveloxis serve` is active and look for packet loss. Any drops indicate the client is saturating something (NIC, switch port queue, ephemeral-port pool) and reducing `workers` is the right move.
+3. **Check for pgbouncer.** If a pgbouncer in transaction or statement pooling mode has appeared in the path, `CacheStatement` cannot work -- pgbouncer shares backends across clients and prepared-statement names are connection-scoped. In `internal/db/postgres.go`, change `pgx.QueryExecModeCacheStatement` to `pgx.QueryExecModeCacheDescribe` (safe with all pgbouncer modes; gives up the plan-cache speedup but keeps client-side describe caching).
+4. **Tighten keepalives further.** The `appendKeepaliveParams` defaults (idle 60s, interval 10s, count 6 = ~2 min detection) are conservative. On a very flaky link, drop them to `keepalives_idle=30 keepalives_interval=5 keepalives_count=4` (~50 sec detection) in `internal/db/prepared_stmt_retry.go`.
+
+---
+
 ## Next steps
 
 - [Monitoring](monitoring.md) -- use the dashboard for real-time status

--- a/internal/collector/parallel_slots.go
+++ b/internal/collector/parallel_slots.go
@@ -1,0 +1,34 @@
+package collector
+
+// parallelSlotsForWorkers returns how many extra ParallelSlots a
+// large-repo parallel collection should claim, given the scheduler's
+// total worker count.
+//
+// The claim serves two purposes simultaneously:
+//
+//  1. Represent actual in-flight work: collectParallel forks 3
+//     goroutines (issues, PRs, events), so the floor is 3.
+//
+//  2. Signal "reserve bandwidth" to the scheduler: fillWorkerSlots
+//     stops claiming new jobs when len(sem)+extraSlots >= workers.
+//     A fixed claim of 3 on an 80-worker pool throttles only at 77
+//     active — effectively never — so the large repo's three
+//     goroutines end up competing with 79 other jobs for DB
+//     connections and API headroom. Scaling the claim to ~10% of
+//     the pool (8 on workers=80) makes the throttle kick in at 72
+//     active, actually reserving capacity for the big repo.
+//
+// The 30-worker break point is where legacy and scaled claims agree:
+// 30/10 == 3. Below that, returning workers/10 would drop below the
+// goroutine floor.
+func parallelSlotsForWorkers(workers int) int {
+	const legacyClaim = 3
+	if workers <= 30 {
+		return legacyClaim
+	}
+	scaled := workers / 10
+	if scaled < legacyClaim {
+		return legacyClaim
+	}
+	return scaled
+}

--- a/internal/collector/parallel_slots_test.go
+++ b/internal/collector/parallel_slots_test.go
@@ -1,0 +1,147 @@
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestParallelSlotsForWorkersSmallFleet pins the legacy claim of 3 slots
+// for worker counts at or below the scale-up threshold. collectParallel
+// only forks 3 goroutines (issues, PRs, events), so 3 is both the
+// minimum and the truthful count of extra concurrent work on small
+// fleets. Claiming more would reserve phantom capacity a small fleet
+// can't spare.
+func TestParallelSlotsForWorkersSmallFleet(t *testing.T) {
+	cases := []struct{ workers, want int }{
+		{0, 3},
+		{1, 3},
+		{10, 3},
+		{20, 3},
+		{29, 3},
+		{30, 3},
+	}
+	for _, c := range cases {
+		got := parallelSlotsForWorkers(c.workers)
+		if got != c.want {
+			t.Errorf("parallelSlotsForWorkers(%d) = %d, want %d", c.workers, got, c.want)
+		}
+	}
+}
+
+// TestParallelSlotsForWorkersLargeFleet verifies the claim scales to
+// ~10% of the worker pool once the pool grows past the small-fleet
+// band. This is what makes the scheduler's throttling rule at
+// fillWorkerSlots actually trigger — a fixed claim of 3 on an 80-worker
+// pool throttles only at 77 active workers, effectively never. At
+// workers=80, returning 8 makes fillWorkerSlots stop claiming new jobs
+// once 72 are busy, reserving bandwidth for the large repo's parallel
+// goroutines to actually make progress.
+func TestParallelSlotsForWorkersLargeFleet(t *testing.T) {
+	cases := []struct{ workers, want int }{
+		{40, 4},
+		{50, 5},
+		{60, 6},
+		{80, 8},
+		{100, 10},
+		{200, 20},
+	}
+	for _, c := range cases {
+		got := parallelSlotsForWorkers(c.workers)
+		if got != c.want {
+			t.Errorf("parallelSlotsForWorkers(%d) = %d, want %d", c.workers, got, c.want)
+		}
+	}
+}
+
+// TestParallelSlotsForWorkersMonotonic verifies the slot count never
+// decreases as worker count grows. A regression that, e.g., clamped
+// the claim to min(3, workers/10) for small fleets would break this
+// invariant and silently under-reserve for the 31–40 band.
+func TestParallelSlotsForWorkersMonotonic(t *testing.T) {
+	prev := 0
+	for w := 0; w <= 300; w++ {
+		got := parallelSlotsForWorkers(w)
+		if got < prev {
+			t.Fatalf("parallelSlotsForWorkers(%d) = %d, was %d at %d workers (not monotonic)",
+				w, got, prev, w-1)
+		}
+		prev = got
+	}
+}
+
+// TestParallelSlotsForWorkersNeverBelowThree verifies the function
+// never returns fewer than 3. collectParallel unconditionally forks
+// 3 goroutines; returning fewer would under-represent actual in-flight
+// work and the scheduler's throttle rule would leak real capacity.
+func TestParallelSlotsForWorkersNeverBelowThree(t *testing.T) {
+	for w := -5; w <= 500; w++ {
+		if got := parallelSlotsForWorkers(w); got < 3 {
+			t.Fatalf("parallelSlotsForWorkers(%d) = %d, must be >= 3", w, got)
+		}
+	}
+}
+
+// TestCollectParallelUsesScaledSlotHelper is a source-contract test
+// pinning that collectParallel uses parallelSlotsForWorkers rather
+// than a literal ParallelSlots.Add(3). A regression back to the
+// hardcoded constant would silently revert the v0.18.11 fix on
+// large worker pools.
+func TestCollectParallelUsesScaledSlotHelper(t *testing.T) {
+	data, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "parallelSlotsForWorkers") {
+		t.Error("staged.go must call parallelSlotsForWorkers to scale the ParallelSlots " +
+			"claim with the scheduler worker count")
+	}
+	if strings.Contains(src, "ParallelSlots.Add(3)") {
+		t.Error("staged.go still has a literal ParallelSlots.Add(3) — replace it with " +
+			"parallelSlotsForWorkers(sc.workers) so the claim scales with the pool")
+	}
+}
+
+// TestStagedCollectorCarriesWorkerCount pins that StagedCollector has
+// a workers field so collectParallel's slot scaling has a real number
+// to work with. A regression that dropped the field would make the
+// helper always fall back to the small-fleet constant.
+func TestStagedCollectorCarriesWorkerCount(t *testing.T) {
+	data, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// The struct must declare a workers field.
+	if !strings.Contains(src, "workers") {
+		t.Error("staged.go StagedCollector must carry a workers field so " +
+			"parallelSlotsForWorkers has the current scheduler worker count")
+	}
+}
+
+// TestSchedulerPassesWorkerCountToCollector pins that the scheduler
+// actually propagates its configured Workers into StagedCollector —
+// otherwise the plumbing exists but the field stays at zero and the
+// scaling helper silently uses the small-fleet fallback forever.
+func TestSchedulerPassesWorkerCountToCollector(t *testing.T) {
+	data, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// The scheduler must reference s.cfg.Workers when constructing
+	// or configuring a StagedCollector. Accept either a new
+	// constructor signature or a setter/builder call.
+	if !strings.Contains(src, "s.cfg.Workers") {
+		t.Error("scheduler.go must pass s.cfg.Workers into StagedCollector so the " +
+			"parallel-slot claim scales with the pool")
+	}
+	// Belt-and-suspenders: the scheduler file must show Workers
+	// flowing into the staged collector construction path.
+	if !strings.Contains(src, "WithWorkers") && !strings.Contains(src, "Workers:") &&
+		!strings.Contains(src, ", s.cfg.Workers") {
+		t.Error("scheduler.go must wire s.cfg.Workers into the StagedCollector — either via " +
+			"a WithWorkers builder, a Workers struct field, or a constructor argument")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -105,6 +105,20 @@ type StagedCollector struct {
 	listingMode   string // "rest" (default) or "graphql" — see CollectionConfig.ListingMode
 	threadingMode string // "single" (default) or "sharded" — see CollectionConfig.ThreadingMode
 	shardSize     int    // item-count threshold for sharded fan-out (default 3000)
+	workers       int    // scheduler worker pool size — feeds parallelSlotsForWorkers
+}
+
+// WithWorkers records the scheduler's worker-pool size on a
+// StagedCollector so collectParallel can scale its ParallelSlots
+// claim (see parallelSlotsForWorkers). Returns the same collector
+// for chaining. A zero or negative value leaves the legacy 3-slot
+// fallback in place.
+func (sc *StagedCollector) WithWorkers(n int) *StagedCollector {
+	if n < 0 {
+		n = 0
+	}
+	sc.workers = n
+	return sc
 }
 
 // NewStagedCollector creates a staged collector in the fully-default
@@ -384,12 +398,15 @@ func (sc *StagedCollector) fullGraphQLMode() bool {
 
 // collectParallel runs issues, PRs, and events concurrently in 3 goroutines,
 // each with its own StagingWriter for thread safety. The parent waits for all
-// three to complete before collecting messages. Claims 3 extra parallel slots
-// from the global counter so fillWorkerSlots can respect the capacity.
+// three to complete before collecting messages. Claims ParallelSlots so
+// fillWorkerSlots can respect the reserved capacity — see
+// parallelSlotsForWorkers for why the claim scales with worker count.
 func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, owner, repo string, since time.Time, result *CollectResult) {
-	// Claim 3 extra parallel slots.
-	ParallelSlots.Add(3)
-	defer ParallelSlots.Add(-3)
+	// Claim extra parallel slots scaled to the worker pool so the
+	// scheduler's throttle rule actually engages on large fleets.
+	slots := int32(parallelSlotsForWorkers(sc.workers))
+	ParallelSlots.Add(slots)
+	defer ParallelSlots.Add(-slots)
 
 	// Pre-enumerate once before forking goroutines when listingMode is
 	// graphql. Calling ListIssuesAndPRs in each child goroutine would

--- a/internal/db/pool_test.go
+++ b/internal/db/pool_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestNewPostgresStoreAcceptsMaxConns verifies the constructor supports an
@@ -127,115 +129,112 @@ func TestPoolCyclesIdleConnections(t *testing.T) {
 	}
 }
 
-// TestPoolAppendsKeepaliveParams verifies NewPostgresStore amends the
-// connection string with libpq-compatible TCP keepalive settings so
-// pgx's dialer installs aggressive kernel-level keepalive probes on
-// every pooled socket.
+// TestPoolInstallsKeepaliveDialer verifies NewPostgresStore installs
+// a custom DialFunc that configures TCP_KEEPIDLE/INTVL/CNT on every
+// pooled socket via net.KeepAliveConfig.
 //
-// Without these, macOS + Linux defaults give ~2h of silence before a
-// dead socket is detected — long enough that pgx's per-connection
-// prepared-statement cache diverges from the server and the next
-// SendBatch hits SQLSTATE 26000 (the v0.18.11 failure we retried
-// around in v0.18.14 via sendBatchWithRetry).
+// Why not conn-string params: pgx v5 does NOT parse libpq's
+// keepalives_idle / keepalives_interval / keepalives_count from
+// either URL or keyword-form conn strings. Unrecognized keys get
+// forwarded to the server as StartupMessage RuntimeParams, and
+// Postgres responds with FATAL "unrecognized configuration
+// parameter 'keepalives_idle' (SQLSTATE 42704)" — observed in
+// production when v0.18.14 first shipped with the conn-string
+// approach.
 //
-// With keepalives_idle=60 / keepalives_interval=10 / keepalives_count=6,
-// the kernel declares a silent socket dead in ~2 minutes, pgxpool
-// evicts it, and the stale-cache race window shrinks dramatically.
-// The retry wrapper handles the residue; keepalives keep the residue
-// small.
+// The correct pgx-v5 path is a custom DialFunc that builds a
+// net.Dialer with KeepAliveConfig set, requires Go 1.23+.
 //
-// The constant and helper live in prepared_stmt_retry.go alongside
-// the retry wrapper — the two defenses are a package deal and
-// belong next to each other.
-func TestPoolAppendsKeepaliveParams(t *testing.T) {
-	// The hot-path wiring: NewPostgresStore must call the helper.
+// Why it matters: without a tighter-than-default keepalive
+// configuration, macOS + Linux give ~2h of silence before a dead
+// socket is detected. At 60s idle + 10s interval × 6 probes we
+// detect in ~2 minutes, pgxpool evicts the broken connection, and
+// the v0.18.11 "SQLSTATE 26000" race window shrinks dramatically.
+// sendBatchWithRetry handles any residue.
+func TestPoolInstallsKeepaliveDialer(t *testing.T) {
+	// Hot-path wiring: NewPostgresStore must call the installer
+	// after ParseConfig so the dialer is set on the pool's
+	// ConnConfig before pgxpool.NewWithConfig.
 	pgData, err := os.ReadFile("postgres.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(pgData), "appendKeepaliveParams(connString)") {
-		t.Error("NewPostgresStore must call appendKeepaliveParams(connString) " +
-			"before pgxpool.ParseConfig so every pooled socket gets the " +
-			"keepalive settings")
+	pgSrc := string(pgData)
+	if !strings.Contains(pgSrc, "installKeepaliveDialer(cfg)") {
+		t.Error("NewPostgresStore must call installKeepaliveDialer(cfg) after " +
+			"pgxpool.ParseConfig so every pooled socket gets TCP keepalives " +
+			"set via net.KeepAliveConfig (not via libpq-style conn-string " +
+			"params, which pgx v5 forwards to Postgres as unknown runtime " +
+			"parameters and causes 42704 on connect)")
+	}
+	// Defensive: the old conn-string approach must be gone. Keeping
+	// both would send keepalives= to Postgres as a RuntimeParam and
+	// the FATAL 42704 startup error would return.
+	if strings.Contains(pgSrc, "appendKeepaliveParams") {
+		t.Error("postgres.go still references appendKeepaliveParams — the conn-" +
+			"string approach was removed in v0.18.14 because pgx v5 forwards " +
+			"the params to Postgres as runtime parameters (FATAL 42704)")
 	}
 
-	// The params themselves: must live in the helper file.
 	helperData, err := os.ReadFile("prepared_stmt_retry.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	helperSrc := string(helperData)
 	required := []string{
-		"keepalives=1",
-		"keepalives_idle=60",
-		"keepalives_interval=10",
-		"keepalives_count=6",
-		"connect_timeout=10",
+		"installKeepaliveDialer",
+		"net.KeepAliveConfig",
+		"DialFunc",
+		"Idle:",
+		"Interval:",
+		"Count:",
 	}
 	for _, want := range required {
 		if !strings.Contains(helperSrc, want) {
-			t.Errorf("prepared_stmt_retry.go must define keepalive param %q "+
-				"so kernel TCP keepalives detect dead sockets in ~2 minutes "+
-				"instead of the OS default 2 hours", want)
+			t.Errorf("prepared_stmt_retry.go must contain %q so the installer "+
+				"wires TCP keepalive socket options via net.KeepAliveConfig", want)
 		}
 	}
-}
-
-// TestAppendKeepaliveParams_URLForm — runtime behavior check on the
-// helper. Must merge the params into URL-form conn strings correctly,
-// whether or not the caller already included other query params.
-func TestAppendKeepaliveParams_URLForm(t *testing.T) {
-	cases := []struct {
-		name, in string
-		want     []string // substrings that must appear in the output
-	}{
-		{
-			name: "with existing query",
-			in:   "postgres://u:p@h:5432/db?sslmode=prefer",
-			want: []string{"sslmode=prefer", "&keepalives=1", "keepalives_idle=60"},
-		},
-		{
-			name: "without query",
-			in:   "postgres://u:p@h:5432/db",
-			want: []string{"?keepalives=1", "keepalives_idle=60"},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := appendKeepaliveParams(tc.in)
-			for _, w := range tc.want {
-				if !strings.Contains(got, w) {
-					t.Errorf("output %q must contain %q", got, w)
-				}
-			}
-		})
+	// The const-string keepalive params from the first v0.18.14
+	// attempt must be gone.
+	if strings.Contains(helperSrc, "keepalives=1") {
+		t.Error("prepared_stmt_retry.go still contains a libpq-style " +
+			"keepalive param string — remove it so pgx doesn't forward " +
+			"these keys to Postgres as runtime params")
 	}
 }
 
-// TestAppendKeepaliveParams_Idempotent — if the caller already set
-// keepalives=, the helper must not clobber or duplicate. Per-
-// deployment overrides have to survive the merge.
-func TestAppendKeepaliveParams_Idempotent(t *testing.T) {
-	in := "postgres://u:p@h:5432/db?sslmode=prefer&keepalives=1&keepalives_idle=30"
-	got := appendKeepaliveParams(in)
-	if got != in {
-		t.Errorf("appendKeepaliveParams must be a no-op when keepalives= is already set\n  in:  %s\n  got: %s", in, got)
+// TestInstallKeepaliveDialer_SetsDialFuncAndTimeout — runtime
+// behavior check. The installer must populate DialFunc (replacing
+// pgx's default) and ConnectTimeout on the pool config.
+//
+// ConnectTimeout going from 0 → non-zero is the cheapest observable
+// signal that the installer ran. We don't try to compare DialFunc
+// pointers (Go forbids function equality) but we do verify a non-
+// nil function is present after installation — pgxpool.ParseConfig
+// sets its own default, so this mostly guards "the installer did
+// not forget to set a DialFunc at all".
+func TestInstallKeepaliveDialer_SetsDialFuncAndTimeout(t *testing.T) {
+	// Build a minimal config — ParseConfig doesn't actually connect,
+	// so any well-formed DSN is fine here.
+	cfg, err := pgxpool.ParseConfig("postgres://u:p@localhost:5432/test?sslmode=disable")
+	if err != nil {
+		t.Fatalf("ParseConfig failed on test DSN: %v", err)
 	}
-}
+	beforeTimeout := cfg.ConnConfig.ConnectTimeout
 
-// TestAppendKeepaliveParams_KeywordForm — libpq keyword-form conn
-// strings use space-separated key=value pairs, not URL query syntax.
-// The helper must emit the right shape.
-func TestAppendKeepaliveParams_KeywordForm(t *testing.T) {
-	in := "host=h port=5432 user=u dbname=db sslmode=prefer"
-	got := appendKeepaliveParams(in)
-	if !strings.Contains(got, "host=h") {
-		t.Errorf("original fields must survive: %s", got)
+	installKeepaliveDialer(cfg)
+
+	if cfg.ConnConfig.DialFunc == nil {
+		t.Error("installKeepaliveDialer must set cfg.ConnConfig.DialFunc")
 	}
-	if !strings.Contains(got, " keepalives=1") {
-		t.Errorf("keyword-form output must use space-separator for new params: %s", got)
+	if cfg.ConnConfig.ConnectTimeout == beforeTimeout {
+		t.Errorf("installKeepaliveDialer must change ConnectTimeout from its "+
+			"pre-install value %v so a misconfigured host fails fast instead "+
+			"of blocking on the default kernel syn timeout",
+			beforeTimeout)
 	}
-	if strings.Contains(got, "&keepalives") {
-		t.Errorf("keyword-form output must NOT use URL-query '&' separator: %s", got)
+	if cfg.ConnConfig.ConnectTimeout == 0 {
+		t.Error("installKeepaliveDialer must set a non-zero ConnectTimeout")
 	}
 }

--- a/internal/db/pool_test.go
+++ b/internal/db/pool_test.go
@@ -41,30 +41,45 @@ func TestDefaultPoolSizeIsReasonable(t *testing.T) {
 	}
 }
 
-// TestPoolDisablesStatementCache verifies NewPostgresStore configures pgx
-// to NOT cache server-side prepared-statement names per connection.
+// TestPoolUsesStatementCache verifies NewPostgresStore configures pgx to
+// cache prepared statements on each pooled connection.
 //
-// Background: pgx v5's default is QueryExecModeCacheStatement, which assigns
-// names like "stmtcache_<hash>" and re-uses them. Any event that silently
-// swaps the TCP connection's backend — pgbouncer in txn/statement pool mode,
-// a stateful NAT/firewall/cloud LB expiring an idle connection, a DB
-// restart mid-collection — leaves pgx's client cache out of sync and
-// SendBatch fails with SQLSTATE 26000 "prepared statement does not exist".
-// QueryExecModeExec re-prepares per call as an unnamed statement, so
-// there is no cache to go stale.
+// Background: pgx v5's QueryExecModeCacheStatement assigns server-side
+// statement names ("stmtcache_<hash>") and re-uses them, so repeat queries
+// skip Parse+Describe on the server — a meaningful win on the hot
+// INSERT/SELECT paths when the DB is on a LAN rather than a loopback
+// socket.
 //
-// Regressing this flag out would reintroduce the gap-fill / refresh-open
-// batch flush failures we chased in v0.18.10.
-func TestPoolDisablesStatementCache(t *testing.T) {
+// The v0.18.10 deployment briefly used QueryExecModeExec as a defensive
+// patch against SQLSTATE 26000 "prepared statement does not exist"
+// surprises when a TCP connection got silently swapped under pgx — seen
+// in NAT/firewall/pgbouncer deployments. For the direct-Postgres LAN
+// setup this code targets, that risk is covered by cfg.MaxConnIdleTime
+// (4 min) cycling connections before NAT timeouts, so we get the
+// caching win without the correctness hazard.
+//
+// If a pgbouncer in transaction or statement pooling mode ever appears
+// in front of the DB, revert this flag to QueryExecModeExec (or switch
+// to QueryExecModeCacheDescribe) — prepared statements are connection-
+// scoped and transaction-pooling breaks the cache.
+func TestPoolUsesStatementCache(t *testing.T) {
 	data, err := os.ReadFile("postgres.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	src := string(data)
-	if !strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec") {
-		t.Error("postgres.go must set cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec " +
-			"to avoid SQLSTATE 26000 when a TCP connection is silently replaced by an upstream " +
-			"NAT/firewall/pgbouncer")
+	if !strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement") {
+		t.Error("postgres.go must set cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement " +
+			"so repeat queries skip server-side Parse+Describe on the hot INSERT/SELECT paths. " +
+			"Revert to QueryExecModeExec only if a pgbouncer in txn/statement pooling mode is " +
+			"introduced in front of the DB.")
+	}
+	// Defensive: the legacy Exec-mode line must not linger alongside the
+	// new one — that would set the field twice and the second assignment
+	// would win silently.
+	if strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec") {
+		t.Error("postgres.go still contains a QueryExecModeExec assignment — remove it so only " +
+			"the CacheStatement line remains as the single source of truth")
 	}
 }
 

--- a/internal/db/pool_test.go
+++ b/internal/db/pool_test.go
@@ -41,28 +41,45 @@ func TestDefaultPoolSizeIsReasonable(t *testing.T) {
 	}
 }
 
-// TestPoolUsesStatementCache verifies NewPostgresStore configures pgx to
-// cache prepared statements on each pooled connection.
+// TestPoolUsesCacheStatement verifies NewPostgresStore configures pgx
+// to cache server-side prepared statements on each pooled connection.
 //
-// Background: pgx v5's QueryExecModeCacheStatement assigns server-side
-// statement names ("stmtcache_<hash>") and re-uses them, so repeat queries
-// skip Parse+Describe on the server — a meaningful win on the hot
-// INSERT/SELECT paths when the DB is on a LAN rather than a loopback
-// socket.
+// Why this is worth the server-side handle risk:
 //
-// The v0.18.10 deployment briefly used QueryExecModeExec as a defensive
-// patch against SQLSTATE 26000 "prepared statement does not exist"
-// surprises when a TCP connection got silently swapped under pgx — seen
-// in NAT/firewall/pgbouncer deployments. For the direct-Postgres LAN
-// setup this code targets, that risk is covered by cfg.MaxConnIdleTime
-// (4 min) cycling connections before NAT timeouts, so we get the
-// caching win without the correctness hazard.
+//   - v0.18.10 used QueryExecModeExec. Safe but every query paid for
+//     a full server-side Parse+plan. On a LAN (vs loopback) that
+//     overhead dominated.
 //
-// If a pgbouncer in transaction or statement pooling mode ever appears
-// in front of the DB, revert this flag to QueryExecModeExec (or switch
-// to QueryExecModeCacheDescribe) — prepared statements are connection-
-// scoped and transaction-pooling breaks the cache.
-func TestPoolUsesStatementCache(t *testing.T) {
+//   - v0.18.11 switched to CacheStatement. Fast but produced a swarm
+//     of SQLSTATE 26000 "prepared statement does not exist" errors
+//     under heavy concurrent load, even with no pgbouncer. Root
+//     cause (diagnosed v0.18.14): aveloxis's own 80-worker load on
+//     the client mac stressed the network stack enough that TCP
+//     connections were being silently swapped faster than the
+//     4-minute MaxConnIdleTime could defend against. Kernel
+//     keepalive detection window on both sides was ~2 hours by
+//     default, leaving a huge race.
+//
+//   - v0.18.12 retreated to CacheDescribe. Safe, but gave back
+//     essentially all of the CacheStatement speedup because server-
+//     side Parse+plan was still happening on every query.
+//
+//   - v0.18.14 (this): CacheStatement again, with two new
+//     defenses — aggressive TCP keepalives via
+//     appendKeepaliveParams (detect dead sockets in ~2 minutes,
+//     not 2 hours) AND a SendBatch retry wrapper (prepared_stmt_
+//     retry.go) that recovers from any residual 26000 by re-
+//     executing the batch once on a fresh connection.
+//
+// Reversion triggers:
+//   - Repeated 26000 errors surviving the retry (the retry is
+//     single-shot on purpose; sustained failures mean something
+//     systemic is wrong).
+//   - A pgbouncer in transaction or statement pooling mode appears
+//     in the path.
+//
+// Revert to QueryExecModeCacheDescribe if either of those shows up.
+func TestPoolUsesCacheStatement(t *testing.T) {
 	data, err := os.ReadFile("postgres.go")
 	if err != nil {
 		t.Fatal(err)
@@ -70,13 +87,20 @@ func TestPoolUsesStatementCache(t *testing.T) {
 	src := string(data)
 	if !strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement") {
 		t.Error("postgres.go must set cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement " +
-			"so repeat queries skip server-side Parse+Describe on the hot INSERT/SELECT paths. " +
-			"Revert to QueryExecModeExec only if a pgbouncer in txn/statement pooling mode is " +
-			"introduced in front of the DB.")
+			"to reuse server-side prepared statements on the hot INSERT/SELECT paths. Revert to " +
+			"QueryExecModeCacheDescribe only if the keepalive + retry defenses from v0.18.14 prove " +
+			"insufficient (sustained 26000s surviving sendBatchWithRetry) or if pgbouncer appears " +
+			"in txn/statement pooling mode.")
 	}
-	// Defensive: the legacy Exec-mode line must not linger alongside the
-	// new one — that would set the field twice and the second assignment
-	// would win silently.
+	// Defensive: the old modes must not linger alongside the new one.
+	// A second assignment would silently win and either reintroduce
+	// the v0.18.10 Parse-per-query cost (Exec) or the v0.18.12
+	// Parse+plan-per-query cost (CacheDescribe).
+	if strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe") {
+		t.Error("postgres.go still contains a QueryExecModeCacheDescribe assignment — remove it so " +
+			"only the CacheStatement line remains (v0.18.14 moved back to CacheStatement with " +
+			"keepalive + retry defenses)")
+	}
 	if strings.Contains(src, "cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec") {
 		t.Error("postgres.go still contains a QueryExecModeExec assignment — remove it so only " +
 			"the CacheStatement line remains as the single source of truth")
@@ -100,5 +124,118 @@ func TestPoolCyclesIdleConnections(t *testing.T) {
 	if !strings.Contains(src, "cfg.MaxConnLifetime") {
 		t.Error("postgres.go must set cfg.MaxConnLifetime to cap total connection age " +
 			"so credential rotation / failover eventually reaches every connection")
+	}
+}
+
+// TestPoolAppendsKeepaliveParams verifies NewPostgresStore amends the
+// connection string with libpq-compatible TCP keepalive settings so
+// pgx's dialer installs aggressive kernel-level keepalive probes on
+// every pooled socket.
+//
+// Without these, macOS + Linux defaults give ~2h of silence before a
+// dead socket is detected — long enough that pgx's per-connection
+// prepared-statement cache diverges from the server and the next
+// SendBatch hits SQLSTATE 26000 (the v0.18.11 failure we retried
+// around in v0.18.14 via sendBatchWithRetry).
+//
+// With keepalives_idle=60 / keepalives_interval=10 / keepalives_count=6,
+// the kernel declares a silent socket dead in ~2 minutes, pgxpool
+// evicts it, and the stale-cache race window shrinks dramatically.
+// The retry wrapper handles the residue; keepalives keep the residue
+// small.
+//
+// The constant and helper live in prepared_stmt_retry.go alongside
+// the retry wrapper — the two defenses are a package deal and
+// belong next to each other.
+func TestPoolAppendsKeepaliveParams(t *testing.T) {
+	// The hot-path wiring: NewPostgresStore must call the helper.
+	pgData, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(pgData), "appendKeepaliveParams(connString)") {
+		t.Error("NewPostgresStore must call appendKeepaliveParams(connString) " +
+			"before pgxpool.ParseConfig so every pooled socket gets the " +
+			"keepalive settings")
+	}
+
+	// The params themselves: must live in the helper file.
+	helperData, err := os.ReadFile("prepared_stmt_retry.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helperSrc := string(helperData)
+	required := []string{
+		"keepalives=1",
+		"keepalives_idle=60",
+		"keepalives_interval=10",
+		"keepalives_count=6",
+		"connect_timeout=10",
+	}
+	for _, want := range required {
+		if !strings.Contains(helperSrc, want) {
+			t.Errorf("prepared_stmt_retry.go must define keepalive param %q "+
+				"so kernel TCP keepalives detect dead sockets in ~2 minutes "+
+				"instead of the OS default 2 hours", want)
+		}
+	}
+}
+
+// TestAppendKeepaliveParams_URLForm — runtime behavior check on the
+// helper. Must merge the params into URL-form conn strings correctly,
+// whether or not the caller already included other query params.
+func TestAppendKeepaliveParams_URLForm(t *testing.T) {
+	cases := []struct {
+		name, in string
+		want     []string // substrings that must appear in the output
+	}{
+		{
+			name: "with existing query",
+			in:   "postgres://u:p@h:5432/db?sslmode=prefer",
+			want: []string{"sslmode=prefer", "&keepalives=1", "keepalives_idle=60"},
+		},
+		{
+			name: "without query",
+			in:   "postgres://u:p@h:5432/db",
+			want: []string{"?keepalives=1", "keepalives_idle=60"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendKeepaliveParams(tc.in)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("output %q must contain %q", got, w)
+				}
+			}
+		})
+	}
+}
+
+// TestAppendKeepaliveParams_Idempotent — if the caller already set
+// keepalives=, the helper must not clobber or duplicate. Per-
+// deployment overrides have to survive the merge.
+func TestAppendKeepaliveParams_Idempotent(t *testing.T) {
+	in := "postgres://u:p@h:5432/db?sslmode=prefer&keepalives=1&keepalives_idle=30"
+	got := appendKeepaliveParams(in)
+	if got != in {
+		t.Errorf("appendKeepaliveParams must be a no-op when keepalives= is already set\n  in:  %s\n  got: %s", in, got)
+	}
+}
+
+// TestAppendKeepaliveParams_KeywordForm — libpq keyword-form conn
+// strings use space-separated key=value pairs, not URL query syntax.
+// The helper must emit the right shape.
+func TestAppendKeepaliveParams_KeywordForm(t *testing.T) {
+	in := "host=h port=5432 user=u dbname=db sslmode=prefer"
+	got := appendKeepaliveParams(in)
+	if !strings.Contains(got, "host=h") {
+		t.Errorf("original fields must survive: %s", got)
+	}
+	if !strings.Contains(got, " keepalives=1") {
+		t.Errorf("keyword-form output must use space-separator for new params: %s", got)
+	}
+	if strings.Contains(got, "&keepalives") {
+		t.Errorf("keyword-form output must NOT use URL-query '&' separator: %s", got)
 	}
 }

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -29,6 +29,7 @@ type PostgresStore struct {
 // For scheduler use, pass workers+15 so collection workers don't starve
 // each other for database connections.
 func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logger, maxConns ...int32) (*PostgresStore, error) {
+	connString = appendKeepaliveParams(connString)
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, fmt.Errorf("parsing connection string: %w", err)
@@ -39,27 +40,49 @@ func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logge
 	}
 	cfg.MinConns = 2
 
-	// Use pgx's per-connection prepared-statement cache. Server-side
-	// statement names ("stmtcache_...") let repeat queries skip Parse +
-	// Describe on every call — a meaningful win on the hot INSERT /
-	// SELECT paths when the DB is on a LAN rather than a loopback
-	// socket.
+	// Cache server-side prepared statements on each pooled
+	// connection. Named statements ("stmtcache_<hash>") let repeat
+	// queries skip Parse+plan on the server — the real cost on the
+	// hot INSERT/SELECT paths when the DB is on a LAN rather than a
+	// loopback socket.
 	//
-	// The correctness hazard this mode carries is SQLSTATE 26000
+	// The correctness hazard of this mode is SQLSTATE 26000
 	// "prepared statement does not exist" when a TCP connection is
-	// silently replaced out from under pgx (pgbouncer in transaction
-	// or statement pooling mode, or a stateful NAT/firewall/cloud LB
-	// expiring an idle connection). For the direct-Postgres LAN
-	// deployment this code targets, MaxConnIdleTime (4 min, below) is
-	// set below the typical 5-minute NAT idle timeout so pgx cycles
-	// connections before upstream gear does — the cache stays in sync.
+	// silently replaced out from under pgx. v0.18.14 adds two
+	// defenses that together keep this path safe for direct-Postgres
+	// LAN deployments:
 	//
-	// If a pgbouncer in txn/statement pooling mode ever appears in
-	// front of the DB, swap this to QueryExecModeExec (unnamed
-	// statements, no client cache) or QueryExecModeCacheDescribe
-	// (cache type info but not server-side names). Prepared statements
-	// are connection-scoped; transaction pooling shares backends
-	// across clients and the cache goes stale immediately.
+	//   1. appendKeepaliveParams (prepared_stmt_retry.go) merges
+	//      libpq keepalive settings into the conn string so pgx's
+	//      dialer sets TCP_KEEPIDLE/INTVL/CNT on every socket. A
+	//      silently-dead socket is detected in ~2 minutes instead
+	//      of the OS default 2 hours, and pgxpool evicts it before
+	//      the cache can fire many queries at a swapped backend.
+	//
+	//   2. sendBatchWithRetry (prepared_stmt_retry.go) wraps
+	//      pool.SendBatch to retry once on SQLSTATE 26000. The
+	//      retry picks up a fresh connection from the pool and the
+	//      batch succeeds. Residual races during the keepalive
+	//      window become single transparent retries instead of
+	//      500-row batch data loss.
+	//
+	// Full incident record leading to the v0.18.14 configuration:
+	//
+	//   - v0.18.10  QueryExecModeExec. Safe everywhere (no cache),
+	//               but Parse+plan on every query dominated cost
+	//               once the DB moved off loopback.
+	//   - v0.18.11  Flipped to CacheStatement. Hit SQLSTATE 26000
+	//               within hours — client load was stressing TCP
+	//               faster than MaxConnIdleTime could defend.
+	//   - v0.18.12  Retreated to CacheDescribe. Safe, but server-
+	//               side Parse+plan still ran per query — most of
+	//               the CacheStatement speedup never materialized.
+	//   - v0.18.14  Back to CacheStatement with keepalive + retry.
+	//
+	// Reversion triggers: sustained 26000s surviving the retry, or
+	// pgbouncer landing in front of the DB in txn/statement pooling
+	// mode. In either case, swap to QueryExecModeCacheDescribe (or
+	// QueryExecModeExec for absolute safety).
 	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement
 
 	// Cycle idle connections before network gear does. The common NAT

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -29,11 +29,15 @@ type PostgresStore struct {
 // For scheduler use, pass workers+15 so collection workers don't starve
 // each other for database connections.
 func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logger, maxConns ...int32) (*PostgresStore, error) {
-	connString = appendKeepaliveParams(connString)
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, fmt.Errorf("parsing connection string: %w", err)
 	}
+	// Install TCP keepalives via a custom DialFunc so every pooled
+	// socket detects dead peers in ~2 minutes instead of the OS
+	// default 2 hours. See installKeepaliveDialer for why this is
+	// not done via conn-string params.
+	installKeepaliveDialer(cfg)
 	cfg.MaxConns = 20
 	if len(maxConns) > 0 && maxConns[0] > 0 {
 		cfg.MaxConns = maxConns[0]
@@ -52,12 +56,15 @@ func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logge
 	// defenses that together keep this path safe for direct-Postgres
 	// LAN deployments:
 	//
-	//   1. appendKeepaliveParams (prepared_stmt_retry.go) merges
-	//      libpq keepalive settings into the conn string so pgx's
-	//      dialer sets TCP_KEEPIDLE/INTVL/CNT on every socket. A
-	//      silently-dead socket is detected in ~2 minutes instead
-	//      of the OS default 2 hours, and pgxpool evicts it before
+	//   1. installKeepaliveDialer (prepared_stmt_retry.go) sets a
+	//      custom pgconn DialFunc that builds every socket with
+	//      net.KeepAliveConfig — TCP_KEEPIDLE/INTVL/CNT tuned for
+	//      ~2-minute dead-peer detection instead of the OS default
+	//      2 hours. pgxpool evicts the broken connection before
 	//      the cache can fire many queries at a swapped backend.
+	//      (Libpq-style conn-string keepalive params do NOT work —
+	//      pgx v5 forwards them to Postgres as RuntimeParams and
+	//      the startup fails with FATAL 42704.)
 	//
 	//   2. sendBatchWithRetry (prepared_stmt_retry.go) wraps
 	//      pool.SendBatch to retry once on SQLSTATE 26000. The

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -39,18 +39,28 @@ func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logge
 	}
 	cfg.MinConns = 2
 
-	// Avoid pgx's per-connection prepared-statement cache. The default
-	// QueryExecModeCacheStatement assigns server-side statement names
-	// ("stmtcache_...") and re-uses them across queries — which breaks
-	// as SQLSTATE 26000 "prepared statement does not exist" whenever a
-	// TCP connection gets silently replaced out from under pgx. That
-	// happens under pgbouncer (transaction/statement pooling) AND
-	// across stateful NAT/firewalls/cloud LBs with idle-connection
-	// timeouts when the DB is on a different host. QueryExecModeExec
-	// uses the extended protocol with unnamed statements — re-prepared
-	// per call, no client-side cache to go stale. Tiny per-query
-	// overhead; no correctness loss.
-	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	// Use pgx's per-connection prepared-statement cache. Server-side
+	// statement names ("stmtcache_...") let repeat queries skip Parse +
+	// Describe on every call — a meaningful win on the hot INSERT /
+	// SELECT paths when the DB is on a LAN rather than a loopback
+	// socket.
+	//
+	// The correctness hazard this mode carries is SQLSTATE 26000
+	// "prepared statement does not exist" when a TCP connection is
+	// silently replaced out from under pgx (pgbouncer in transaction
+	// or statement pooling mode, or a stateful NAT/firewall/cloud LB
+	// expiring an idle connection). For the direct-Postgres LAN
+	// deployment this code targets, MaxConnIdleTime (4 min, below) is
+	// set below the typical 5-minute NAT idle timeout so pgx cycles
+	// connections before upstream gear does — the cache stays in sync.
+	//
+	// If a pgbouncer in txn/statement pooling mode ever appears in
+	// front of the DB, swap this to QueryExecModeExec (unnamed
+	// statements, no client cache) or QueryExecModeCacheDescribe
+	// (cache type info but not server-side names). Prepared statements
+	// are connection-scoped; transaction pooling shares backends
+	// across clients and the cache goes stale immediately.
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheStatement
 
 	// Cycle idle connections before network gear does. The common NAT
 	// idle timeout is 5 minutes; we cycle at 4 so pgx opens a fresh

--- a/internal/db/prepared_stmt_retry.go
+++ b/internal/db/prepared_stmt_retry.go
@@ -3,58 +3,13 @@ package db
 import (
 	"context"
 	"errors"
-	"strings"
+	"net"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-// keepaliveParams are the libpq-compatible TCP keepalive settings
-// appended to the pgx connection string by appendKeepaliveParams.
-// pgx's dialer reads these and sets TCP_KEEPIDLE / TCP_KEEPINTVL /
-// TCP_KEEPCNT on every pooled socket.
-//
-// Values tuned for dead-socket detection in ~2 minutes (60 idle + 6
-// probes × 10s interval), which is fast enough that pgxpool evicts
-// the broken connection before the per-connection prepared-statement
-// cache can fire many queries at a swapped backend. The
-// sendBatchWithRetry wrapper handles any residual race.
-//
-// connect_timeout=10 caps initial dial time so a misconfigured host
-// fails fast instead of blocking the scheduler's startup-Migrate
-// path for the default 2-minute kernel syn timeout.
-const keepaliveParams = "keepalives=1&keepalives_idle=60&keepalives_interval=10&keepalives_count=6&connect_timeout=10"
-
-// appendKeepaliveParams merges keepaliveParams into a pgx connection
-// string. Idempotent: if the caller already set keepalives=, returns
-// the string unchanged so per-deployment overrides survive.
-//
-// Handles both URL-form ("postgres://user:pass@host:port/db?sslmode=prefer")
-// and libpq keyword-form ("host=... port=... sslmode=prefer") conn
-// strings. ConnectionString() in internal/config/config.go emits
-// URL-form today, but pgx accepts both.
-func appendKeepaliveParams(connString string) string {
-	if strings.Contains(connString, "keepalives=") {
-		return connString
-	}
-	if strings.Contains(connString, "://") {
-		// URL form — query string gets an extra param. If there's
-		// no query string yet, start one with '?'; otherwise extend
-		// with '&'.
-		sep := "&"
-		if !strings.Contains(connString, "?") {
-			sep = "?"
-		}
-		return connString + sep + keepaliveParams
-	}
-	// Keyword form — space-separated key=value pairs. Convert the
-	// '&'-joined keepalive string to space-joined.
-	kw := strings.ReplaceAll(keepaliveParams, "&", " ")
-	if connString == "" {
-		return kw
-	}
-	return connString + " " + kw
-}
 
 // staleStatementSQLSTATE is the PostgreSQL error code for "prepared
 // statement does not exist" — the symptom when pgx's per-connection
@@ -108,4 +63,47 @@ func (s *PostgresStore) sendBatchWithRetry(ctx context.Context, batch *pgx.Batch
 	s.logger.Warn("prepared statement cache miss on SendBatch — retrying once",
 		"sqlstate", staleStatementSQLSTATE, "rows", batch.Len(), "error", err)
 	return s.pool.SendBatch(ctx, batch).Close()
+}
+
+// keepaliveIdle, keepaliveInterval, keepaliveCount tune dead-socket
+// detection. At 60s idle + 6 probes × 10s interval the kernel
+// declares a silent socket dead in ~2 minutes, pgxpool evicts it,
+// and the stale-prepared-statement race window shrinks dramatically.
+// Values are deliberately conservative; tighten further if a
+// deployment has a very flaky link.
+const (
+	keepaliveIdle     = 60 * time.Second
+	keepaliveInterval = 10 * time.Second
+	keepaliveCount    = 6
+	connectTimeout    = 10 * time.Second
+)
+
+// installKeepaliveDialer configures a custom pgconn DialFunc that
+// sets TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT on every pooled
+// socket via net.KeepAliveConfig (Go 1.23+). Also sets
+// ConnectTimeout so a misconfigured host fails fast instead of
+// blocking the scheduler's startup-Migrate path on the default
+// kernel syn timeout.
+//
+// WHY NOT CONN-STRING PARAMS: pgx v5 does NOT parse libpq's
+// keepalives / keepalives_idle / keepalives_interval / keepalives_count
+// keys from the connection string. Unrecognized keys get forwarded to
+// the server as StartupMessage RuntimeParams, and Postgres responds
+// with FATAL "unrecognized configuration parameter (SQLSTATE 42704)"
+// — observed in production when v0.18.14 first shipped with a
+// conn-string approach. The DialFunc path below is the pgx-v5
+// idiomatic way to achieve what libpq accepts as conn-string params.
+func installKeepaliveDialer(cfg *pgxpool.Config) {
+	dialer := &net.Dialer{
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     keepaliveIdle,
+			Interval: keepaliveInterval,
+			Count:    keepaliveCount,
+		},
+	}
+	cfg.ConnConfig.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, addr)
+	}
+	cfg.ConnConfig.ConnectTimeout = connectTimeout
 }

--- a/internal/db/prepared_stmt_retry.go
+++ b/internal/db/prepared_stmt_retry.go
@@ -1,0 +1,111 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// keepaliveParams are the libpq-compatible TCP keepalive settings
+// appended to the pgx connection string by appendKeepaliveParams.
+// pgx's dialer reads these and sets TCP_KEEPIDLE / TCP_KEEPINTVL /
+// TCP_KEEPCNT on every pooled socket.
+//
+// Values tuned for dead-socket detection in ~2 minutes (60 idle + 6
+// probes × 10s interval), which is fast enough that pgxpool evicts
+// the broken connection before the per-connection prepared-statement
+// cache can fire many queries at a swapped backend. The
+// sendBatchWithRetry wrapper handles any residual race.
+//
+// connect_timeout=10 caps initial dial time so a misconfigured host
+// fails fast instead of blocking the scheduler's startup-Migrate
+// path for the default 2-minute kernel syn timeout.
+const keepaliveParams = "keepalives=1&keepalives_idle=60&keepalives_interval=10&keepalives_count=6&connect_timeout=10"
+
+// appendKeepaliveParams merges keepaliveParams into a pgx connection
+// string. Idempotent: if the caller already set keepalives=, returns
+// the string unchanged so per-deployment overrides survive.
+//
+// Handles both URL-form ("postgres://user:pass@host:port/db?sslmode=prefer")
+// and libpq keyword-form ("host=... port=... sslmode=prefer") conn
+// strings. ConnectionString() in internal/config/config.go emits
+// URL-form today, but pgx accepts both.
+func appendKeepaliveParams(connString string) string {
+	if strings.Contains(connString, "keepalives=") {
+		return connString
+	}
+	if strings.Contains(connString, "://") {
+		// URL form — query string gets an extra param. If there's
+		// no query string yet, start one with '?'; otherwise extend
+		// with '&'.
+		sep := "&"
+		if !strings.Contains(connString, "?") {
+			sep = "?"
+		}
+		return connString + sep + keepaliveParams
+	}
+	// Keyword form — space-separated key=value pairs. Convert the
+	// '&'-joined keepalive string to space-joined.
+	kw := strings.ReplaceAll(keepaliveParams, "&", " ")
+	if connString == "" {
+		return kw
+	}
+	return connString + " " + kw
+}
+
+// staleStatementSQLSTATE is the PostgreSQL error code for "prepared
+// statement does not exist" — the symptom when pgx's per-connection
+// prepared-statement cache falls out of sync with the backend after
+// a TCP connection is silently swapped under load.
+const staleStatementSQLSTATE = "26000"
+
+// isStalePreparedStatement returns true when err (possibly wrapped)
+// represents SQLSTATE 26000. This is the single retry signal the
+// sendBatchWithRetry wrapper uses.
+//
+// Why only 26000: other SQL errors (constraint violations, bad JSON,
+// etc.) are not transient — retrying them would waste time and mask
+// real data problems. 26000 specifically means "this cache went
+// stale; a fresh connection will succeed", which is the one case
+// where a blind retry is correct.
+func isStalePreparedStatement(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == staleStatementSQLSTATE
+}
+
+// sendBatchWithRetry sends a pgx.Batch through the pool and retries
+// ONCE on SQLSTATE 26000. Under heavy concurrent load on a LAN link,
+// a TCP connection can be silently replaced out from under pgx while
+// the client still thinks the server-side prepared-statement cache
+// holds "stmtcache_<hash>". The next SendBatch fires statements that
+// the new backend has never seen, and Postgres rejects the whole
+// batch with 26000.
+//
+// On the retry, pgxpool is very likely to hand us a different pooled
+// connection, and even if it returns the same one, pgx's cache
+// invalidation on 26000 causes the statements to be re-prepared
+// before the second SendBatch executes. Either way a fresh prepare
+// cycle runs and the batch succeeds.
+//
+// A single retry is deliberate: if the retry also 26000s, something
+// more systemic is wrong (network is thrashing, or pgbouncer has
+// appeared in the path) and looping would just amplify the problem.
+// The caller sees the second error, which surfaces in the monitor.
+func (s *PostgresStore) sendBatchWithRetry(ctx context.Context, batch *pgx.Batch) error {
+	err := s.pool.SendBatch(ctx, batch).Close()
+	if err == nil || !isStalePreparedStatement(err) {
+		return err
+	}
+	s.logger.Warn("prepared statement cache miss on SendBatch — retrying once",
+		"sqlstate", staleStatementSQLSTATE, "rows", batch.Len(), "error", err)
+	return s.pool.SendBatch(ctx, batch).Close()
+}

--- a/internal/db/prepared_stmt_retry_test.go
+++ b/internal/db/prepared_stmt_retry_test.go
@@ -1,0 +1,138 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestIsStalePreparedStatement_MatchesSQLSTATE26000 — the classifier
+// must recognize a pgconn.PgError with Code "26000" (prepared
+// statement does not exist). This is the v0.18.11 production failure
+// mode: pgx's per-connection prepared-statement cache falls out of
+// sync with the server backend when a TCP connection is silently
+// swapped under load, and the next SendBatch hits SQLSTATE 26000.
+func TestIsStalePreparedStatement_MatchesSQLSTATE26000(t *testing.T) {
+	err := &pgconn.PgError{
+		Code:    "26000",
+		Message: `prepared statement "stmtcache_c9d081ae61e306706c11345fabcd5c6b0cbe6f7ae724995e" does not exist`,
+	}
+	if !isStalePreparedStatement(err) {
+		t.Error("isStalePreparedStatement must return true for SQLSTATE 26000 " +
+			"(the stale-cache retry signal)")
+	}
+}
+
+// TestIsStalePreparedStatement_MatchesWrappedError — real errors
+// come through a fmt.Errorf("flushing staging batch (%d rows): %w",
+// ...) wrapper. The classifier must errors.As unwrap to find the
+// underlying PgError, otherwise production 26000s appear wrapped
+// and the retry never fires.
+func TestIsStalePreparedStatement_MatchesWrappedError(t *testing.T) {
+	inner := &pgconn.PgError{Code: "26000", Message: "prepared statement X does not exist"}
+	wrapped := fmt.Errorf("flushing staging batch (500 rows): %w", inner)
+	if !isStalePreparedStatement(wrapped) {
+		t.Error("isStalePreparedStatement must unwrap via errors.As so callers can " +
+			"wrap the error with context (batch size, file path, etc.) without " +
+			"breaking the retry classifier")
+	}
+}
+
+// TestIsStalePreparedStatement_RejectsOtherPgErrors — other SQL
+// errors must NOT trigger a retry. Retrying a 22P02 (invalid JSON),
+// 22P05 (bad escape), 23505 (unique violation), or 42P01 (undefined
+// table) would waste time and possibly mask real bugs.
+func TestIsStalePreparedStatement_RejectsOtherPgErrors(t *testing.T) {
+	cases := []string{
+		"22P02", // invalid_text_representation
+		"22P05", // untranslatable_character
+		"23505", // unique_violation
+		"42P01", // undefined_table
+		"40P01", // deadlock_detected
+		"",      // empty code — shouldn't match
+	}
+	for _, code := range cases {
+		err := &pgconn.PgError{Code: code, Message: "test"}
+		if isStalePreparedStatement(err) {
+			t.Errorf("isStalePreparedStatement must return false for SQLSTATE %q; "+
+				"only 26000 triggers the prepared-statement retry", code)
+		}
+	}
+}
+
+// TestIsStalePreparedStatement_RejectsNonPgErrors — non-pg errors
+// (context cancellation, plain io errors, nil) must not match.
+func TestIsStalePreparedStatement_RejectsNonPgErrors(t *testing.T) {
+	cases := []error{
+		nil,
+		errors.New("random string error"),
+		fmt.Errorf("wrapped: %w", errors.New("inner")),
+	}
+	for _, err := range cases {
+		if isStalePreparedStatement(err) {
+			t.Errorf("isStalePreparedStatement must return false for non-pg error %v", err)
+		}
+	}
+}
+
+// TestSendBatchWithRetry_ExistsOnStore — source-contract test:
+// PostgresStore must expose sendBatchWithRetry so the hot flush
+// path can route around stale prepared-statement cache entries.
+// Without this method, StagingWriter.Flush is stuck with
+// pool.SendBatch which has no retry on SQLSTATE 26000.
+//
+// The method lives in prepared_stmt_retry.go alongside the
+// classifier — kept out of postgres.go so the retry policy is easy
+// to find and easy to change without touching the pool setup.
+func TestSendBatchWithRetry_ExistsOnStore(t *testing.T) {
+	data, err := os.ReadFile("prepared_stmt_retry.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "func (s *PostgresStore) sendBatchWithRetry(") {
+		t.Error("prepared_stmt_retry.go must define sendBatchWithRetry on " +
+			"PostgresStore to wrap pool.SendBatch with a retry-once-on-" +
+			"SQLSTATE-26000 policy")
+	}
+	if !strings.Contains(src, "isStalePreparedStatement") {
+		t.Error("sendBatchWithRetry must use isStalePreparedStatement to " +
+			"classify the retry signal")
+	}
+}
+
+// TestStagingFlushUsesRetryWrapper — source-contract test: the hot
+// flush path in staging.go must go through sendBatchWithRetry, not
+// raw pool.SendBatch. Otherwise the 26000 stays fatal and the whole
+// batch is lost.
+func TestStagingFlushUsesRetryWrapper(t *testing.T) {
+	data, err := os.ReadFile("staging.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "sendBatchWithRetry") {
+		t.Error("staging.go must call sendBatchWithRetry (not raw pool.SendBatch) " +
+			"in the Flush path so a stale prepared-statement on one connection " +
+			"doesn't fail the whole 500-row batch")
+	}
+	// Also: the raw pool.SendBatch line should be gone from Flush —
+	// leaving both would silently defeat the wrapper.
+	flushIdx := strings.Index(src, "func (w *StagingWriter) Flush(")
+	if flushIdx < 0 {
+		t.Fatal("cannot find StagingWriter.Flush in staging.go")
+	}
+	flushBody := src[flushIdx:]
+	end := strings.Index(flushBody, "\n}\n")
+	if end > 0 {
+		flushBody = flushBody[:end]
+	}
+	if strings.Contains(flushBody, "w.store.pool.SendBatch(") {
+		t.Error("StagingWriter.Flush still calls w.store.pool.SendBatch directly — " +
+			"remove it so only sendBatchWithRetry runs the batch")
+	}
+}

--- a/internal/db/staging.go
+++ b/internal/db/staging.go
@@ -10,27 +10,79 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// nullEscapeLower and nullEscapeUpper match JSON's two legal renderings of a
-// NUL byte: \u0000 and \u0000. PostgreSQL JSONB rejects both with
-// SQLSTATE 22P05 ("unsupported Unicode escape sequence"), and a single
-// occurrence in any row of a batched insert fails the whole flush.
-var (
-	nullEscapeLower = []byte(`\u0000`)
-	nullEscapeUpper = []byte(`\u0000`)
-)
+// nullEscape is the 6-byte JSON NUL-escape sequence (backslash, u,
+// 0, 0, 0, 0). Built from byte literals so this source file never
+// contains the sequence directly — otherwise an over-eager editor or
+// JSON-aware tool can decode it to an actual NUL byte and corrupt
+// the source.
+//
+// PostgreSQL JSONB rejects this escape with SQLSTATE 22P05
+// ("unsupported Unicode escape sequence"). A single occurrence in
+// any row of a batched insert fails the whole flush.
+//
+// JSON (RFC 8259) only defines the lowercase form; there is no
+// uppercase \U escape in JSON. Go's encoding/json always emits the
+// lowercase form, so a single needle suffices.
+var nullEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 
-// sanitizeJSONForJSONB strips \u0000 escapes from marshaled JSON before it
-// hits PostgreSQL JSONB. GitHub/GitLab API responses occasionally carry NUL
-// bytes in text fields (bot-generated comments, binary content echoed back
-// in diffs), and PostgreSQL refuses to accept them. We drop the escape
-// rather than replace with a placeholder because the character has no
-// legitimate semantic value in the fields we stage.
+// sanitizeJSONForJSONB strips JSON NUL-escape sequences from
+// marshaled JSON before it hits PostgreSQL JSONB. GitHub/GitLab API
+// responses occasionally carry NUL bytes in text fields (bot-
+// generated comments, binary content echoed back in diffs), and
+// PostgreSQL refuses the escape. We drop it rather than replace with
+// a placeholder — the character has no legitimate semantic value in
+// the fields we stage.
+//
+// The sanitizer is BACKSLASH-RUN AWARE. A candidate NUL-escape at
+// position j is only a real JSON escape when the run of consecutive
+// backslashes ending at j-1 has even length (including zero). If
+// the run is odd, the backslash at j is itself the tail of a "\\"
+// literal-backslash pair, and the "u0000" that follows is ordinary
+// content — the string represents those six characters literally
+// (e.g. a user pasted that text into an issue body or PR comment).
+// In that case we MUST preserve the sequence verbatim.
+//
+// Why this matters: a context-free bytes.ReplaceAll, as used before
+// v0.18.13, would match the escape needle starting at the SECOND
+// backslash of an escaped-backslash-plus-u0000 pair and strip six
+// bytes — leaving a lone backslash before the next JSON token. That
+// produced SQLSTATE 22P02 "invalid input syntax for type json" and
+// killed the whole 500-row staging batch: the v0.18.12 production
+// swarm this routine was patched to prevent.
 func sanitizeJSONForJSONB(data []byte) []byte {
-	if !bytes.Contains(data, nullEscapeLower) && !bytes.Contains(data, nullEscapeUpper) {
+	if !bytes.Contains(data, nullEscape) {
 		return data
 	}
-	out := bytes.ReplaceAll(data, nullEscapeLower, nil)
-	out = bytes.ReplaceAll(out, nullEscapeUpper, nil)
+	out := make([]byte, 0, len(data))
+	i := 0
+	for i < len(data) {
+		rel := bytes.Index(data[i:], nullEscape)
+		if rel < 0 {
+			out = append(out, data[i:]...)
+			break
+		}
+		j := i + rel
+		// Count consecutive backslashes immediately preceding j in
+		// the ORIGINAL input (not the output buffer). Even count =
+		// the backslash at j introduces a real escape. Odd count =
+		// it's the tail of a "\\" literal-backslash pair, and the
+		// u0000 is content.
+		precedingBackslashes := 0
+		for k := j - 1; k >= 0 && data[k] == '\\'; k-- {
+			precedingBackslashes++
+		}
+		if precedingBackslashes%2 == 0 {
+			// Real NUL escape — keep bytes up to j, drop the 6
+			// escape bytes.
+			out = append(out, data[i:j]...)
+			i = j + len(nullEscape)
+		} else {
+			// Literal content — keep everything through the
+			// candidate inclusive.
+			out = append(out, data[i:j+len(nullEscape)]...)
+			i = j + len(nullEscape)
+		}
+	}
 	return out
 }
 
@@ -64,8 +116,9 @@ func (w *StagingWriter) Stage(ctx context.Context, entityType string, payload an
 	if err != nil {
 		return fmt.Errorf("marshaling %s: %w", entityType, err)
 	}
-	// Strip \u0000 escapes — PostgreSQL JSONB rejects them and a single
-	// poisoned row would fail the whole 500-row batch flush.
+	// Strip JSON NUL-escape sequences. PostgreSQL JSONB rejects them
+	// and a single poisoned row would fail the whole 500-row batch
+	// flush. See sanitizeJSONForJSONB for the backslash-run rule.
 	data = sanitizeJSONForJSONB(data)
 	w.batch.Queue(`
 		INSERT INTO aveloxis_ops.staging (repo_id, platform_id, entity_type, payload)
@@ -81,11 +134,16 @@ func (w *StagingWriter) Stage(ctx context.Context, entityType string, payload an
 }
 
 // Flush writes all buffered staging rows to the database.
+//
+// Goes through PostgresStore.sendBatchWithRetry so a stale
+// prepared-statement cache entry on one pooled connection (SQLSTATE
+// 26000 under heavy LAN load — see prepared_stmt_retry.go) becomes
+// a single transparent retry instead of a 500-row data loss.
 func (w *StagingWriter) Flush(ctx context.Context) error {
 	if w.count == 0 {
 		return nil
 	}
-	err := w.store.pool.SendBatch(ctx, w.batch).Close()
+	err := w.store.sendBatchWithRetry(ctx, w.batch)
 	if err != nil {
 		return fmt.Errorf("flushing staging batch (%d rows): %w", w.count, err)
 	}

--- a/internal/db/staging_sanitize_test.go
+++ b/internal/db/staging_sanitize_test.go
@@ -2,10 +2,22 @@ package db
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
 )
+
+// nulEsc is the 6-char literal JSON NUL-escape sequence: backslash,
+// u, 0, 0, 0, 0. Built from byte literals so this source file never
+// contains the sequence directly — otherwise an over-eager editor or
+// tool can decode it to an actual NUL byte and break the file.
+var nulEsc = string([]byte{'\\', 'u', '0', '0', '0', '0'})
+
+// doubleBackslashNulEsc is the 7-char wire sequence json.Marshal emits
+// when a Go string's CONTENT is the 6 chars of nulEsc: the leading
+// backslash gets escaped, yielding backslash-backslash-u-0-0-0-0.
+var doubleBackslashNulEsc = "\\" + nulEsc
 
 func readFileForTest(t *testing.T, name string) string {
 	t.Helper()
@@ -16,46 +28,47 @@ func readFileForTest(t *testing.T, name string) string {
 	return string(data)
 }
 
-// TestSanitizeJSONForJSONB_StripsNullEscape — the helper must strip literal
-// `\u0000` sequences from JSON bytes before they reach PostgreSQL. A single
-// `\u0000` in any field value fails the whole JSONB insert with
-// SQLSTATE 22P05 "unsupported Unicode escape sequence", killing 500-row
-// batches on a single poisoned GitHub/GitLab payload.
+// TestSanitizeJSONForJSONB_StripsNullEscape — the helper must strip
+// the literal NUL-escape sequence from JSON bytes before they reach
+// PostgreSQL. A single NUL-escape in any field value fails the whole
+// JSONB insert with SQLSTATE 22P05 "unsupported Unicode escape
+// sequence", killing 500-row batches on a single poisoned payload.
 func TestSanitizeJSONForJSONB_StripsNullEscape(t *testing.T) {
-	in := []byte(`{"body":"hello\u0000world","id":42}`)
+	in := []byte(`{"body":"hello` + nulEsc + `world","id":42}`)
 	got := sanitizeJSONForJSONB(in)
-	if bytes.Contains(got, []byte(`\u0000`)) {
-		t.Errorf("expected \\u0000 removed; got %s", got)
+	if bytes.Contains(got, []byte(nulEsc)) {
+		t.Errorf("expected NUL-escape removed; got %s", got)
 	}
-	// Must remain valid-ish JSON shape (outer braces, other fields intact).
 	if !bytes.Contains(got, []byte(`"id":42`)) {
 		t.Errorf("sanitizer must not damage unrelated fields: %s", got)
 	}
 }
 
-// TestSanitizeJSONForJSONB_PreservesValidContent — scrubber must not touch
-// other escape sequences (\n, \t, \u00e9 …) or non-ASCII content.
+// TestSanitizeJSONForJSONB_PreservesValidContent — the scrubber must
+// not touch other escape sequences (\n, \t, é …) or non-ASCII
+// content.
 func TestSanitizeJSONForJSONB_PreservesValidContent(t *testing.T) {
-	in := []byte(`{"text":"hello\nworld\t\u00e9","id":1}`)
+	in := []byte(`{"text":"hello\nworld\té","id":1}`)
 	got := sanitizeJSONForJSONB(in)
 	if !bytes.Equal(in, got) {
-		t.Errorf("sanitizer must be a no-op when no \\u0000 present.\n  in:  %s\n  got: %s", in, got)
+		t.Errorf("sanitizer must be a no-op when no NUL-escape is present.\n  in:  %s\n  got: %s", in, got)
 	}
 }
 
-// TestSanitizeJSONForJSONB_StripsAllOccurrences — one row can carry many
-// poisoned fields; every one must go.
+// TestSanitizeJSONForJSONB_StripsAllOccurrences — one row can carry
+// many poisoned fields; every NUL-escape must go.
 func TestSanitizeJSONForJSONB_StripsAllOccurrences(t *testing.T) {
-	in := []byte(`{"a":"\u0000","b":"x\u0000y","c":"\u0000\u0000"}`)
+	in := []byte(`{"a":"` + nulEsc + `","b":"x` + nulEsc + `y","c":"` + nulEsc + nulEsc + `"}`)
 	got := sanitizeJSONForJSONB(in)
-	if bytes.Contains(got, []byte(`\u0000`)) {
-		t.Errorf("every \\u0000 must be removed: %s", got)
+	if bytes.Contains(got, []byte(nulEsc)) {
+		t.Errorf("every NUL-escape must be removed: %s", got)
 	}
 }
 
-// TestStagingWriterStageCallsSanitizer — source-level contract: Stage must
-// run the scrubber on the marshaled bytes before queuing the batch insert.
-// Without this, the scrubber exists but is never called on the hot path.
+// TestStagingWriterStageCallsSanitizer — source-level contract: Stage
+// must run the scrubber on the marshaled bytes before queuing the
+// batch insert. Without this, the scrubber exists but is never
+// called on the hot path.
 func TestStagingWriterStageCallsSanitizer(t *testing.T) {
 	src := readFileForTest(t, "staging.go")
 	idx := strings.Index(src, "func (w *StagingWriter) Stage(")
@@ -70,6 +83,120 @@ func TestStagingWriterStageCallsSanitizer(t *testing.T) {
 	if !strings.Contains(fnBody, "sanitizeJSONForJSONB") {
 		t.Error("StagingWriter.Stage must call sanitizeJSONForJSONB on the " +
 			"marshaled bytes before w.batch.Queue — otherwise a single " +
-			"\\u0000 in a GitHub/GitLab payload kills the whole batch flush")
+			"NUL-escape in a GitHub/GitLab payload kills the whole batch flush")
+	}
+}
+
+// TestSanitizeJSONForJSONB_KeepsLiteralBackslashUSequence — the root
+// cause of the v0.18.12 22P02 swarm in staging flushes.
+//
+// When an API payload carries a Go string whose CONTENT is the 6
+// literal characters of nulEsc (e.g. a user pasted that exact text
+// into an issue body, PR comment, or commit message), json.Marshal
+// escapes the leading backslash and emits doubleBackslashNulEsc on
+// the wire.
+//
+// The pre-fix sanitizer did a context-free bytes.ReplaceAll, matched
+// its 6-byte needle starting at the SECOND backslash of that
+// sequence, and stripped 6 bytes — leaving a lone backslash before
+// the closing quote, which is an unterminated JSON string.
+// PostgreSQL rejected the whole 500-row batch with SQLSTATE 22P02
+// "invalid input syntax for type json".
+//
+// Correct behavior: a NUL-escape whose introducing backslash is
+// itself ESCAPED (preceded by an odd-length run of backslashes)
+// represents 6 literal characters inside a JSON string value. It is
+// content, not an escape, and must be preserved verbatim.
+func TestSanitizeJSONForJSONB_KeepsLiteralBackslashUSequence(t *testing.T) {
+	in := []byte(`{"body":"` + doubleBackslashNulEsc + `","id":7}`)
+	got := sanitizeJSONForJSONB(in)
+
+	want := []byte(`"body":"` + doubleBackslashNulEsc + `"`)
+	if !bytes.Contains(got, want) {
+		t.Errorf("escaped-backslash + u0000 is content, not an escape; "+
+			"sanitizer must leave it intact.\n  in:  %s\n  got: %s", in, got)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Errorf("sanitized output must still be valid JSON; got parse error %v on %s", err, got)
+	}
+}
+
+// TestSanitizeJSONForJSONB_MixedEscapeAndLiteral — a single payload
+// can contain BOTH a real NUL-escape (NUL char, rejected by PG JSONB
+// with 22P05 and which must be stripped) and a doubleBackslashNulEsc
+// escaped-backslash literal (content, which must be preserved to
+// avoid 22P02). A correct implementation distinguishes them by
+// counting the run of backslashes introducing each candidate.
+func TestSanitizeJSONForJSONB_MixedEscapeAndLiteral(t *testing.T) {
+	in := []byte(`{"a":"x` + nulEsc + `y","b":"` + doubleBackslashNulEsc + `"}`)
+	got := sanitizeJSONForJSONB(in)
+
+	if !bytes.Contains(got, []byte(`"a":"xy"`)) {
+		t.Errorf("real NUL-escape in field a must be stripped, yielding xy: got %s", got)
+	}
+	if !bytes.Contains(got, []byte(`"b":"`+doubleBackslashNulEsc+`"`)) {
+		t.Errorf("escaped-backslash literal in field b must be preserved: got %s", got)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Errorf("sanitized mixed-case output must parse as JSON; got %v on %s", err, got)
+	}
+}
+
+// TestSanitizeJSONForJSONB_TripleBackslashBeforeU0000 — stress the
+// backslash-run counting rule: runs of length 0, 2, 4, ... mean the
+// NUL-escape IS an escape (strip it). Runs of length 1, 3, 5, ...
+// mean it is content (keep it). A three-backslash source means
+// "escaped backslash + real NUL escape": strip the NUL, keep the
+// escaped backslash.
+func TestSanitizeJSONForJSONB_TripleBackslashBeforeU0000(t *testing.T) {
+	tripleBackslashNulEsc := "\\\\" + nulEsc // 3 backslashes + u0000
+	in := []byte(`{"x":"` + tripleBackslashNulEsc + `"}`)
+	got := sanitizeJSONForJSONB(in)
+
+	wantFragment := []byte(`"x":"\\"`) // Go source: 2 backslashes inside the string
+	if !bytes.Contains(got, wantFragment) {
+		t.Errorf("triple-backslash + u0000 must become double-backslash "+
+			"(escaped backslash remains, real NUL-escape stripped): got %s", got)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Errorf("output must parse as valid JSON: got %v on %s", err, got)
+	}
+}
+
+// TestSanitizeJSONForJSONB_RoundtripOnMarshaledRealPayload — the
+// production-shaped regression. Marshal a Go struct whose string
+// field contains the 6 literal characters of nulEsc as CONTENT,
+// run it through the sanitizer, then Unmarshal. A correct round-trip
+// must yield valid JSON AND preserve the original string exactly.
+// Anything less is either data loss or another 22P02 waiting to fire.
+func TestSanitizeJSONForJSONB_RoundtripOnMarshaledRealPayload(t *testing.T) {
+	type payload struct {
+		Body string `json:"body"`
+		ID   int    `json:"id"`
+	}
+	original := payload{
+		Body: "before " + nulEsc + " after",
+		ID:   42,
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sanitized := sanitizeJSONForJSONB(data)
+
+	var decoded payload
+	if err := json.Unmarshal(sanitized, &decoded); err != nil {
+		t.Fatalf("sanitized output failed to parse as JSON (this is the 22P02 Postgres sees):"+
+			"\n  err:       %v\n  marshaled: %s\n  sanitized: %s", err, data, sanitized)
+	}
+	if decoded.Body != original.Body {
+		t.Errorf("body content corrupted by sanitizer:\n  before: %q\n  after:  %q", original.Body, decoded.Body)
+	}
+	if decoded.ID != original.ID {
+		t.Errorf("unrelated field lost: got id=%d, want %d", decoded.ID, original.ID)
 	}
 }

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.15"
+var ToolVersion = "0.18.16"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.16"
+var ToolVersion = "0.18.17"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.10"
+var ToolVersion = "0.18.11"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.14"
+var ToolVersion = "0.18.15"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.11"
+var ToolVersion = "0.18.14"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -507,7 +507,8 @@ func (s *Scheduler) determineSince(job *db.QueueJob) time.Time {
 // the API, then process staged data into relational tables with bulk
 // contributor resolution.
 func (s *Scheduler) collectAndProcess(ctx context.Context, repoID int64, repo *model.Repo, client platform.Client, since time.Time) (*collector.CollectResult, error) {
-	sc := collector.NewStagedCollectorWithAllModes(client, s.store, s.logger, s.cfg.PRChildMode, s.cfg.ListingMode, s.cfg.ThreadingMode, s.cfg.ShardSize)
+	sc := collector.NewStagedCollectorWithAllModes(client, s.store, s.logger, s.cfg.PRChildMode, s.cfg.ListingMode, s.cfg.ThreadingMode, s.cfg.ShardSize).
+		WithWorkers(s.cfg.Workers)
 	result, err := sc.CollectRepo(ctx, repoID, repo.Owner, repo.Name, since)
 
 	if err == nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -182,6 +182,15 @@ func (s *Scheduler) Run(ctx context.Context) {
 	defer matviewCheckTicker.Stop()
 	var lastMatviewRebuild time.Time
 
+	// Staging table cleanup: delete processed rows older than 7 days
+	// so the table doesn't accumulate bloat indefinitely. v0.18.15
+	// observed a 21.5M-row table on a long-running deployment
+	// (PurgeStagedProcessed was defined but wired to nothing),
+	// enough to visibly slow every staging INSERT and DELETE.
+	// Hourly keeps the bloat bounded with negligible overhead.
+	stagingCleanupTicker := time.NewTicker(1 * time.Hour)
+	defer stagingCleanupTicker.Stop()
+
 	// Immediately fill worker slots on startup instead of waiting for the
 	// first poll tick (default 10s). With 30 workers and 78 queued repos,
 	// this avoids a visible delay before collection begins.
@@ -226,10 +235,32 @@ func (s *Scheduler) Run(ctx context.Context) {
 				}
 			}
 
+		case <-stagingCleanupTicker.C:
+			go s.runStagingCleanup(ctx)
+
 		case <-pollTicker.C:
 			s.fillWorkerSlots(ctx, sem)
 			s.maybeStartMatviewRebuild(ctx, sem, &lastMatviewRebuild)
 		}
+	}
+}
+
+// runStagingCleanup deletes processed staging rows older than 7 days.
+// The DELETE is run in a background goroutine so an unusually slow
+// cleanup pass (e.g. just after a first enablement against a table
+// with millions of stale rows) does not block the scheduler's main
+// poll loop. PurgeStagedProcessed itself is serializable — concurrent
+// fires are rare (ticker is hourly, cleanup typically finishes in
+// seconds) and at worst race on the same DELETE WHERE, which is
+// safe because the predicate is monotonic.
+func (s *Scheduler) runStagingCleanup(ctx context.Context) {
+	deleted, err := s.store.PurgeStagedProcessed(ctx)
+	if err != nil {
+		s.logger.Warn("staging cleanup failed", "error", err)
+		return
+	}
+	if deleted > 0 {
+		s.logger.Info("staging cleanup complete", "rows_deleted", deleted)
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -128,10 +128,15 @@ func (s *Scheduler) Run(ctx context.Context) {
 		s.logger.Warn("FORCE FULL COLLECTION enabled — all repos will be fully re-collected. Set collection.force_full to false in aveloxis.json after this pass completes.")
 	}
 
-	// On startup: check for tool updates (monthly), process leftover staging,
-	// and release stale locks.
+	// On startup: check for tool updates (monthly), then release any
+	// stale locks BEFORE processing leftover staging. Lock recovery
+	// is a single UPDATE that takes milliseconds; leftover staging
+	// can block for many minutes on a realistic backlog. Running
+	// lock recovery first gets the queue into a correct state
+	// immediately — monitor shows accurate "collecting" counts,
+	// orphaned jobs from a crashed prior process stop appearing as
+	// in-flight, and the next fillWorkerSlots tick sees reality.
 	collector.CheckAndUpdateTools(s.logger)
-	s.processLeftoverStaging(ctx)
 
 	// Immediately reclaim all locks held by dead worker IDs. A fresh process
 	// cannot have any legitimate in-flight work, so all locks from other
@@ -146,6 +151,14 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 	s.recoverStale(ctx)
 	s.releaseOurLocks(ctx)
+
+	// Process leftover staging rows from a previous interrupted run.
+	// Runs AFTER lock recovery so orphan locks don't wait on this
+	// multi-minute drain. Still synchronous: we must finish draining
+	// before fillWorkerSlots starts claiming new jobs, because
+	// PurgeStagedForRepo at the top of CollectRepo would wipe any
+	// unprocessed rows from the repo being re-claimed.
+	s.processLeftoverStaging(ctx)
 
 	// Recompute due_at = last_collected + recollectAfter for already-queued
 	// rows so a changed days_until_recollect takes effect immediately. Without

--- a/internal/scheduler/staging_cleanup_test.go
+++ b/internal/scheduler/staging_cleanup_test.go
@@ -1,0 +1,118 @@
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSchedulerRunsPeriodicStagingCleanup — source-contract test
+// pinning that scheduler.Run has a ticker that calls
+// store.PurgeStagedProcessed.
+//
+// Background: the staging table accumulates rows with processed=true
+// forever unless something deletes them. PurgeStagedProcessed is
+// defined in internal/db/staging.go but was not wired to any caller
+// until v0.18.16 — by v0.18.15 a single deployment had grown to
+// 21.5M processed rows, at which point every staging DELETE /
+// INSERT was touching a hugely bloated heap and the whole
+// collection pipeline felt slow at restart.
+//
+// Without this test pinning the wiring, a future refactor could
+// silently drop the ticker and the bloat would return.
+func TestSchedulerRunsPeriodicStagingCleanup(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// A named ticker of some form must exist so the cadence is
+	// discoverable from the source (not a bare time.Tick).
+	if !strings.Contains(src, "stagingCleanupTicker") {
+		t.Error("scheduler.go must declare stagingCleanupTicker — a named " +
+			"time.Ticker that fires periodic PurgeStagedProcessed calls so " +
+			"the aveloxis_ops.staging table doesn't accumulate processed-row " +
+			"bloat indefinitely")
+	}
+
+	// Actual call site must exist — the ticker without the call is
+	// a no-op.
+	if !strings.Contains(src, "PurgeStagedProcessed") {
+		t.Error("scheduler.go must call store.PurgeStagedProcessed on the " +
+			"cleanup ticker; without it the ticker fires but no cleanup " +
+			"happens")
+	}
+
+	// The stop / defer cleanup must be present like every other
+	// ticker in Run. Missing .Stop() leaks the ticker's goroutine on
+	// scheduler shutdown.
+	if !strings.Contains(src, "stagingCleanupTicker.Stop()") {
+		t.Error("scheduler.go must defer stagingCleanupTicker.Stop() to match " +
+			"the pattern of every other ticker in Run")
+	}
+
+	// The switch-case branch wiring the ticker to the cleanup
+	// handler must exist.
+	if !strings.Contains(src, "<-stagingCleanupTicker.C") {
+		t.Error("scheduler.go must have a `case <-stagingCleanupTicker.C:` " +
+			"branch in the main select loop so the ticker actually drives " +
+			"cleanup")
+	}
+}
+
+// TestStagingCleanupIntervalIsReasonable — pins the cadence at
+// something non-degenerate. Too short and we hammer the DB with
+// DELETEs; too long and a burst of collection can regrow the bloat
+// before the next fire. Hourly is the sweet spot documented in
+// v0.18.16.
+func TestStagingCleanupIntervalIsReasonable(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Accept any interval in the "reasonable" range [30 min, 24 h]
+	// by checking for a few common Go duration literals. Tests
+	// should be tight enough to catch "1 * time.Second" mistakes
+	// but loose enough to allow future tuning.
+	reasonable := []string{
+		"30 * time.Minute",
+		"1 * time.Hour",
+		"time.Hour",
+		"2 * time.Hour",
+		"3 * time.Hour",
+		"6 * time.Hour",
+		"12 * time.Hour",
+		"24 * time.Hour",
+	}
+	// The staging cleanup ticker declaration must be on a line that
+	// uses one of these. Find the declaration and check the right-
+	// hand side.
+	idx := strings.Index(src, "stagingCleanupTicker")
+	if idx < 0 {
+		// TestSchedulerRunsPeriodicStagingCleanup will fail with a
+		// clearer message; don't double-report.
+		return
+	}
+	// Look at the 200-char window starting at that identifier.
+	end := idx + 200
+	if end > len(src) {
+		end = len(src)
+	}
+	window := src[idx:end]
+
+	found := false
+	for _, r := range reasonable {
+		if strings.Contains(window, r) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("stagingCleanupTicker interval looks unreasonable (expected one of %v "+
+			"within ~200 chars of the ticker declaration).\n  window: %q",
+			reasonable, window)
+	}
+}

--- a/internal/scheduler/startup_order_test.go
+++ b/internal/scheduler/startup_order_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLockRecoveryRunsBeforeLeftoverStaging pins the startup
+// ordering invariant that RecoverOtherWorkerLocks executes BEFORE
+// processLeftoverStaging.
+//
+// Background: in v0.18.16 and earlier the order was reversed — the
+// comment above the lock-recovery call claimed "Immediately reclaim
+// all locks" but the actual call sat AFTER processLeftoverStaging.
+// processLeftoverStaging blocks for minutes on a realistic backlog
+// (370K unprocessed rows across 15 repos took ~12 min in the
+// v0.18.15 observed deployment), during which time the orphan
+// locks from a previously-crashed worker stayed stale. A user
+// watching the monitor would see 48 "collecting" rows with 2h40m+
+// lock ages while their new scheduler was busy draining staging.
+//
+// Lock recovery is a single UPDATE that takes milliseconds and has
+// zero data dependency on leftover staging. Running it first costs
+// nothing and gets the queue into a correct state immediately.
+//
+// This is a pure-ordering test — it reads the source and asserts
+// the call positions, so a future refactor can't silently swap
+// the order back.
+func TestLockRecoveryRunsBeforeLeftoverStaging(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	lockIdx := strings.Index(src, "RecoverOtherWorkerLocks")
+	if lockIdx < 0 {
+		t.Fatal("cannot find RecoverOtherWorkerLocks call site in scheduler.go")
+	}
+	leftoverIdx := strings.Index(src, "processLeftoverStaging(ctx)")
+	if leftoverIdx < 0 {
+		t.Fatal("cannot find processLeftoverStaging call site in scheduler.go")
+	}
+
+	if lockIdx >= leftoverIdx {
+		t.Errorf("scheduler startup ordering is wrong: RecoverOtherWorkerLocks "+
+			"appears at byte %d, processLeftoverStaging at byte %d. Lock "+
+			"recovery must come FIRST so orphan locks from a crashed prior "+
+			"process are released in milliseconds, not after the multi-minute "+
+			"leftover-staging drain.", lockIdx, leftoverIdx)
+	}
+}
+
+// TestRecoverStaleRunsBeforeLeftoverStaging — same logic for the
+// general stale-lock sweep (not just this-process's worker ID).
+// recoverStale reclaims any lock older than StaleLockTimeout (1h
+// default); orphans from pre-restart crashes are always >1h in
+// practice by the time a human notices, so this sweep is what
+// actually reclaims them.
+func TestRecoverStaleRunsBeforeLeftoverStaging(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Find the first call to s.recoverStale(ctx) (a bare call, not
+	// part of a comment or the recoveryTicker.C branch). The simpler
+	// check: look for s.recoverStale(ctx) before processLeftoverStaging.
+	recoverIdx := strings.Index(src, "s.recoverStale(ctx)")
+	if recoverIdx < 0 {
+		t.Fatal("cannot find s.recoverStale(ctx) call site in scheduler.go")
+	}
+	leftoverIdx := strings.Index(src, "processLeftoverStaging(ctx)")
+	if leftoverIdx < 0 {
+		t.Fatal("cannot find processLeftoverStaging call site in scheduler.go")
+	}
+
+	if recoverIdx >= leftoverIdx {
+		t.Errorf("scheduler startup ordering is wrong: s.recoverStale(ctx) "+
+			"appears at byte %d, processLeftoverStaging at byte %d. The "+
+			"stale-lock sweep must come FIRST so locks older than "+
+			"StaleLockTimeout get reclaimed in milliseconds.", recoverIdx, leftoverIdx)
+	}
+}


### PR DESCRIPTION
Volume of collection is so ridiculously high and fast that two servers, Aveloxis and the Database, on the same LAN can actually exceed the flow of a 100GB local connection. This addresses those issues with some backoff logic that preserves collection velocity in those scenarios, while addressing intermittent network hiccups (like 10ms pings instead of 0.10). 