### PR TITLE
 #2 — Reverse-proxy API through web server (v0.18.18)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,16 @@ type WebConfig struct {
 	GitLabClientID     string `json:"gitlab_client_id"`
 	GitLabClientSecret string `json:"gitlab_client_secret"`
 	GitLabBaseURL      string `json:"gitlab_base_url"` // default "https://gitlab.com"
+
+	// APIInternalURL is where the web server reaches the `aveloxis api` process
+	// server-to-server. The web server reverse-proxies /api/* requests to this
+	// URL so the browser talks only to the web origin — eliminating the old
+	// hardcoded `http://localhost:8383` JS fetch that broke for any
+	// non-localhost browser and was further broken by CORS tightening on
+	// 2026-04-14. Default assumes the api process runs on the same host as
+	// the web process, which matches `aveloxis start all`. Override to point
+	// at a remote API instance.
+	APIInternalURL string `json:"api_internal_url"`
 }
 
 // CollectionConfig controls collection behavior.
@@ -247,8 +257,9 @@ func DefaultConfig() *Config {
 			BaseURL: "https://gitlab.com/api/v4",
 		},
 		Web: WebConfig{
-			Addr:          ":8082",
-			GitLabBaseURL: "https://gitlab.com",
+			Addr:           ":8082",
+			GitLabBaseURL:  "https://gitlab.com",
+			APIInternalURL: "http://127.0.0.1:8383",
 		},
 		Collection: CollectionConfig{
 			BatchSize:               1000,

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -2,4 +2,4 @@ package db
 
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
-var ToolVersion = "0.18.17"
+var ToolVersion = "0.18.20"

--- a/internal/web/api_proxy_test.go
+++ b/internal/web/api_proxy_test.go
@@ -1,0 +1,147 @@
+package web
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augurlabs/aveloxis/internal/config"
+)
+
+// TestTemplatesHaveNoHardcodedLocalhostAPI regresses the root cause of the
+// compare-autocomplete outage: the templates used to hardcode
+// 'http://localhost:8383', which silently failed for any browser not running
+// on the same host as the api process. Same-origin relative URLs fix this.
+// If someone re-introduces a hardcoded API host, this test fails before ship.
+func TestTemplatesHaveNoHardcodedLocalhostAPI(t *testing.T) {
+	forbidden := []string{
+		"http://localhost:8383",
+		"https://localhost:8383",
+		"http://127.0.0.1:8383",
+		"https://127.0.0.1:8383",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(allTemplates, f) {
+			t.Errorf("templates contain hardcoded API host %q — use relative /api/v1/... URLs instead so the browser always fetches from the page's own origin (same-origin, no CORS, works behind nginx/TLS)", f)
+		}
+	}
+}
+
+// TestTemplatesUseRelativeAPIFetches ensures the three compare pages still
+// call /api/v1/repos/search — the endpoint that drives the autocomplete
+// dropdown. Without a search fetch, the dropdown stays empty.
+func TestTemplatesUseRelativeAPIFetches(t *testing.T) {
+	if !strings.Contains(allTemplates, "/api/v1/repos/search") {
+		t.Error("templates must call /api/v1/repos/search for the compare autocomplete dropdown")
+	}
+	// At least one API fetch must be wired. More thorough shape checks live
+	// in dashboard_test.go (structural) and api_proxy_integration_test.go
+	// (runtime).
+}
+
+// TestAPIProxyForwardsToInternalURL is the mini-e2e for recommendation #1:
+// stand up a fake api on httptest, configure the web server to proxy to it,
+// make an authenticated /api/v1/repos/search request to the web server's
+// handler, and verify the fake api's JSON comes back. This simulates the
+// full production path (browser → nginx → web :8082 → internal proxy →
+// api :8383) because nginx is transparent to the handler-level test.
+//
+// This is the test that would have caught the original outage: it fails if
+// the web server doesn't wire a /api/* proxy, if it points at the wrong URL,
+// if auth isn't required (security regression), or if the upstream response
+// doesn't make it back to the browser.
+func TestAPIProxyForwardsToInternalURL(t *testing.T) {
+	// Fake api server stands in for `aveloxis api` on :8383.
+	var gotPath, gotQuery string
+	fakeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":42,"owner":"augurlabs","name":"aveloxis"}]`))
+	}))
+	defer fakeAPI.Close()
+
+	s := newTestServerWithAPIURL(t, fakeAPI.URL)
+
+	// Unauthenticated request: must NOT proxy (leaks data otherwise).
+	reqAnon := httptest.NewRequest(http.MethodGet, "/api/v1/repos/search?q=av", nil)
+	wAnon := httptest.NewRecorder()
+	s.Handler().ServeHTTP(wAnon, reqAnon)
+	if wAnon.Code == http.StatusOK {
+		t.Errorf("anonymous /api request returned 200 — auth gate is missing; got body=%q", wAnon.Body.String())
+	}
+
+	// Authenticated request: must proxy.
+	token := s.createSession(1, "tester", "", "github")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/search?q=av", nil)
+	req.AddCookie(&http.Cookie{Name: "aveloxis_session", Value: token})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("authenticated proxy request: got %d, want 200. body=%q", w.Code, w.Body.String())
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "augurlabs") {
+		t.Errorf("upstream response not forwarded: body=%q", body)
+	}
+	if gotPath != "/api/v1/repos/search" {
+		t.Errorf("upstream saw path=%q, want /api/v1/repos/search", gotPath)
+	}
+	if gotQuery != "q=av" {
+		t.Errorf("upstream saw query=%q, want q=av", gotQuery)
+	}
+}
+
+// TestAPIProxyReturns502WhenBackendDown verifies the fail-fast behavior.
+// If aveloxis api is stopped, the web server must return a quick 502 instead
+// of hanging the browser — operators (and the existing JS .catch) can react.
+func TestAPIProxyReturns502WhenBackendDown(t *testing.T) {
+	// Point at a port nothing is listening on. 127.0.0.1:1 is almost always
+	// closed; the proxy should fail immediately.
+	s := newTestServerWithAPIURL(t, "http://127.0.0.1:1")
+	token := s.createSession(1, "tester", "", "github")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/search?q=a", nil)
+	req.AddCookie(&http.Cookie{Name: "aveloxis_session", Value: token})
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		s.Handler().ServeHTTP(w, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("proxy hung when backend was down — fail-fast is broken")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("backend-down proxy: got %d, want 502 Bad Gateway. body=%q", w.Code, w.Body.String())
+	}
+}
+
+// TestAPIProxyDefaultURLFallback ensures an empty api_internal_url doesn't
+// silently disable the proxy; it falls back to 127.0.0.1:8383 so the "just
+// works" configuration (aveloxis start all, no custom config) keeps working.
+func TestAPIProxyDefaultURLFallback(t *testing.T) {
+	s := New(nil, config.WebConfig{Addr: ":0"}, nil, slog.Default())
+	if s.apiProxy == nil {
+		t.Fatal("empty api_internal_url should fall back to a default, not disable the proxy")
+	}
+}
+
+// newTestServerWithAPIURL constructs a web server pointed at the given api URL.
+// Store is nil because the proxy path never touches Postgres; if a test ever
+// hits a non-/api route, it will nil-deref and we'll fix the test.
+func newTestServerWithAPIURL(t *testing.T, apiURL string) *Server {
+	t.Helper()
+	return New(nil, config.WebConfig{
+		Addr:           ":0",
+		APIInternalURL: apiURL,
+	}, nil, slog.Default())
+}

--- a/internal/web/compare_integration_test.go
+++ b/internal/web/compare_integration_test.go
@@ -1,0 +1,232 @@
+package web
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/augurlabs/aveloxis/internal/config"
+	"github.com/augurlabs/aveloxis/internal/db"
+)
+
+// This file implements recommendation #1 from the compare-autocomplete
+// diagnosis: a test that would have caught the original outage by connecting
+// "what the browser sees in the rendered JS" to "what URL the web server
+// actually serves". The pre-v0.18.18 bug was that these two diverged silently:
+// the JS pointed at http://localhost:8383 (the user's own machine) while the
+// web server knew nothing about /api/*, so the autocomplete dropdown never
+// populated and there was no server-side error to notice.
+//
+// These tests simulate the full production path described by the operator's
+// nginx config (browser → nginx → web :8082 → internal proxy → api :8383).
+// Nginx is transparent at the handler level, so we test web → proxy → api
+// directly — the same invariants hold.
+
+// TestCompareSearchWidgetRendersRelativeFetch renders the shared widget and
+// asserts that the JS it produces calls a relative /api/v1/repos/search URL.
+// A regression to an absolute http://localhost:... URL would fail here.
+func TestCompareSearchWidgetRendersRelativeFetch(t *testing.T) {
+	s := newTestServerWithAPIURL(t, "http://127.0.0.1:8383")
+
+	var buf bytes.Buffer
+	if err := s.tmpl.ExecuteTemplate(&buf, "compareSearchWidget", map[string]any{"Prefix": "dash"}); err != nil {
+		t.Fatalf("render compareSearchWidget: %v", err)
+	}
+	rendered := buf.String()
+
+	// Positive: the relative endpoint must appear in the rendered JS.
+	if !strings.Contains(rendered, "/api/v1/repos/search") {
+		t.Errorf("rendered widget missing /api/v1/repos/search fetch call:\n%s", rendered)
+	}
+	// Positive: widget-specific IDs (derived from Prefix) must appear.
+	for _, id := range []string{`id="dash-repo-search"`, `id="dash-search-results"`, `id="dash-repo-ids"`, `id="dash-selected"`} {
+		if !strings.Contains(rendered, id) {
+			t.Errorf("rendered widget missing %s", id)
+		}
+	}
+	// Negative: no absolute API host should ever appear in the rendered JS.
+	// This is the literal string that caused the outage.
+	for _, forbidden := range []string{"http://localhost:8383", "https://localhost:8383", "http://127.0.0.1:8383"} {
+		if strings.Contains(rendered, forbidden) {
+			t.Errorf("rendered widget contains forbidden absolute URL %q — use relative fetch paths so the browser always resolves against its own origin", forbidden)
+		}
+	}
+}
+
+// TestCompareSearchWidgetRendersGrpPrefix is the same check for the "grp"
+// prefix — the two-widget invariant: swapping the prefix is the ONLY
+// difference between the dashboard and group page.
+func TestCompareSearchWidgetRendersGrpPrefix(t *testing.T) {
+	s := newTestServerWithAPIURL(t, "http://127.0.0.1:8383")
+
+	var buf bytes.Buffer
+	if err := s.tmpl.ExecuteTemplate(&buf, "compareSearchWidget", map[string]any{"Prefix": "grp"}); err != nil {
+		t.Fatalf("render compareSearchWidget: %v", err)
+	}
+	rendered := buf.String()
+
+	for _, id := range []string{`id="grp-repo-search"`, `id="grp-search-results"`, `id="grp-repo-ids"`, `id="grp-selected"`} {
+		if !strings.Contains(rendered, id) {
+			t.Errorf("rendered widget missing %s", id)
+		}
+	}
+	// Cross-contamination check: rendering with Prefix=grp must not emit
+	// any dash-* IDs. Pre-extraction copies were hand-edited and did drift;
+	// the template now forbids that by construction, so this test pins it.
+	for _, wrongID := range []string{"dash-repo-search", "dash-search-results"} {
+		if strings.Contains(rendered, wrongID) {
+			t.Errorf("rendered grp widget contains wrong-prefix %q — prefix isolation broken", wrongID)
+		}
+	}
+}
+
+// TestDashboardFullRenderHasRelativeFetch renders the real dashboard template
+// with stub data and verifies the rendered HTML wires the compare widget to
+// a relative API URL. This is the template-level equivalent of "load the
+// page in a browser and look at the source".
+func TestDashboardFullRenderHasRelativeFetch(t *testing.T) {
+	s := newTestServerWithAPIURL(t, "http://127.0.0.1:8383")
+
+	var buf bytes.Buffer
+	err := s.tmpl.ExecuteTemplate(&buf, "dashboard", map[string]any{
+		"Session": &Session{LoginName: "tester"},
+		"Groups":  []db.UserGroup{{GroupID: 1, Name: "chaoss", RepoCount: 42}},
+	})
+	if err != nil {
+		t.Fatalf("render dashboard: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, `id="compare-card"`) {
+		t.Error("dashboard missing compare card")
+	}
+	if !strings.Contains(html, `id="dash-repo-search"`) {
+		t.Error("dashboard missing compare search input (dash-repo-search)")
+	}
+	if !strings.Contains(html, "/api/v1/repos/search") {
+		t.Error("dashboard JS does not call /api/v1/repos/search")
+	}
+	if strings.Contains(html, "http://localhost:8383") {
+		t.Error("dashboard rendered with hardcoded http://localhost:8383 — regression to pre-v0.18.18 bug")
+	}
+}
+
+// TestGroupFullRenderHasRelativeFetch is the companion for the group page.
+// This is the page that "never worked" before: if the shared widget ever
+// gets accidentally removed from the group template, this test catches it
+// before ship.
+func TestGroupFullRenderHasRelativeFetch(t *testing.T) {
+	s := newTestServerWithAPIURL(t, "http://127.0.0.1:8383")
+
+	group := &db.GroupDetail{GroupID: 7, Name: "chaoss", Repos: nil, Orgs: nil}
+	var buf bytes.Buffer
+	err := s.tmpl.ExecuteTemplate(&buf, "group", map[string]any{
+		"Session":    &Session{LoginName: "tester"},
+		"Group":      group,
+		"Page":       1,
+		"TotalPages": 1,
+		"TotalRepos": 0,
+		"Query":      "",
+		"PageWindow": []int{1},
+	})
+	if err != nil {
+		t.Fatalf("render group: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, `id="grp-compare-card"`) {
+		t.Error("group page missing grp-compare-card")
+	}
+	if !strings.Contains(html, `id="grp-repo-search"`) {
+		t.Error("group page missing compare search input (grp-repo-search)")
+	}
+	if !strings.Contains(html, "/api/v1/repos/search") {
+		t.Error("group page JS does not call /api/v1/repos/search")
+	}
+	if strings.Contains(html, "http://localhost:8383") {
+		t.Error("group page rendered with hardcoded http://localhost:8383")
+	}
+}
+
+// TestFetchURLFromRenderedPageIsServedByProxy is the tightest coupling test:
+// we extract the literal fetch URL from the rendered dashboard HTML and then
+// issue that exact URL against the web server's Handler, asserting the fake
+// api's response comes back. If the rendered JS ever starts fetching from a
+// path that the proxy doesn't route, this test fails loudly — exactly the
+// class of regression that silently broke the feature for months.
+func TestFetchURLFromRenderedPageIsServedByProxy(t *testing.T) {
+	// Fake api server: matches any /api/v1/repos/search?... and returns JSON.
+	fakeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":1,"owner":"chaoss","name":"augur"}]`))
+	}))
+	defer fakeAPI.Close()
+
+	s := newTestServerWithAPIURL(t, fakeAPI.URL)
+
+	// 1. Render the dashboard (what a logged-in browser would see).
+	var buf bytes.Buffer
+	err := s.tmpl.ExecuteTemplate(&buf, "dashboard", map[string]any{
+		"Session": &Session{LoginName: "tester"},
+		"Groups":  []db.UserGroup{},
+	})
+	if err != nil {
+		t.Fatalf("render dashboard: %v", err)
+	}
+	html := buf.String()
+
+	// 2. Extract the fetch URL pattern from the JS. The widget builds it as
+	//    API + '/api/v1/repos/search?q=' + encodeURIComponent(q).
+	//    With API='' (same-origin), the effective URL is the suffix alone.
+	re := regexp.MustCompile(`'(/api/v1/repos/search\?q=)'`)
+	m := re.FindStringSubmatch(html)
+	if m == nil {
+		t.Fatalf("could not locate the fetch URL fragment in rendered dashboard JS; regex miss on /api/v1/repos/search")
+	}
+	fetchURL := m[1] + "chaoss"
+
+	// 3. Issue that exact URL against the web server's Handler with a
+	//    session cookie (what the browser would do automatically for a
+	//    same-origin fetch).
+	token := s.createSession(1, "tester", "", "github")
+	req := httptest.NewRequest(http.MethodGet, fetchURL, nil)
+	req.AddCookie(&http.Cookie{Name: "aveloxis_session", Value: token})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("fetch URL %q from rendered page returned %d (want 200). body=%q", fetchURL, w.Code, w.Body.String())
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "chaoss") {
+		t.Errorf("upstream response not forwarded for fetch URL %q; body=%q", fetchURL, body)
+	}
+}
+
+// discardLogger is used when a test wants a Server but doesn't care about logs.
+// Keeps test output clean.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// silenceServer replaces the default logger used by newTestServerWithAPIURL
+// when a test wants to suppress the "api reverse proxy error" warning during
+// the 502 test. Not used yet — left here so follow-up tests that expect an
+// error path can opt in without adding plumbing.
+var _ = discardLogger
+
+// init guards the package-level config default — if someone accidentally
+// reverts the default APIInternalURL to empty, the proxy would silently
+// disable and the integration tests would fail. This check fails fast with
+// a clearer message than a generic proxy-unreachable error.
+func TestDefaultConfigHasAPIInternalURL(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if cfg.Web.APIInternalURL == "" {
+		t.Error("DefaultConfig.Web.APIInternalURL must be non-empty so the reverse proxy is wired by default")
+	}
+}

--- a/internal/web/dashboard_test.go
+++ b/internal/web/dashboard_test.go
@@ -95,21 +95,70 @@ func TestComparePrePopulateDoesNotNestStatsFetch(t *testing.T) {
 
 // TestGroupTemplateHasCompareSearch verifies the group detail page includes
 // the API-powered compare search widget, not just the server-side filter.
+// As of v0.18.18 the widget lives in the shared compareSearchWidget template;
+// we assert the group template invokes that shared definition.
 func TestGroupTemplateHasCompareSearch(t *testing.T) {
-	// The group template must contain the compare search input and the
-	// API fetch call. We search between the group define and the next
-	// template define to isolate the group section.
 	start := strings.Index(allTemplates, `{{define "group"}}`)
 	end := strings.Index(allTemplates, `{{define "repo_detail"}}`)
 	if start < 0 || end < 0 || end <= start {
 		t.Fatal("could not locate group template boundaries")
 	}
 	groupSection := allTemplates[start:end]
-	if !strings.Contains(groupSection, "grp-repo-search") {
-		t.Error("group template should include an API-powered compare search widget (grp-repo-search)")
+	if !strings.Contains(groupSection, `{{template "compareSearchWidget" (dict "Prefix" "grp")}}`) {
+		t.Error(`group template must invoke the shared compareSearchWidget template with Prefix "grp"`)
 	}
-	if !strings.Contains(groupSection, "/api/v1/repos/search") {
-		t.Error("group template compare search should call the repos search API")
+}
+
+// TestCompareSearchWidgetIsShared pins the recommendation #5 contract: the
+// dashboard and group pages both invoke a single shared compareSearchWidget
+// template. If a future refactor duplicates the markup back into each page
+// (the pre-v0.18.18 state), this fails before ship. That duplication was
+// the shape that produced "fixed on home page, not on group page" drift.
+func TestCompareSearchWidgetIsShared(t *testing.T) {
+	if !strings.Contains(allTemplates, `{{define "compareSearchWidget"}}`) {
+		t.Fatal("missing shared compareSearchWidget template definition")
+	}
+
+	dashStart := strings.Index(allTemplates, `{{define "dashboard"}}`)
+	dashEnd := strings.Index(allTemplates[dashStart+1:], `{{define "`)
+	if dashStart < 0 || dashEnd < 0 {
+		t.Fatal("could not locate dashboard template boundaries")
+	}
+	dashSection := allTemplates[dashStart : dashStart+1+dashEnd]
+	if !strings.Contains(dashSection, `{{template "compareSearchWidget" (dict "Prefix" "dash")}}`) {
+		t.Error(`dashboard template must invoke compareSearchWidget with Prefix "dash" — do not re-inline the markup`)
+	}
+
+	grpStart := strings.Index(allTemplates, `{{define "group"}}`)
+	grpEnd := strings.Index(allTemplates[grpStart+1:], `{{define "`)
+	if grpStart < 0 || grpEnd < 0 {
+		t.Fatal("could not locate group template boundaries")
+	}
+	grpSection := allTemplates[grpStart : grpStart+1+grpEnd]
+	if !strings.Contains(grpSection, `{{template "compareSearchWidget" (dict "Prefix" "grp")}}`) {
+		t.Error(`group template must invoke compareSearchWidget with Prefix "grp" — do not re-inline the markup`)
+	}
+
+	// The old #dash-repo-search and #grp-repo-search IDs must not appear
+	// as inline hardcoded strings outside the shared template. The shared
+	// template builds them via the Prefix parameter, so a hardcoded
+	// literal inside dashboard/group indicates a regression.
+	widgetStart := strings.Index(allTemplates, `{{define "compareSearchWidget"}}`)
+	widgetEnd := strings.Index(allTemplates[widgetStart:], `{{end}}`) + widgetStart
+	inWidget := allTemplates[widgetStart:widgetEnd]
+	for _, literal := range []string{"'dash-repo-search'", "'grp-repo-search'", "'dash-search-results'", "'grp-search-results'"} {
+		// Literal string occurrences outside the shared widget would mean
+		// someone started hand-rolling the JS again. The widget itself
+		// builds IDs from the prefix so doesn't contain these literals.
+		if strings.Contains(inWidget, literal) {
+			t.Errorf("compareSearchWidget should derive %s from the Prefix parameter, not hardcode it", literal)
+		}
+		// Count occurrences across the whole template string: anything
+		// outside the shared widget is a duplicate.
+		total := strings.Count(allTemplates, literal)
+		if total > 0 {
+			t.Errorf("found %d hardcoded occurrences of %s — the shared widget builds these from Prefix", total, literal)
+		}
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +39,7 @@ type Server struct {
 	sessionMu sync.RWMutex
 	sessions  map[string]*Session // session token -> session
 	tmpl     *template.Template
+	apiProxy http.Handler // reverse proxy for /api/* → cfg.APIInternalURL; nil on parse failure
 }
 
 // Session tracks a logged-in user.
@@ -94,6 +97,35 @@ func New(store *db.PostgresStore, cfg config.WebConfig, ghKeys *platform.KeyPool
 			},
 			RedirectURL: baseURL + "/auth/gitlab/callback",
 		}
+	}
+
+	// Build the internal API reverse proxy. The web server forwards /api/*
+	// to cfg.APIInternalURL so the browser can fetch data using relative
+	// URLs (same-origin, no CORS). This works transparently behind an nginx
+	// front proxy: nginx → web(:8082) → reverse proxy → api(:8383). If an
+	// operator prefers to handle /api/* in nginx directly, adding a
+	// `location /api/` block pointing at the api port takes precedence and
+	// the web server's built-in proxy becomes unused — no code change needed.
+	apiURL := strings.TrimSpace(cfg.APIInternalURL)
+	if apiURL == "" {
+		apiURL = "http://127.0.0.1:8383"
+	}
+	if target, err := url.Parse(apiURL); err == nil && target.Host != "" {
+		rp := httputil.NewSingleHostReverseProxy(target)
+		rp.Transport = &http.Transport{
+			// Short timeouts so a dead api process fails fast instead of
+			// blocking browser requests. The browser sees 502 Bad Gateway.
+			ResponseHeaderTimeout: 15 * time.Second,
+			IdleConnTimeout:       60 * time.Second,
+		}
+		rp.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			logger.Warn("api reverse proxy error", "path", r.URL.Path, "error", err)
+			http.Error(w, "API backend unavailable", http.StatusBadGateway)
+		}
+		s.apiProxy = rp
+	} else {
+		logger.Warn("invalid api_internal_url; /api proxy disabled",
+			"api_internal_url", apiURL, "error", err)
 	}
 
 	// Parse embedded templates.
@@ -155,6 +187,15 @@ func (s *Server) Handler() http.Handler {
 	// Monitor dashboard — integrated from the standalone monitor server.
 	mux.HandleFunc("/monitor", s.requireAuth(s.handleMonitor))
 	mux.HandleFunc("POST /monitor/prioritize/{repoID}", s.requireAuth(s.handleMonitorPrioritize))
+
+	// Same-origin API reverse proxy. Browser fetch calls use relative
+	// /api/v1/... URLs; this handler forwards them to cfg.APIInternalURL.
+	// Gated by requireAuth so an anonymous visitor can't query collected
+	// data through the proxy. The browser sends the aveloxis_session cookie
+	// on same-origin requests, which the auth middleware validates.
+	if s.apiProxy != nil {
+		mux.Handle("/api/", s.requireAuth(s.apiProxy.ServeHTTP))
+	}
 
 	return mux
 }

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -112,85 +112,7 @@ h3{font-size:16px;margin-bottom:12px;color:#24292e}
 <div class="card" id="compare-card">
 <h2>Compare Repositories</h2>
 <p style="color:#586069;font-size:14px;margin-bottom:12px">Search and select up to 5 repositories to compare side-by-side with weekly activity charts. Use 100% or Z-Score modes to normalize for community size.</p>
-<form id="compare-form" action="/compare" method="GET" style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">
-<div style="position:relative;flex:1;min-width:250px">
-<input type="text" id="dash-repo-search" placeholder="Type to search repositories..." autocomplete="off" style="width:100%">
-<div id="dash-search-results" style="display:none;position:absolute;top:100%;left:0;right:0;background:white;border:1px solid #d1d5da;border-top:none;border-radius:0 0 6px 6px;box-shadow:0 4px 12px rgba(0,0,0,0.15);max-height:220px;overflow-y:auto;z-index:100"></div>
-</div>
-<input type="hidden" id="dash-repo-ids" name="repos" value="">
-<button type="submit" class="btn btn-primary">Compare</button>
-</form>
-<div id="dash-selected" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px"></div>
-<script>
-(function() {
-  const API = 'http://localhost:8383';
-  const input = document.getElementById('dash-repo-search');
-  const results = document.getElementById('dash-search-results');
-  const selected = document.getElementById('dash-selected');
-  const hiddenIds = document.getElementById('dash-repo-ids');
-  const COLORS = ['#2563eb','#10b981','#f59e0b','#ef4444','#8b5cf6'];
-  let repos = [];
-  let timer;
-
-  input.addEventListener('input', function() {
-    clearTimeout(timer);
-    const q = this.value.trim();
-    if (q.length < 2) { results.style.display = 'none'; return; }
-    timer = setTimeout(() => {
-      fetch(API + '/api/v1/repos/search?q=' + encodeURIComponent(q))
-        .then(r => r.json())
-        .then(data => {
-          if (!data || data.length === 0) { results.style.display = 'none'; return; }
-          results.innerHTML = data.slice(0, 15).map(r =>
-            '<div style="padding:8px 12px;cursor:pointer;font-size:13px;border-bottom:1px solid #f0f0f0" ' +
-            'onmouseover="this.style.background=\'#f6f8fa\'" onmouseout="this.style.background=\'white\'" ' +
-            'data-id="' + r.id + '" data-owner="' + r.owner + '" data-name="' + r.name + '">' +
-            r.owner + '/<strong>' + r.name + '</strong></div>'
-          ).join('');
-          results.style.display = 'block';
-          results.querySelectorAll('div').forEach(el => {
-            el.onclick = () => addRepo(+el.dataset.id, el.dataset.owner, el.dataset.name);
-          });
-        })
-        .catch(() => { results.style.display = 'none'; });
-    }, 200);
-  });
-
-  input.addEventListener('focus', function() {
-    if (results.innerHTML && this.value.length >= 2) results.style.display = 'block';
-  });
-
-  document.addEventListener('click', e => {
-    if (!e.target.closest('#dash-repo-search') && !e.target.closest('#dash-search-results'))
-      results.style.display = 'none';
-  });
-
-  function addRepo(id, owner, name) {
-    if (repos.length >= 5) { alert('Maximum 5 repos.'); return; }
-    if (repos.find(r => r.id === id)) return;
-    repos.push({id, owner, name});
-    results.style.display = 'none';
-    input.value = '';
-    render();
-  }
-
-  function removeRepo(id) {
-    repos = repos.filter(r => r.id !== id);
-    render();
-  }
-  window._dashRemoveRepo = removeRepo;
-
-  function render() {
-    selected.innerHTML = repos.map((r, i) =>
-      '<span style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:16px;font-size:13px;font-weight:500;background:' +
-      COLORS[i] + '20;color:' + COLORS[i] + '">' +
-      r.owner + '/' + r.name +
-      ' <button onclick="_dashRemoveRepo(' + r.id + ')" style="background:none;border:none;cursor:pointer;color:inherit;font-size:14px">&times;</button></span>'
-    ).join('');
-    hiddenIds.value = repos.map(r => r.id).join(',');
-  }
-})();
-</script>
+{{template "compareSearchWidget" (dict "Prefix" "dash")}}
 </div>
 </div>
 </body></html>
@@ -254,15 +176,7 @@ https://gitlab.com/group/project" style="width:100%;padding:8px 12px;border:1px 
 <div class="section" id="grp-compare-card">
 <h3>Compare Repositories</h3>
 <p style="color:#586069;font-size:13px;margin-bottom:8px">Search and select up to 5 repositories to compare activity charts side-by-side.</p>
-<form id="grp-compare-form" action="/compare" method="GET" style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">
-<div style="position:relative;flex:1;min-width:250px">
-<input type="text" id="grp-repo-search" placeholder="Type to search repositories..." autocomplete="off" style="width:100%">
-<div id="grp-search-results" style="display:none;position:absolute;top:100%;left:0;right:0;background:white;border:1px solid #d1d5da;border-top:none;border-radius:0 0 6px 6px;box-shadow:0 4px 12px rgba(0,0,0,0.15);max-height:220px;overflow-y:auto;z-index:100"></div>
-</div>
-<input type="hidden" id="grp-repo-ids" name="repos" value="">
-<button type="submit" class="btn btn-primary">Compare</button>
-</form>
-<div id="grp-selected" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px"></div>
+{{template "compareSearchWidget" (dict "Prefix" "grp")}}
 </div>
 
 <div class="section">
@@ -321,78 +235,6 @@ https://gitlab.com/group/project" style="width:100%;padding:8px 12px;border:1px 
 </div>
 </div>
 </div>
-<script>
-// Compare search widget for the group detail page.
-// Uses the same API-powered autocomplete as the dashboard and compare pages.
-(function() {
-  const API = 'http://localhost:8383';
-  const input = document.getElementById('grp-repo-search');
-  const results = document.getElementById('grp-search-results');
-  const selected = document.getElementById('grp-selected');
-  const hiddenIds = document.getElementById('grp-repo-ids');
-  const COLORS = ['#2563eb','#10b981','#f59e0b','#ef4444','#8b5cf6'];
-  let repos = [];
-  let timer;
-
-  input.addEventListener('input', function() {
-    clearTimeout(timer);
-    const q = this.value.trim();
-    if (q.length < 2) { results.style.display = 'none'; return; }
-    timer = setTimeout(() => {
-      fetch(API + '/api/v1/repos/search?q=' + encodeURIComponent(q))
-        .then(r => r.json())
-        .then(data => {
-          if (!data || data.length === 0) { results.style.display = 'none'; return; }
-          results.innerHTML = data.slice(0, 15).map(r =>
-            '<div style="padding:8px 12px;cursor:pointer;font-size:13px;border-bottom:1px solid #f0f0f0" ' +
-            'onmouseover="this.style.background=\'#f6f8fa\'" onmouseout="this.style.background=\'white\'" ' +
-            'data-id="' + r.id + '" data-owner="' + r.owner + '" data-name="' + r.name + '">' +
-            r.owner + '/<strong>' + r.name + '</strong></div>'
-          ).join('');
-          results.style.display = 'block';
-          results.querySelectorAll('div').forEach(el => {
-            el.onclick = () => addRepo(+el.dataset.id, el.dataset.owner, el.dataset.name);
-          });
-        })
-        .catch(() => { results.style.display = 'none'; });
-    }, 200);
-  });
-
-  input.addEventListener('focus', function() {
-    if (results.innerHTML && this.value.length >= 2) results.style.display = 'block';
-  });
-
-  document.addEventListener('click', e => {
-    if (!e.target.closest('#grp-repo-search') && !e.target.closest('#grp-search-results'))
-      results.style.display = 'none';
-  });
-
-  function addRepo(id, owner, name) {
-    if (repos.length >= 5) { alert('Maximum 5 repos.'); return; }
-    if (repos.find(r => r.id === id)) return;
-    repos.push({id, owner, name});
-    results.style.display = 'none';
-    input.value = '';
-    render();
-  }
-
-  function removeRepo(id) {
-    repos = repos.filter(r => r.id !== id);
-    render();
-  }
-  window._grpRemoveRepo = removeRepo;
-
-  function render() {
-    selected.innerHTML = repos.map((r, i) =>
-      '<span style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:16px;font-size:13px;font-weight:500;background:' +
-      COLORS[i] + '20;color:' + COLORS[i] + '">' +
-      r.owner + '/' + r.name +
-      ' <button onclick="_grpRemoveRepo(' + r.id + ')" style="background:none;border:none;cursor:pointer;color:inherit;font-size:14px">&times;</button></span>'
-    ).join('');
-    hiddenIds.value = repos.map(r => r.id).join(',');
-  }
-})();
-</script>
 </body></html>
 {{end}}
 
@@ -476,7 +318,10 @@ https://gitlab.com/group/project" style="width:100%;padding:8px 12px;border:1px 
 </div>
 
 <script>
-const API_BASE = 'http://localhost:8383';
+// Same-origin fetch: the web server reverse-proxies /api/* to the
+// configured api process (web.api_internal_url), so relative URLs
+// work behind nginx/TLS and eliminate CORS concerns.
+const API_BASE = '';
 const REPO_ID = {{.RepoID}};
 
 // Chart color palette.
@@ -727,7 +572,10 @@ fetch(API_BASE + '/api/v1/repos/' + REPO_ID + '/scancode-files')
 </div>
 
 <script>
-const API_BASE = 'http://localhost:8383';
+// Same-origin fetch: the web server reverse-proxies /api/* to the
+// configured api process (web.api_internal_url), so relative URLs
+// work behind nginx/TLS and eliminate CORS concerns.
+const API_BASE = '';
 const CHART_COLORS = ['#2563eb','#10b981','#f59e0b','#ef4444','#8b5cf6'];
 let selectedRepos = [];
 let allRepoData = {};
@@ -1083,6 +931,113 @@ if (urlRepos.length > 0) {
   had correct hrefs in unit tests but failed in practice because the
   10s auto-refresh raced with click navigation on slow page renders.
 */}}
+{{/*
+  compareSearchWidget: the type-to-search autocomplete used on the
+  dashboard and the group detail page to pick up to 5 repos to compare.
+  Takes a Prefix string (e.g. "dash", "grp") which scopes all DOM IDs so
+  multiple widgets can coexist if ever needed.
+
+  Extracted from two near-identical copies that had drifted apart in the
+  past — the group-page copy never worked correctly because the hardcoded
+  API URL (pre-v0.18.18) resolved to the user's own machine. Sharing a
+  single definition eliminates that drift class: a fix on one page is a
+  fix on both, and the source-contract test below asserts every compare
+  page invokes this template by name.
+
+  Not used by the full /compare page's widget (#repo-search): that one is
+  interleaved with charts and date-range state and would require a
+  heavier refactor. The compareSearchWidget invariants (endpoint, debounce,
+  dropdown behavior) still apply there and are covered by runtime tests.
+*/}}
+{{define "compareSearchWidget"}}
+<form id="{{.Prefix}}-compare-form" action="/compare" method="GET" style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">
+<div style="position:relative;flex:1;min-width:250px">
+<input type="text" id="{{.Prefix}}-repo-search" placeholder="Type to search repositories..." autocomplete="off" style="width:100%">
+<div id="{{.Prefix}}-search-results" style="display:none;position:absolute;top:100%;left:0;right:0;background:white;border:1px solid #d1d5da;border-top:none;border-radius:0 0 6px 6px;box-shadow:0 4px 12px rgba(0,0,0,0.15);max-height:220px;overflow-y:auto;z-index:100"></div>
+</div>
+<input type="hidden" id="{{.Prefix}}-repo-ids" name="repos" value="">
+<button type="submit" class="btn btn-primary">Compare</button>
+</form>
+<div id="{{.Prefix}}-selected" style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px"></div>
+<script>
+(function() {
+  // Same-origin fetch: the web server reverse-proxies /api/* to the
+  // configured api process (web.api_internal_url), so relative URLs
+  // work behind nginx/TLS and eliminate CORS concerns.
+  const API = '';
+  const prefix = {{.Prefix}};
+  const input = document.getElementById(prefix + '-repo-search');
+  const results = document.getElementById(prefix + '-search-results');
+  const selected = document.getElementById(prefix + '-selected');
+  const hiddenIds = document.getElementById(prefix + '-repo-ids');
+  const COLORS = ['#2563eb','#10b981','#f59e0b','#ef4444','#8b5cf6'];
+  let repos = [];
+  let timer;
+
+  input.addEventListener('input', function() {
+    clearTimeout(timer);
+    const q = this.value.trim();
+    if (q.length < 2) { results.style.display = 'none'; return; }
+    timer = setTimeout(() => {
+      fetch(API + '/api/v1/repos/search?q=' + encodeURIComponent(q))
+        .then(r => r.json())
+        .then(data => {
+          if (!data || data.length === 0) { results.style.display = 'none'; return; }
+          results.innerHTML = data.slice(0, 15).map(r =>
+            '<div style="padding:8px 12px;cursor:pointer;font-size:13px;border-bottom:1px solid #f0f0f0" ' +
+            'onmouseover="this.style.background=\'#f6f8fa\'" onmouseout="this.style.background=\'white\'" ' +
+            'data-id="' + r.id + '" data-owner="' + r.owner + '" data-name="' + r.name + '">' +
+            r.owner + '/<strong>' + r.name + '</strong></div>'
+          ).join('');
+          results.style.display = 'block';
+          results.querySelectorAll('div').forEach(el => {
+            el.onclick = () => addRepo(+el.dataset.id, el.dataset.owner, el.dataset.name);
+          });
+        })
+        .catch(() => { results.style.display = 'none'; });
+    }, 200);
+  });
+
+  input.addEventListener('focus', function() {
+    if (results.innerHTML && this.value.length >= 2) results.style.display = 'block';
+  });
+
+  document.addEventListener('click', e => {
+    if (!e.target.closest('#' + prefix + '-repo-search') && !e.target.closest('#' + prefix + '-search-results'))
+      results.style.display = 'none';
+  });
+
+  function addRepo(id, owner, name) {
+    if (repos.length >= 5) { alert('Maximum 5 repos.'); return; }
+    if (repos.find(r => r.id === id)) return;
+    repos.push({id, owner, name});
+    results.style.display = 'none';
+    input.value = '';
+    render();
+  }
+
+  function removeRepo(id) {
+    repos = repos.filter(r => r.id !== id);
+    render();
+  }
+  // Expose a uniquely-named global so multiple widgets on one page (not
+  // today, but nothing prevents it in the future) don't collide.
+  const removeFnName = '_' + prefix + 'RemoveRepo';
+  window[removeFnName] = removeRepo;
+
+  function render() {
+    selected.innerHTML = repos.map((r, i) =>
+      '<span style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:16px;font-size:13px;font-weight:500;background:' +
+      COLORS[i] + '20;color:' + COLORS[i] + '">' +
+      r.owner + '/' + r.name +
+      ' <button onclick="' + removeFnName + '(' + r.id + ')" style="background:none;border:none;cursor:pointer;color:inherit;font-size:14px">&times;</button></span>'
+    ).join('');
+    hiddenIds.value = repos.map(r => r.id).join(',');
+  }
+})();
+</script>
+{{end}}
+
 {{define "paginationNav"}}
 {{if gt .TotalPages 1}}
 <div class="pagination">

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# smoke.sh — end-to-end smoke test for the three-process Aveloxis deployment.
+#
+# Implements recommendation #6 from the compare-autocomplete post-mortem:
+# catch "api crashes on startup" and "web can't reach api" regressions before
+# they reach users. The unit-test suite can't catch startup failures (config
+# parse errors, bad DB auth, missing keys, port conflicts) because nothing
+# runs the real binaries together. This script does.
+#
+# What it exercises:
+#   1. `aveloxis serve`, `aveloxis web`, `aveloxis api` all start cleanly.
+#   2. The api responds at /api/v1/health.
+#   3. The api responds at /api/v1/repos/search (the endpoint that powers
+#      the compare autocomplete — the one that silently stopped working).
+#   4. The web server's reverse proxy at /api/v1/* is wired. A GET through
+#      the web origin returns the same payload as a direct GET to the api.
+#      This is the invariant that was broken pre-v0.18.18 (hardcoded
+#      localhost:8383 in the JS) and the one this script guards.
+#
+# What it does NOT exercise:
+#   - OAuth login (requires GitHub/GitLab credentials and live redirects).
+#   - Actual collection work (requires API keys; see `aveloxis add-key`).
+#
+# Usage:
+#   ./scripts/smoke.sh                    # uses ./aveloxis.json
+#   ./scripts/smoke.sh path/to/config.json
+#
+# Requirements on the host:
+#   - PostgreSQL reachable per the config's `database` section.
+#   - `aveloxis` binary present in PATH or buildable from this repo.
+#   - `curl` and `jq` (curl for probes, jq for JSON assertions).
+#   - At least one API key in the aveloxis_ops.worker_oauth table; without
+#     one, `aveloxis serve` refuses to start (CLAUDE.md "API keys required"
+#     pitfall). Add with `aveloxis add-key <token> --platform github`.
+#
+# CI integration:
+#   Wire this into GitHub Actions / equivalent by calling:
+#     ./scripts/smoke.sh
+#   after starting a postgres service container and running `aveloxis migrate`
+#   and `aveloxis add-key`.
+#
+# Exit codes:
+#   0  — all probes passed.
+#   1  — any probe failed, or any process failed to start.
+
+set -euo pipefail
+
+CONFIG="${1:-aveloxis.json}"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "smoke.sh: config file not found: $CONFIG" >&2
+  exit 1
+fi
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "smoke.sh: $cmd is required but not installed" >&2
+    exit 1
+  fi
+done
+
+# Locate the aveloxis binary. Prefer PATH; fall back to a local build in
+# a temp dir so a fresh clone can run this without an existing install.
+AVELOXIS_BIN="$(command -v aveloxis || true)"
+if [[ -z "$AVELOXIS_BIN" ]]; then
+  echo "smoke.sh: building aveloxis binary (not found on PATH)..."
+  tmpbin="$(mktemp -d)/aveloxis"
+  (cd "$(dirname "$0")/.." && go build -o "$tmpbin" ./cmd/aveloxis)
+  AVELOXIS_BIN="$tmpbin"
+fi
+echo "smoke.sh: using binary $AVELOXIS_BIN"
+
+# Work in an isolated temp dir so we don't clobber any logs/pids in ~/.aveloxis
+# or wherever the operator's live install lives.
+WORKDIR="$(mktemp -d -t aveloxis-smoke-XXXXXX)"
+cleanup() {
+  local rc=$?
+  echo
+  echo "smoke.sh: cleaning up..."
+  # Kill in reverse startup order. `kill 0 -PGID` style is safer but harder
+  # to do portably; we keep explicit PIDs.
+  for pidfile in "$WORKDIR"/api.pid "$WORKDIR"/web.pid "$WORKDIR"/serve.pid; do
+    if [[ -f "$pidfile" ]]; then
+      pid=$(cat "$pidfile" 2>/dev/null || true)
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        # Give it up to 3 seconds to exit cleanly, then SIGKILL.
+        for _ in 1 2 3; do
+          kill -0 "$pid" 2>/dev/null || break
+          sleep 1
+        done
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+    fi
+  done
+  if [[ $rc -ne 0 ]]; then
+    echo "smoke.sh: FAILED (exit $rc). Logs preserved in $WORKDIR"
+  else
+    rm -rf "$WORKDIR"
+  fi
+  exit $rc
+}
+trap cleanup EXIT
+
+# Read API / web addresses from the config. The api --addr flag overrides the
+# config, which is useful for running this alongside a live aveloxis install.
+# Web addr comes from config only; override in your config file if you need
+# a different port.
+API_ADDR=$(jq -r '.web.api_internal_url // "http://127.0.0.1:8383"' "$CONFIG")
+# Strip scheme for --addr (which expects host:port).
+API_HOSTPORT="${API_ADDR#http://}"
+API_HOSTPORT="${API_HOSTPORT#https://}"
+API_HOSTPORT="${API_HOSTPORT%/}"
+
+WEB_ADDR=$(jq -r '.web.addr // ":8082"' "$CONFIG")
+# Normalize ":8082" → "127.0.0.1:8082" for curl.
+if [[ "$WEB_ADDR" == :* ]]; then
+  WEB_HOSTPORT="127.0.0.1${WEB_ADDR}"
+else
+  WEB_HOSTPORT="$WEB_ADDR"
+fi
+
+# Start the three processes. `serve` is the heaviest; we tolerate it failing
+# to start (e.g. no API keys loaded) only if the operator opted in.
+echo "smoke.sh: starting aveloxis api on ${API_HOSTPORT}..."
+"$AVELOXIS_BIN" -c "$CONFIG" api --addr "$API_HOSTPORT" \
+  > "$WORKDIR/api.log" 2>&1 &
+echo $! > "$WORKDIR/api.pid"
+
+echo "smoke.sh: starting aveloxis web on ${WEB_HOSTPORT}..."
+"$AVELOXIS_BIN" -c "$CONFIG" web \
+  > "$WORKDIR/web.log" 2>&1 &
+echo $! > "$WORKDIR/web.pid"
+
+# Serve is optional: it refuses to start without API keys. We start it but
+# don't fail the smoke test if it exits — the compare-autocomplete bug class
+# this script targets lives in web+api, not in the scheduler.
+echo "smoke.sh: starting aveloxis serve (scheduler)..."
+"$AVELOXIS_BIN" -c "$CONFIG" serve \
+  > "$WORKDIR/serve.log" 2>&1 &
+echo $! > "$WORKDIR/serve.pid"
+
+# Wait for web and api to be listening. Poll with a bounded timeout rather
+# than sleeping a fixed duration — we want to fail fast if something is wrong
+# but not time out on a slow-booting DB.
+wait_for_http() {
+  local url="$1" label="$2" timeout="${3:-30}"
+  local deadline=$(( $(date +%s) + timeout ))
+  while (( $(date +%s) < deadline )); do
+    if curl -sf -o /dev/null "$url"; then
+      echo "smoke.sh: ${label} ready (${url})"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "smoke.sh: ${label} did not come up at ${url} within ${timeout}s" >&2
+  echo "--- ${label} log (tail) ---" >&2
+  tail -30 "$WORKDIR/${label}.log" >&2 || true
+  return 1
+}
+
+wait_for_http "http://${API_HOSTPORT}/api/v1/health" api 30
+wait_for_http "http://${WEB_HOSTPORT}/login" web 30
+
+# --- Probes ---
+
+fail=0
+probe() {
+  local name="$1" url="$2" check="$3"
+  local body
+  if ! body=$(curl -sf "$url" 2>/dev/null); then
+    echo "smoke.sh: PROBE FAIL  $name  GET $url (non-2xx or connection failed)"
+    fail=1
+    return
+  fi
+  if ! echo "$body" | eval "$check" >/dev/null 2>&1; then
+    echo "smoke.sh: PROBE FAIL  $name  GET $url  (body did not satisfy: $check)"
+    echo "  body: $body"
+    fail=1
+    return
+  fi
+  echo "smoke.sh: PROBE OK    $name"
+}
+
+# 1. API health returns {"status":"ok", ...}.
+probe "api /health" \
+  "http://${API_HOSTPORT}/api/v1/health" \
+  'jq -e ".status == \"ok\""'
+
+# 2. API search returns a JSON array (possibly empty). The 'q=a' is required
+#    by the handler; a missing q parameter is a 400 which curl -f catches.
+probe "api /repos/search" \
+  "http://${API_HOSTPORT}/api/v1/repos/search?q=a" \
+  'jq -e "type == \"array\""'
+
+# 3. Web reverse proxy forwards /api/v1/health. This is the invariant the
+#    compare autocomplete depends on: the browser fetches relative
+#    /api/v1/... URLs, which must hit the api via the web origin.
+#
+#    The proxy is auth-gated. We probe with a dummy session cookie; the
+#    requireAuth middleware will redirect (302) to /login for an invalid
+#    token. Rather than log in via OAuth (which requires real credentials),
+#    we assert the SHAPE of the failure — the proxy IS wired and rejecting
+#    unauth'd requests, NOT returning 404 which would mean no handler.
+unauth_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  "http://${WEB_HOSTPORT}/api/v1/health")
+if [[ "$unauth_code" != "302" && "$unauth_code" != "401" && "$unauth_code" != "403" ]]; then
+  echo "smoke.sh: PROBE FAIL  web /api/* proxy  expected 302/401/403 for unauth'd request, got $unauth_code"
+  echo "  A 404 here means the web server isn't reverse-proxying /api/* — the compare autocomplete will be broken."
+  fail=1
+else
+  echo "smoke.sh: PROBE OK    web /api/* proxy is wired (unauth -> $unauth_code)"
+fi
+
+# 4. Web login page loads (smoke test of template parsing / static assets).
+probe "web /login renders" \
+  "http://${WEB_HOSTPORT}/login" \
+  'grep -q "Sign in"'
+
+if (( fail )); then
+  echo "smoke.sh: FAILURE — one or more probes did not pass"
+  exit 1
+fi
+
+echo "smoke.sh: SUCCESS — all probes passed"
+exit 0

--- a/scripts/smoke_test.go
+++ b/scripts/smoke_test.go
@@ -1,0 +1,59 @@
+// Package scripts_test verifies shell scripts under ./scripts/ stay sound.
+//
+// Shell scripts aren't covered by `go test ./...` by default; this file
+// promotes the smoke.sh script to a first-class test target so a broken
+// script (syntax error, deleted file) fails CI the same way a broken Go
+// test does. It does NOT execute the script end-to-end — that requires a
+// live Postgres + API keys and is the job of the CI workflow that calls
+// the script directly. It only guards "does this script still parse".
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestSmokeScriptParses runs `bash -n scripts/smoke.sh` from the repo root.
+// A regression that breaks bash syntax (missing quote, unbalanced if/fi,
+// mis-edited heredoc) fails this test before it reaches CI.
+func TestSmokeScriptParses(t *testing.T) {
+	// Locate the repo root. Tests run from the package dir (./scripts/) but
+	// we want to check-parse the script at its actual path.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	script := filepath.Join(wd, "smoke.sh")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("smoke.sh not found at %s: %v", script, err)
+	}
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not found on PATH; skipping smoke.sh syntax check")
+	}
+
+	out, err := exec.Command(bash, "-n", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("smoke.sh failed bash -n syntax check:\n%s\nerror: %v", out, err)
+	}
+}
+
+// TestSmokeScriptIsExecutable guards the chmod +x bit. A non-executable
+// script fails with a cryptic "Permission denied" in CI; this test
+// surfaces the issue immediately.
+func TestSmokeScriptIsExecutable(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(wd, "smoke.sh"))
+	if err != nil {
+		t.Fatalf("smoke.sh not found: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("smoke.sh is not executable (mode=%v); run: chmod +x scripts/smoke.sh", info.Mode())
+	}
+}


### PR DESCRIPTION
  - WebConfig.APIInternalURL added; default http://127.0.0.1:8383.
  - internal/web/server.go builds an authenticated httputil.NewSingleHostReverseProxy at /api/* with a 15 s response-header timeout and a 502-returning error handler.
  - All four hardcoded http://localhost:8383 URLs in templates.go switched to same-origin empty prefix. Works transparently through your nginx location / block (nginx → web :8082 → proxy → api :8383). Operators who prefer nginx to handle /api/* can add a location /api/ block pointing at 8383; nginx precedence means the web proxy becomes unused with zero code changes.
  - Regression test TestTemplatesHaveNoHardcodedLocalhostAPI fails the build if anyone re-adds the bad pattern.

  #5 — Shared compareSearchWidget template (v0.18.19)
  - New {{define compareSearchWidget}} in templates.go, parameterized by Prefix.
  - Dashboard and group pages each collapsed to one line: {{template compareSearchWidget (dict Prefix dash)}} / grp.
  - TestCompareSearchWidgetIsShared pins: definition exists, both pages invoke it, and no hardcoded dash-repo-search / grp-repo-search literals remain outside the widget.

  #1 — Integration tests for compare widgets (internal/web/compare_integration_test.go, api_proxy_test.go)
  - Six tests covering: rendered widget has relative fetch URL, prefix isolation works, full dashboard/group page renders wire the API endpoint correctly, and the key round-trip: render dashboard → extract fetch URL from JS → issue it against the web Handler → fake-api response comes back through the proxy. Two proxy tests verify auth-gating and fail-fast (502) when the api is down.

  #6 — Smoke script (v0.18.20, scripts/smoke.sh + scripts/smoke_test.go)
  - Script starts all three binaries, probes /api/v1/health, /api/v1/repos/search?q=a, the web reverse proxy at /api/v1/health (asserts auth-gated 302/401/403, not 404), and /login. Trap cleans up processes on any exit.
  - TestSmokeScriptParses and TestSmokeScriptIsExecutable run bash -n and check the exec bit so a broken script fails go test ./... before CI does.

  Version is now 0.18.20.