### PR TITLE
fix 40k repo test issues surfaced

### DIFF
--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -158,6 +158,7 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		ListingMode:         cfg.Collection.ListingMode,
 		ThreadingMode:       cfg.Collection.ThreadingMode,
 		ShardSize:           cfg.Collection.ShardSize,
+		EnrichInterval:      cfg.Collection.EnrichIntervalDuration(),
 	})
 	go sched.Run(ctx)
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -746,6 +746,77 @@ If the service outage is prolonged, the repo will fail after 10 retries and be r
 
 ---
 
+## Restart appears to take days before collection resumes
+
+**Symptom:** After `aveloxis serve` restarts on a large fleet (10K+ repos), the monitor dashboard shows zero active workers for hours or days, even though the queue has thousands of due repos. New collection traffic doesn't begin until what looks like a multi-day "warm-up" finishes.
+
+**Cause:** Before v0.18.29, `processLeftoverStaging` ran synchronously on the scheduler's main goroutine before `fillWorkerSlots` could claim any new jobs. Each repo with backlogged staging from a prior interrupted run could take 30+ hours to process; with 23 backlogged repos, the worker pool sat idle for ~3 days while staging drained.
+
+**Solution (v0.18.29):** The drain now runs in a background goroutine. Repos with leftover staging are atomically lock-parked (`status='collecting'`, `locked_by='<workerID>:drain'`) before the goroutine launches, so `fillWorkerSlots` skips them naturally and immediately starts claiming the rest of the fleet's queued repos. Each drained repo rejoins the queue as draining completes.
+
+**Confirm the fix is active:**
+
+```bash
+grep "launching background leftover-staging drain" ~/.aveloxis/aveloxis.log
+# v0.18.29: this line appears within seconds of restart with the count
+# of repos being drained. Workers begin claiming queued repos in parallel.
+```
+
+If the log instead shows `processing leftover staging data from previous run (synchronous fallback)`, the drain-park UPDATE failed (e.g. transient DB error) and the scheduler fell back to the synchronous path to preserve data integrity. The fallback is rare; investigate the preceding `failed to lock-park leftover drain set` warning.
+
+**The first-collection invariant is preserved:** for repos whose initial collection was interrupted (`last_collected = NULL` in `aveloxis_ops.collection_queue`), the drain processes pre-staged data into relational tables but does NOT set `last_collected`. The repo rejoins the queue with `last_collected = NULL`, so its next claim runs `since=zero` (a fresh full re-fetch) and only `CompleteJob` ever sets the timestamp after a successful end-to-end collection. This is enforced by source-contract test `TestLockReposForDrainSQLDoesNotTouchLastCollected` and integration test `TestLockReposForDrainPreservesNullLastCollected` (gated on `AVELOXIS_TEST_DB`).
+
+---
+
+## All API tokens exhausted within minutes of restart
+
+**Symptom:** After `aveloxis serve` finishes startup, the log fills with `all API keys rate-limited, waiting for reset` within 10–15 minutes. All 73 (or however many) GitHub keys hit zero remaining requests almost simultaneously, and collection pauses for ~45 minutes until the GitHub rate window resets.
+
+**Cause:** Before v0.18.29, `EnrichThinContributors(EnrichBatchSize=14000)` was called from inside `runJob` — i.e. **once per repo collection**. Every worker, after finishing its (often tiny) repo, would query up to 14,000 thin-profile logins and fire `GET /users/{login}` against REST for each one. With 120 workers all firing concurrently, the fleet attempted on the order of 1.7 million REST calls in parallel windows. The 73-key pool's hourly budget (~365K calls) was exhausted in ~11 minutes on production fleets.
+
+**Solution (v0.18.29):** Enrichment moved to a periodic scheduler-level task (`Scheduler.runEnrichment`) driven by `cfg.EnrichInterval` (default 30 minutes). Single goroutine, single 14K batch per tick, ~28K REST calls per hour against the available budget — well within headroom and leaves the rest of the budget for actual collection traffic.
+
+**Configure the cadence in `aveloxis.json`:**
+
+```json
+{
+  "collection": {
+    "enrich_interval_minutes": 30
+  }
+}
+```
+
+Faster (e.g. `15`) catches up enrichment sooner; slower (e.g. `60`) leaves more REST headroom. Default is 30 if unset.
+
+**Confirm the fix is active:**
+
+```bash
+grep "enriching thin contributor profiles" ~/.aveloxis/aveloxis.log | head -5
+# v0.18.29: should appear at most twice per hour (default 30-min interval),
+# not 120 times within a few seconds after a restart.
+```
+
+---
+
+## Repeated `duplicate key value violates unique constraint "contributors_pkey"` in Postgres logs
+
+**Symptom:** PostgreSQL logs show thousands of `ERROR: duplicate key value violates unique constraint "contributors_pkey"` warnings per day, all from `INSERT INTO aveloxis_data.contributors`. The errors don't crash collection (the upsert is wrapped in a retry/skip), but they generate log noise and individual contributor rows may end up with stale `cntrb_login` values.
+
+**Cause:** Before v0.18.29, `ContributorResolver.Resolve` (`internal/db/contributors.go`) passed the deterministic `cntrb_id = PlatformUUID(platform, userID)` as `$1` but used `ON CONFLICT (cntrb_login) WHERE cntrb_login != ''`. When two workers race to insert the same numeric platform user under different login strings (historical login drift across repos, GitHub renames, or just two workers seeing the same hot user — like `dependabot[bot]` appearing in hundreds of repos — concurrently), the login-targeted conflict check fails to match (the new login differs from the existing row's login), so the INSERT proceeds, then trips `contributors_pkey` because that `cntrb_id` already exists in the table.
+
+**Solution (v0.18.29):** `Resolve` now branches on `userID > 0`. The deterministic-UUID path uses `ON CONFLICT (cntrb_id) DO UPDATE SET cntrb_login = COALESCE(NULLIF(EXCLUDED.cntrb_login,''), contributors.cntrb_login), …`. Concurrent inserts of the same numeric user route cleanly to DO UPDATE; renamed users' rows pick up the new login on next observation. The `userID == 0` branch (random UUID for email-only contributors, no platform user) keeps `ON CONFLICT (cntrb_login) WHERE cntrb_login != ''` because login is the natural unique key there.
+
+**Confirm the fix is active:**
+
+```bash
+# Should show very few or zero contributors_pkey errors per day after v0.18.29.
+grep "contributors_pkey" /var/log/postgresql/postgresql-*.log | wc -l
+```
+
+If you still see them after upgrading, ensure both `aveloxis migrate` AND `aveloxis serve` are running v0.18.29 (mismatched binaries can leave the old SQL active in some code paths).
+
+---
+
 ## Next steps
 
 - [Monitoring](monitoring.md) -- use the dashboard for real-time status

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -581,16 +581,31 @@ func (c *Collector) collectReleases(ctx context.Context, repoID int64, owner, re
 
 func (c *Collector) collectContributors(ctx context.Context, repoID int64, owner, repo string, result *CollectResult) error {
 	c.logger.Info("collecting contributors", "owner", owner, "repo", repo)
+
+	// v0.18.29 Fix 4: accumulate into a slice and call UpsertContributorBatch
+	// once at the end. Per-row UpsertContributor created one transaction per
+	// contributor — for repos with hundreds of contributors that's hundreds of
+	// tiny transactions and corresponding race windows where concurrent
+	// workers seeing the same hot user (popular contributor across many repos)
+	// trip contributors_pkey before Fix 3's ON CONFLICT (cntrb_id) routing.
+	// Batching also lets UpsertContributorBatch's in-memory dedup merge any
+	// duplicate observations within the same iterator pass (richest-data wins).
+	var contribs []model.Contributor
 	for contrib, err := range c.client.ListContributors(ctx, owner, repo) {
 		if err != nil {
 			return err
 		}
-		if err := c.store.UpsertContributor(ctx, &contrib); err != nil {
-			c.logger.Warn("failed to upsert contributor", "login", contrib.Login, "error", err)
-			continue
-		}
-		result.Contributors++
+		contribs = append(contribs, contrib)
 	}
+	if len(contribs) == 0 {
+		return nil
+	}
+	if err := c.store.UpsertContributorBatch(ctx, contribs); err != nil {
+		c.logger.Warn("failed to upsert contributor batch",
+			"owner", owner, "repo", repo, "count", len(contribs), "error", err)
+		return err
+	}
+	result.Contributors += len(contribs)
 	return nil
 }
 

--- a/internal/collector/enrich.go
+++ b/internal/collector/enrich.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 
 	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/aveloxis/aveloxis/internal/model"
 	"github.com/aveloxis/aveloxis/internal/platform"
 )
 
@@ -26,7 +27,15 @@ import (
 const EnrichBatchSize = 14000
 
 // EnrichThinContributors finds contributors with missing profile data and
-// enriches them via the platform API. Called after collection and gap fill.
+// enriches them via the platform API. Called by the scheduler's periodic
+// enrichment ticker (v0.18.29 — moved off the per-job hot path).
+//
+// Accumulates enriched contributors into a slice and flushes via
+// UpsertContributorBatch at the end. v0.18.28's per-login UpsertContributor
+// loop produced ~14,000 single-row transactions per call; the batch path
+// runs them under one transaction with in-memory dedup, an order-of-
+// magnitude reduction in DB write traffic on a fleet-wide enrichment
+// cycle.
 func EnrichThinContributors(ctx context.Context, store *db.PostgresStore, resolver *db.ContributorResolver, client platform.Client, logger *slog.Logger) int {
 	logins, err := resolver.GetThinContributorLogins(ctx, EnrichBatchSize)
 	if err != nil {
@@ -38,7 +47,8 @@ func EnrichThinContributors(ctx context.Context, store *db.PostgresStore, resolv
 	}
 
 	logger.Info("enriching thin contributor profiles", "count", len(logins))
-	enriched := 0
+	enriched := make([]model.Contributor, 0, len(logins))
+	successLogins := make([]string, 0, len(logins))
 
 	for _, login := range logins {
 		contrib, err := client.EnrichContributor(ctx, login)
@@ -52,20 +62,34 @@ func EnrichThinContributors(ctx context.Context, store *db.PostgresStore, resolv
 			logger.Debug("failed to enrich contributor", "login", login, "error", err)
 			continue
 		}
-		if err := store.UpsertContributor(ctx, contrib); err != nil {
-			logger.Debug("failed to upsert enriched contributor", "login", login, "error", err)
-			continue
+		enriched = append(enriched, *contrib)
+		successLogins = append(successLogins, login)
+	}
+
+	// Single batch flush. UpsertContributorBatch dedupes by login in
+	// memory and runs one transaction.
+	if len(enriched) > 0 {
+		if err := store.UpsertContributorBatch(ctx, enriched); err != nil {
+			logger.Warn("failed to flush enriched contributor batch",
+				"count", len(enriched), "error", err)
+			// Don't mark them enriched if the batch failed — they'll be
+			// retried on the next periodic tick.
+			return 0
 		}
-		// Mark enrichment timestamp so users with genuinely empty profiles
-		// (no company/location on GitHub) are not re-enriched every pass.
+	}
+
+	// Mark enrichment timestamps in a separate pass so users with genuinely
+	// empty profiles (no company/location on GitHub) are not re-enriched
+	// every cycle. Done after the batch flush so we only mark logins whose
+	// data actually landed in the DB.
+	for _, login := range successLogins {
 		if mErr := resolver.MarkContributorEnriched(ctx, login); mErr != nil {
 			logger.Debug("failed to mark contributor enriched", "login", login, "error", mErr)
 		}
-		enriched++
 	}
 
-	if enriched > 0 {
-		logger.Info("contributor enrichment complete", "enriched", enriched, "of", len(logins))
+	if len(enriched) > 0 {
+		logger.Info("contributor enrichment complete", "enriched", len(enriched), "of", len(logins))
 	}
-	return enriched
+	return len(enriched)
 }

--- a/internal/collector/enrich_batch_test.go
+++ b/internal/collector/enrich_batch_test.go
@@ -1,0 +1,115 @@
+// Source-contract tests for v0.18.29 Fix 4: contributor enrichment
+// upserts are batched, not per-login.
+//
+// Background: at v0.18.28, EnrichThinContributors loops over up to 14000
+// thin logins and calls store.UpsertContributor(ctx, contrib) once per
+// login (enrich.go:55). Each call wraps a single contributor in a
+// fresh transaction. With Fix 2 making enrichment periodic, that's
+// 14000 individual transactions every 30 minutes. The bleeding stop
+// (Fix 3) handles correctness; this fix handles efficiency by
+// accumulating into a slice and flushing via UpsertContributorBatch
+// (which already does in-memory dedup and a single transaction per
+// batch — postgres.go:1089).
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEnrichThinContributorsBatchesUpserts pins the batch-flush pattern.
+// The function should accumulate enriched contributors into a slice and
+// flush via UpsertContributorBatch instead of calling UpsertContributor
+// per login.
+func TestEnrichThinContributorsBatchesUpserts(t *testing.T) {
+	src := mustReadEnrichSource(t)
+	body := extractEnrichFunc(src, "EnrichThinContributors")
+	if body == "" {
+		t.Fatal("could not locate EnrichThinContributors body")
+	}
+
+	if !strings.Contains(body, "UpsertContributorBatch") {
+		t.Error("EnrichThinContributors must call UpsertContributorBatch (not UpsertContributor per login). " +
+			"Per-login transactions waste DB write capacity at scale; the batch path already does in-memory " +
+			"dedup and a single transaction.")
+	}
+}
+
+// TestEnrichThinContributorsAccumulatesBeforeFlush pins that the batch
+// flush happens AFTER the API loop completes — not inside the loop
+// (which would defeat the point).
+func TestEnrichThinContributorsAccumulatesBeforeFlush(t *testing.T) {
+	src := mustReadEnrichSource(t)
+	body := extractEnrichFunc(src, "EnrichThinContributors")
+	if body == "" {
+		t.Skip("EnrichThinContributors not yet refactored")
+	}
+	// Expect a slice accumulator declared somewhere in the body. We accept
+	// either `[]model.Contributor` or `[]*model.Contributor`.
+	hasAccumulator := strings.Contains(body, "[]model.Contributor") ||
+		strings.Contains(body, "[]*model.Contributor")
+	if !hasAccumulator {
+		t.Error("EnrichThinContributors must declare a []model.Contributor (or pointer-slice) accumulator " +
+			"inside the function — that's the slice that gets flushed to UpsertContributorBatch.")
+	}
+}
+
+// TestCollectContributorsBatchesUpserts pins the same pattern in the
+// legacy non-staged collector path. collector.go:588 currently calls
+// UpsertContributor once per row inside the API iterator. Batching
+// here matters less than enrichment (the staged collector is the main
+// path) but still cuts per-repo write traffic by an order of magnitude
+// for repos with many contributors.
+func TestCollectContributorsBatchesUpserts(t *testing.T) {
+	src := mustReadCollectorSource(t)
+	idx := strings.Index(src, "func (c *Collector) collectContributors(")
+	if idx < 0 {
+		t.Fatal("could not locate collectContributors")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:end+1]
+	}
+
+	if !strings.Contains(body, "UpsertContributorBatch") {
+		t.Error("collectContributors must accumulate into a []model.Contributor and call " +
+			"UpsertContributorBatch once at the end, instead of UpsertContributor per row inside the iterator.")
+	}
+	if strings.Contains(body, "c.store.UpsertContributor(ctx, &contrib)") {
+		t.Error("collectContributors must NOT call UpsertContributor per row — that's the pre-Fix-4 hot path " +
+			"that this fix replaces with a single batch flush.")
+	}
+}
+
+func mustReadEnrichSource(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("enrich.go")
+	if err != nil {
+		t.Fatalf("read enrich.go: %v", err)
+	}
+	return string(data)
+}
+
+func mustReadCollectorSource(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("collector.go")
+	if err != nil {
+		t.Fatalf("read collector.go: %v", err)
+	}
+	return string(data)
+}
+
+func extractEnrichFunc(src, name string) string {
+	marker := "func " + name + "("
+	idx := strings.Index(src, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := src[idx:]
+	if end := strings.Index(rest[1:], "\nfunc "); end > 0 {
+		return rest[:end+1]
+	}
+	return rest
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,30 @@ type CollectionConfig struct {
 	//
 	// Ignored when ThreadingMode != "sharded".
 	ShardSize int `json:"shard_size"`
+
+	// EnrichIntervalMinutes controls how often thin-contributor profile
+	// enrichment runs as a periodic scheduler task. v0.18.29 moved
+	// enrichment off the per-job hot path because every worker calling
+	// EnrichThinContributors(14000) after its own repo finished
+	// exhausted the GitHub key pool in ~11 minutes on a 120-worker
+	// fleet. The periodic task runs once per interval on a single
+	// goroutine, well under the rate-limit budget.
+	//
+	// Default 30 (minutes) when unset. Faster (10) catches up enrichment
+	// sooner; slower (60) leaves more REST headroom. With 14K thin
+	// contributors and 73 keys, even 60 minutes is comfortably within
+	// the 5K/key/hour budget.
+	EnrichIntervalMinutes int `json:"enrich_interval_minutes"`
+}
+
+// EnrichIntervalDuration converts EnrichIntervalMinutes to a time.Duration.
+// Falls back to 30 minutes when unset (zero) so existing aveloxis.json
+// files without the new key keep the documented default.
+func (c *CollectionConfig) EnrichIntervalDuration() time.Duration {
+	if c.EnrichIntervalMinutes <= 0 {
+		return 30 * time.Minute
+	}
+	return time.Duration(c.EnrichIntervalMinutes) * time.Minute
 }
 
 // Load reads configuration from a JSON file.

--- a/internal/db/contributors.go
+++ b/internal/db/contributors.go
@@ -84,23 +84,58 @@ func (r *ContributorResolver) Resolve(ctx context.Context, platformID int16, use
 		}
 		defer tx.Rollback(ctx)
 
-		// Use the partial unique index form — NOT ON CONSTRAINT, because
-		// idx_contributors_login is an index (not a constraint) and the
-		// ON CONSTRAINT form doesn't accept a WHERE clause. The previous
-		// syntax caused a SQL error on every lazy contributor creation,
-		// resulting in 131K+ messages with NULL cntrb_id.
-		err = tx.QueryRow(ctx, `
-			INSERT INTO aveloxis_data.contributors
-				(cntrb_id, cntrb_login, cntrb_email, cntrb_full_name, cntrb_created_at)
-			VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (cntrb_login) WHERE cntrb_login != ''
-			DO UPDATE SET
-				cntrb_email = COALESCE(NULLIF(EXCLUDED.cntrb_email,''), contributors.cntrb_email),
-				cntrb_full_name = COALESCE(NULLIF(EXCLUDED.cntrb_full_name,''), contributors.cntrb_full_name),
-				data_collection_date = NOW()
-			RETURNING cntrb_id::text`,
-			newID, login, email, name, time.Now(),
-		).Scan(&cntrbID)
+		// Two upsert SQL flavors depending on whether the contributor has
+		// a numeric platform user ID (deterministic cntrb_id) or not
+		// (random UUID). Postgres has no multi-target ON CONFLICT, so
+		// we branch.
+		//
+		// userID > 0: cntrb_id is PlatformUUID(platformID, userID),
+		// deterministic per platform user. The natural unique key here
+		// is cntrb_id — concurrent inserts of the same numeric user
+		// under different login strings (historical login drift across
+		// repos, GitHub renames, two workers seeing the same hot user
+		// at once) all collide on cntrb_id, so ON CONFLICT (cntrb_id)
+		// routes them all to DO UPDATE. The DO UPDATE clause also
+		// updates cntrb_login from EXCLUDED so a renamed user's row
+		// picks up the new login on next observation.
+		//
+		// At v0.18.28 this used ON CONFLICT (cntrb_login) — which
+		// failed to match when login strings differed across observers,
+		// letting INSERT proceed and trip contributors_pkey, raising
+		// thousands of WARNs/day on a 40K-repo fleet.
+		//
+		// userID == 0: cntrb_id is a random UUID per call (email-only
+		// contributor, no platform user). Two observations of the
+		// same person generate different cntrb_ids but the same login,
+		// so ON CONFLICT (cntrb_login) WHERE cntrb_login != '' is the
+		// right target.
+		if userID > 0 {
+			err = tx.QueryRow(ctx, `
+				INSERT INTO aveloxis_data.contributors
+					(cntrb_id, cntrb_login, cntrb_email, cntrb_full_name, cntrb_created_at)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (cntrb_id) DO UPDATE SET
+					cntrb_login = COALESCE(NULLIF(EXCLUDED.cntrb_login,''), contributors.cntrb_login),
+					cntrb_email = COALESCE(NULLIF(EXCLUDED.cntrb_email,''), contributors.cntrb_email),
+					cntrb_full_name = COALESCE(NULLIF(EXCLUDED.cntrb_full_name,''), contributors.cntrb_full_name),
+					data_collection_date = NOW()
+				RETURNING cntrb_id::text`,
+				newID, login, email, name, time.Now(),
+			).Scan(&cntrbID)
+		} else {
+			err = tx.QueryRow(ctx, `
+				INSERT INTO aveloxis_data.contributors
+					(cntrb_id, cntrb_login, cntrb_email, cntrb_full_name, cntrb_created_at)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (cntrb_login) WHERE cntrb_login != ''
+				DO UPDATE SET
+					cntrb_email = COALESCE(NULLIF(EXCLUDED.cntrb_email,''), contributors.cntrb_email),
+					cntrb_full_name = COALESCE(NULLIF(EXCLUDED.cntrb_full_name,''), contributors.cntrb_full_name),
+					data_collection_date = NOW()
+				RETURNING cntrb_id::text`,
+				newID, login, email, name, time.Now(),
+			).Scan(&cntrbID)
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/db/contributors_conflict_test.go
+++ b/internal/db/contributors_conflict_test.go
@@ -1,0 +1,127 @@
+// Source-contract tests for v0.18.29 Fix 3: ContributorResolver.Resolve
+// uses ON CONFLICT (cntrb_id) when the platform user has a numeric ID,
+// so concurrent inserts of the same person under different login strings
+// route to DO UPDATE instead of tripping contributors_pkey.
+//
+// Background: at v0.18.28, the INSERT in contributors.go:92-103 specifies
+// the deterministic cntrb_id (PlatformUUID(platform, userID)) as $1 but
+// uses ON CONFLICT (cntrb_login) WHERE cntrb_login != ''. When two
+// workers race to insert the same numeric user under different login
+// strings (historical login drift across repos, GitHub renames, or just
+// two workers seeing the same hot user concurrently), the cntrb_login
+// conflict check fails to match (different login values) and the INSERT
+// proceeds — then explodes on contributors_pkey because the cntrb_id
+// already exists. The Postgres logs in production show this firing
+// thousands of times per day on a 40K-repo fleet.
+//
+// The fix: when userID > 0 (deterministic UUID path), use ON CONFLICT
+// (cntrb_id) DO UPDATE — that's the constraint actually firing. The
+// userID == 0 path (random UUID for email-only contributors) keeps the
+// partial unique index target since cntrb_login is the natural key
+// there.
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// extractResolverFunc locates a method on *ContributorResolver in the
+// given source string. Boundary is the next top-level `func ` token.
+func extractResolverFunc(src, name string) string {
+	marker := "func (r *ContributorResolver) " + name + "("
+	idx := strings.Index(src, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := src[idx:]
+	if end := strings.Index(rest[1:], "\nfunc "); end > 0 {
+		return rest[:end+1]
+	}
+	return rest
+}
+
+// TestResolveSourceUsesCntrbIdConflictForKnownUserID is the headline
+// contract: the deterministic-UUID path must target cntrb_id.
+func TestResolveSourceUsesCntrbIdConflictForKnownUserID(t *testing.T) {
+	src := mustReadStoreSource(t, "contributors.go")
+	body := extractResolverFunc(src, "Resolve")
+	if body == "" {
+		t.Fatal("could not locate ContributorResolver.Resolve body")
+	}
+
+	if !strings.Contains(body, "ON CONFLICT (cntrb_id)") {
+		t.Error("ContributorResolver.Resolve must use ON CONFLICT (cntrb_id) for the userID > 0 path. " +
+			"Currently uses ON CONFLICT (cntrb_login) WHERE cntrb_login != '', which doesn't match " +
+			"the constraint that actually fires (contributors_pkey) when two workers race to insert " +
+			"the same numeric platform user under different login strings.")
+	}
+}
+
+// TestResolveSourceUpdatesLoginOnConflict pins the rename-handling
+// behavior: when ON CONFLICT (cntrb_id) fires, the DO UPDATE clause
+// must update cntrb_login to the new value. Without it, a renamed
+// GitHub user's row keeps the stale login forever.
+func TestResolveSourceUpdatesLoginOnConflict(t *testing.T) {
+	src := mustReadStoreSource(t, "contributors.go")
+	body := extractResolverFunc(src, "Resolve")
+	if body == "" {
+		t.Skip("Resolve not yet refactored")
+	}
+
+	// We expect the DO UPDATE clause for the cntrb_id path to mention
+	// cntrb_login = ... EXCLUDED.cntrb_login or similar. The COALESCE
+	// pattern is fine — newest non-empty observation wins.
+	idIdx := strings.Index(body, "ON CONFLICT (cntrb_id)")
+	if idIdx < 0 {
+		t.Skip("cntrb_id branch not yet present; covered by sibling test")
+	}
+	// Slice from the cntrb_id ON CONFLICT to the end of that SQL block
+	// (loosely: until a closing backtick or RETURNING).
+	rest := body[idIdx:]
+	endIdx := strings.Index(rest, "RETURNING")
+	if endIdx < 0 {
+		endIdx = len(rest)
+	}
+	clause := rest[:endIdx]
+	if !strings.Contains(clause, "cntrb_login") {
+		t.Error("the ON CONFLICT (cntrb_id) DO UPDATE clause must update cntrb_login. " +
+			"Without it, a renamed user's row keeps the stale login indefinitely.")
+	}
+}
+
+// TestResolveSourceKeepsLoginPathForRandomUUID pins that the userID == 0
+// path still uses the partial unique index. For email-only contributors
+// (no platform user) the cntrb_id is random, so two observations of the
+// same person would generate different cntrb_ids — but the same login.
+// The login partial unique index is the right target there.
+func TestResolveSourceKeepsLoginPathForRandomUUID(t *testing.T) {
+	src := mustReadStoreSource(t, "contributors.go")
+	body := extractResolverFunc(src, "Resolve")
+	if body == "" {
+		t.Skip("Resolve not yet refactored")
+	}
+	if !strings.Contains(body, "ON CONFLICT (cntrb_login)") {
+		t.Error("Resolve must keep the ON CONFLICT (cntrb_login) WHERE cntrb_login != '' branch " +
+			"for the userID == 0 path (random UUID, login is the natural identity)")
+	}
+}
+
+// TestResolveSourceBranchesOnUserID enforces that the function actually
+// has a branch — without it, a single SQL statement can't target both
+// constraints (Postgres has no multi-target ON CONFLICT).
+func TestResolveSourceBranchesOnUserID(t *testing.T) {
+	src := mustReadStoreSource(t, "contributors.go")
+	body := extractResolverFunc(src, "Resolve")
+	if body == "" {
+		t.Skip("Resolve not yet refactored")
+	}
+	// Look for a branch on userID (or platformID/userID). We accept any
+	// of `userID > 0`, `userID != 0`, or a switch/early-return pattern.
+	if !strings.Contains(body, "userID > 0") && !strings.Contains(body, "userID != 0") {
+		t.Error("Resolve must branch on userID > 0 to choose between the cntrb_id-targeted " +
+			"upsert (deterministic UUID) and the cntrb_login-targeted upsert (random UUID). " +
+			"Postgres has no multi-target ON CONFLICT, so two SQL statements are required.")
+	}
+}

--- a/internal/db/queue_drain.go
+++ b/internal/db/queue_drain.go
@@ -1,0 +1,101 @@
+// Drain-park primitives for the background leftover-staging drain
+// (v0.18.29 Fix 1). The scheduler uses these to atomically take a set
+// of repos OUT of the worker-claim path before launching the drain
+// goroutine, then release each one back to 'queued' as draining
+// completes.
+//
+// Critical invariant: NEITHER function touches last_collected. A repo
+// whose first collection was interrupted has last_collected = NULL,
+// and the drain only processes pre-staged data — the original API
+// fetch may have been incomplete. Setting last_collected during the
+// drain would falsely mark a partially-collected repo as fully
+// collected and skip the natural re-fetch on the next cycle. Only
+// CompleteJob (after a successful end-to-end collection) ever sets
+// last_collected.
+
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// LockReposForDrain marks a set of repo_ids as status='collecting',
+// locked_by='<workerID>:drain', locked_at=NOW() in a single UPDATE.
+// Only rows currently in 'queued' status are claimed — a repo already
+// being collected by another worker is left alone (returned set
+// excludes it). Returns the actual list of repo_ids that were locked.
+//
+// The 'drain' suffix on locked_by lets operators distinguish drain
+// parks from normal collection locks in the monitor, and matters for
+// crash recovery: on restart, RecoverOtherWorkerLocks releases all
+// locks not held by the current worker, so a drain lock from a prior
+// crashed process gets cleaned up automatically (the dead worker ID
+// won't match the new one).
+//
+// SQL deliberately mentions only queue-mechanics columns. last_collected
+// is not touched. See queue_drain_lock_test.go for the source-contract
+// and behavioral tests that pin this invariant.
+func (s *PostgresStore) LockReposForDrain(ctx context.Context, repoIDs []int64, workerID string) ([]int64, error) {
+	if len(repoIDs) == 0 {
+		return nil, nil
+	}
+
+	lockedBy := fmt.Sprintf("%s:drain", workerID)
+
+	rows, err := s.pool.Query(ctx, `
+		UPDATE aveloxis_ops.collection_queue
+		SET status = 'collecting',
+		    locked_by = $1,
+		    locked_at = NOW(),
+		    updated_at = NOW()
+		WHERE repo_id = ANY($2) AND status = 'queued'
+		RETURNING repo_id`,
+		lockedBy, repoIDs)
+	if err != nil {
+		return nil, fmt.Errorf("lock repos for drain: %w", err)
+	}
+	defer rows.Close()
+
+	locked := make([]int64, 0, len(repoIDs))
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		locked = append(locked, id)
+	}
+	return locked, rows.Err()
+}
+
+// ReleaseDrainLock releases a single repo back to status='queued'
+// after its staging has been drained. Sets due_at=NOW() so the next
+// fillWorkerSlots tick picks it up immediately for a fresh re-fetch
+// (the drain processed pre-staged data; the original fetch may have
+// been incomplete, so a normal collection cycle will re-fetch and
+// reconcile via the existing ON CONFLICT idempotency).
+//
+// Like LockReposForDrain, this SQL deliberately does not touch
+// last_collected. The drain has not produced a "successful collection"
+// in the CompleteJob sense — only a clean end-to-end collection sets
+// the timestamp.
+//
+// The locked_by check ensures we only release locks we actually hold;
+// a repo whose drain was hijacked by a manual operator action (status
+// changed externally) won't be silently overwritten.
+func (s *PostgresStore) ReleaseDrainLock(ctx context.Context, repoID int64, workerID string) error {
+	lockedBy := fmt.Sprintf("%s:drain", workerID)
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_ops.collection_queue
+		SET status = 'queued',
+		    locked_by = NULL,
+		    locked_at = NULL,
+		    due_at = NOW(),
+		    updated_at = NOW()
+		WHERE repo_id = $1 AND locked_by = $2 AND status = 'collecting'`,
+		repoID, lockedBy)
+	if err != nil {
+		return fmt.Errorf("release drain lock for repo %d: %w", repoID, err)
+	}
+	return nil
+}

--- a/internal/db/queue_drain_lock_test.go
+++ b/internal/db/queue_drain_lock_test.go
@@ -1,0 +1,300 @@
+// Tests for the queue lock-park primitives that support the background
+// staging drain (v0.18.29 Fix 1):
+//
+//   - LockReposForDrain marks a set of repo_ids as status='collecting',
+//     locked_by='<workerID>:drain', locked_at=NOW() in a single UPDATE.
+//   - ReleaseDrainLock releases one repo back to status='queued', clearing
+//     locked_by/locked_at, and setting due_at=NOW() so the next normal
+//     collection picks it up immediately.
+//
+// The critical invariant — verified by source contract AND by integration
+// behavior — is that NEITHER function touches last_collected. A repo
+// whose first collection was interrupted has last_collected=NULL; the
+// drain processes whatever was already staged into relational tables but
+// the *fetch* may have been incomplete, so last_collected must stay NULL
+// until a clean re-collection completes via CompleteJob. Setting it
+// during the drain would falsely mark a partially-collected repo as
+// fully collected and skip the natural re-fetch.
+
+package db
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// TestLockReposForDrainExists pins the function signature on the store.
+func TestLockReposForDrainExists(t *testing.T) {
+	src := mustReadStoreSource(t, "queue_drain.go")
+	if !strings.Contains(src, "func (s *PostgresStore) LockReposForDrain(") {
+		t.Error("queue_drain.go must define LockReposForDrain on *PostgresStore")
+	}
+}
+
+// TestReleaseDrainLockExists pins the per-repo release function.
+func TestReleaseDrainLockExists(t *testing.T) {
+	src := mustReadStoreSource(t, "queue_drain.go")
+	if !strings.Contains(src, "func (s *PostgresStore) ReleaseDrainLock(") {
+		t.Error("queue_drain.go must define ReleaseDrainLock on *PostgresStore")
+	}
+}
+
+// TestLockReposForDrainSQLDoesNotTouchLastCollected is the load-bearing
+// invariant: the lock UPDATE must touch ONLY queue-mechanics columns
+// (status, locked_by, locked_at, updated_at). Any UPDATE that reaches
+// last_collected during a drain park would corrupt the "first collection
+// in progress" signal — workers would see last_collected as non-NULL
+// and switch to incremental since-windowed collection instead of a
+// fresh full re-fetch.
+//
+// We extract the SQL string literal (between backticks) so doc comments
+// that *describe* the invariant (which mention `last_collected` to
+// explain what's NOT touched) don't trip the check.
+func TestLockReposForDrainSQLDoesNotTouchLastCollected(t *testing.T) {
+	src := mustReadStoreSource(t, "queue_drain.go")
+	body := extractDrainFunc(src, "LockReposForDrain")
+	if body == "" {
+		t.Skip("LockReposForDrain not yet defined; covered by TestLockReposForDrainExists")
+	}
+	sql := extractSQLFromBody(body)
+	if sql == "" {
+		t.Fatal("could not locate SQL string literal inside LockReposForDrain")
+	}
+	if strings.Contains(sql, "last_collected") {
+		t.Error("LockReposForDrain SQL must NOT mention last_collected. " +
+			"The drain park is purely a queue-mechanics signal; touching last_collected " +
+			"would corrupt the 'first collection in progress' invariant for repos " +
+			"whose initial collection was interrupted.")
+	}
+	if !strings.Contains(sql, "'collecting'") {
+		t.Error("LockReposForDrain must set status='collecting' (existing enum value) — " +
+			"a new status would require updates across queue.go, monitor templates, etc.")
+	}
+}
+
+// TestReleaseDrainLockSQLDoesNotTouchLastCollected mirrors the lock-side
+// invariant for the release path. CompleteJob is the ONLY function that
+// should ever set last_collected.
+func TestReleaseDrainLockSQLDoesNotTouchLastCollected(t *testing.T) {
+	src := mustReadStoreSource(t, "queue_drain.go")
+	body := extractDrainFunc(src, "ReleaseDrainLock")
+	if body == "" {
+		t.Skip("ReleaseDrainLock not yet defined; covered by TestReleaseDrainLockExists")
+	}
+	sql := extractSQLFromBody(body)
+	if sql == "" {
+		t.Fatal("could not locate SQL string literal inside ReleaseDrainLock")
+	}
+	if strings.Contains(sql, "last_collected") {
+		t.Error("ReleaseDrainLock SQL must NOT mention last_collected. " +
+			"Drain processed pre-staged data; the original fetch may have been " +
+			"incomplete. Only CompleteJob should ever set last_collected, after " +
+			"a successful end-to-end collection.")
+	}
+}
+
+// extractSQLFromBody returns the contents of the first backtick-delimited
+// string literal in the given function body — i.e. the SQL the function
+// passes to pgx. Doc comments mentioning column names for explanation
+// purposes are left out.
+func extractSQLFromBody(body string) string {
+	start := strings.Index(body, "`")
+	if start < 0 {
+		return ""
+	}
+	rest := body[start+1:]
+	end := strings.Index(rest, "`")
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// TestDrainLockSuffixUsesWorkerID enforces that the synthetic worker ID
+// used for the drain park encodes the real worker ID. This matters for
+// crash recovery: on restart, RecoverOtherWorkerLocks releases all locks
+// not held by the current worker. A drain lock from a prior crashed
+// process gets cleaned up automatically because its locked_by suffix
+// references the dead worker ID.
+func TestDrainLockSuffixUsesWorkerID(t *testing.T) {
+	src := mustReadStoreSource(t, "queue_drain.go")
+	body := extractDrainFunc(src, "LockReposForDrain")
+	if body == "" {
+		t.Skip("LockReposForDrain not yet defined")
+	}
+	// The function should accept workerID as a parameter and concatenate
+	// it with ':drain' (or similar suffix marker) for the locked_by value.
+	if !strings.Contains(body, "drain") {
+		t.Error("LockReposForDrain must use a 'drain' suffix on locked_by so operators " +
+			"can distinguish drain parks from normal collection locks in the monitor.")
+	}
+}
+
+// ---------------------------------------------------------------------
+// Integration tests — gated on AVELOXIS_TEST_DB. Verify the actual SQL
+// against a live Postgres.
+// ---------------------------------------------------------------------
+
+// TestLockReposForDrainPreservesNullLastCollected is the headline
+// behavioral test: insert a queue row with last_collected=NULL, run a
+// lock-then-release cycle, assert last_collected is still NULL. This
+// test would catch any regression where a future refactor "helpfully"
+// sets last_collected during the drain park.
+func TestLockReposForDrainPreservesNullLastCollected(t *testing.T) {
+	conn := os.Getenv("AVELOXIS_TEST_DB")
+	if conn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, conn, logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// Insert a fresh repo + queue row with last_collected = NULL.
+	repoID, err := store.UpsertRepo(ctx, &model.Repo{
+		Owner: "_avdrain", Name: "null-lastcollected",
+		GitURL: "https://github.com/_avdrain/null-lastcollected", Platform: model.PlatformGitHub,
+	})
+	if err != nil {
+		t.Fatalf("upsert repo: %v", err)
+	}
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_ops.collection_queue (repo_id, status, due_at, last_collected)
+		VALUES ($1, 'queued', NOW(), NULL)
+		ON CONFLICT (repo_id) DO UPDATE SET status='queued', last_collected=NULL`,
+		repoID); err != nil {
+		t.Fatalf("seed queue row: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, repoID)
+	})
+
+	// Lock for drain.
+	locked, err := store.LockReposForDrain(ctx, []int64{repoID}, "test-worker")
+	if err != nil {
+		t.Fatalf("LockReposForDrain: %v", err)
+	}
+	if len(locked) != 1 || locked[0] != repoID {
+		t.Errorf("LockReposForDrain returned %v, want [%d]", locked, repoID)
+	}
+
+	// Verify status is 'collecting', last_collected is still NULL.
+	var status string
+	var lastCollected *string
+	if err := store.pool.QueryRow(ctx, `
+		SELECT status, last_collected::text FROM aveloxis_ops.collection_queue WHERE repo_id = $1`,
+		repoID).Scan(&status, &lastCollected); err != nil {
+		t.Fatalf("post-lock select: %v", err)
+	}
+	if status != "collecting" {
+		t.Errorf("post-lock status = %q, want 'collecting'", status)
+	}
+	if lastCollected != nil {
+		t.Errorf("post-lock last_collected = %v, want NULL — the drain lock must NOT set last_collected", *lastCollected)
+	}
+
+	// Release.
+	if err := store.ReleaseDrainLock(ctx, repoID, "test-worker"); err != nil {
+		t.Fatalf("ReleaseDrainLock: %v", err)
+	}
+
+	// Verify status is 'queued', last_collected is STILL NULL.
+	if err := store.pool.QueryRow(ctx, `
+		SELECT status, last_collected::text FROM aveloxis_ops.collection_queue WHERE repo_id = $1`,
+		repoID).Scan(&status, &lastCollected); err != nil {
+		t.Fatalf("post-release select: %v", err)
+	}
+	if status != "queued" {
+		t.Errorf("post-release status = %q, want 'queued'", status)
+	}
+	if lastCollected != nil {
+		t.Errorf("post-release last_collected = %v, want NULL — the drain release must NOT set last_collected", *lastCollected)
+	}
+}
+
+// TestLockReposForDrainSkipsActivelyCollecting guards against a worker
+// already mid-collection on a repo getting its lock stomped by the
+// drain park. Only repos in 'queued' status should be lockable for
+// drain.
+func TestLockReposForDrainSkipsActivelyCollecting(t *testing.T) {
+	conn := os.Getenv("AVELOXIS_TEST_DB")
+	if conn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, conn, logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	repoID, err := store.UpsertRepo(ctx, &model.Repo{
+		Owner: "_avdrain", Name: "actively-collecting",
+		GitURL: "https://github.com/_avdrain/actively-collecting", Platform: model.PlatformGitHub,
+	})
+	if err != nil {
+		t.Fatalf("upsert repo: %v", err)
+	}
+	// Seed as 'collecting' with a different worker ID.
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_ops.collection_queue (repo_id, status, locked_by, locked_at, due_at)
+		VALUES ($1, 'collecting', 'other-worker', NOW(), NOW())
+		ON CONFLICT (repo_id) DO UPDATE SET
+			status='collecting', locked_by='other-worker', locked_at=NOW()`,
+		repoID); err != nil {
+		t.Fatalf("seed queue row: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, repoID)
+	})
+
+	locked, err := store.LockReposForDrain(ctx, []int64{repoID}, "test-worker")
+	if err != nil {
+		t.Fatalf("LockReposForDrain: %v", err)
+	}
+	if len(locked) != 0 {
+		t.Errorf("LockReposForDrain claimed an actively-collecting repo (returned %v) — must skip rows already locked by other workers", locked)
+	}
+
+	// Verify the original lock holder is unchanged.
+	var lockedBy string
+	if err := store.pool.QueryRow(ctx,
+		`SELECT locked_by FROM aveloxis_ops.collection_queue WHERE repo_id = $1`, repoID).Scan(&lockedBy); err != nil {
+		t.Fatalf("post-lock select: %v", err)
+	}
+	if lockedBy != "other-worker" {
+		t.Errorf("LockReposForDrain stomped on existing lock: locked_by = %q, want 'other-worker'", lockedBy)
+	}
+}
+
+func mustReadStoreSource(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(data)
+}
+
+func extractDrainFunc(src, name string) string {
+	marker := "func (s *PostgresStore) " + name + "("
+	idx := strings.Index(src, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := src[idx:]
+	if end := strings.Index(rest[1:], "\nfunc "); end > 0 {
+		return rest[:end+1]
+	}
+	return rest
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -3,4 +3,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.18.28"
+var ToolVersion = "0.18.29"

--- a/internal/scheduler/enrich_periodic_test.go
+++ b/internal/scheduler/enrich_periodic_test.go
@@ -1,0 +1,107 @@
+// Source-contract tests for v0.18.29 Fix 2: contributor enrichment runs
+// as a periodic scheduler task, not per-job inside processJob.
+//
+// Background: at v0.18.28, scheduler.go:460 calls
+// collector.EnrichThinContributors(...) at the end of every processJob
+// run. Each call fetches up to EnrichBatchSize=14000 thin logins and
+// hits REST GET /users/{login} for each one. With 120 workers each
+// finishing their tiny repo and immediately calling enrichment, the
+// fleet attempts ~1.68M REST calls in parallel windows and exhausts
+// all 73 GitHub keys in ~11 minutes (verified in production logs from
+// 2026-05-07T01:37:07 through 01:48:23).
+//
+// The fix moves enrichment to a single goroutine driven by a periodic
+// ticker (default 30 min). One caller, one batch per tick, well under
+// the rate-limit budget.
+
+package scheduler
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnrichmentNotCalledFromRunJob is the headline contract: the
+// per-job enrichment call must be removed from runJob. A regression
+// that re-adds it would burn the REST budget again on the next restart.
+func TestEnrichmentNotCalledFromRunJob(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+
+	// Locate runJob (the per-job entry point).
+	idx := strings.Index(src, "func (s *Scheduler) runJob(")
+	if idx < 0 {
+		t.Fatal("could not locate runJob")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:end+1]
+	}
+
+	if strings.Contains(body, "EnrichThinContributors") {
+		t.Error("runJob must NOT call EnrichThinContributors. With 120 workers each " +
+			"calling it after their repo finishes, the fleet attempts ~1.68M REST calls " +
+			"in parallel windows and exhausts all GitHub keys in ~11 minutes. " +
+			"Enrichment must run as a single periodic scheduler task instead.")
+	}
+}
+
+// TestEnrichmentTickerInRun pins that scheduler.Run installs a periodic
+// ticker driving enrichment.
+func TestEnrichmentTickerInRun(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	body := extractRunBody(src)
+	if body == "" {
+		t.Fatal("could not locate Run body")
+	}
+
+	// Look for a ticker variable that drives enrichment. We accept either
+	// a named ticker (`enrichTicker := time.NewTicker(...)`) or an inline
+	// time.Tick. The body must reference both EnrichInterval (config) and
+	// EnrichThinContributors (the call).
+	if !strings.Contains(body, "EnrichInterval") {
+		t.Error("scheduler.Run must reference cfg.EnrichInterval to drive the periodic enrichment ticker")
+	}
+	if !strings.Contains(src, "EnrichThinContributors") {
+		t.Error("scheduler must call collector.EnrichThinContributors from the periodic enrichment goroutine — " +
+			"removing it entirely loses contributor profile data")
+	}
+}
+
+// TestEnrichIntervalConfigField pins the new Config field exists with a
+// time.Duration type so it can be plumbed from aveloxis.json.
+func TestEnrichIntervalConfigField(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	idx := strings.Index(src, "type Config struct {")
+	if idx < 0 {
+		t.Fatal("could not locate scheduler.Config struct")
+	}
+	end := strings.Index(src[idx:], "\n}")
+	if end < 0 {
+		t.Fatal("could not find end of Config struct")
+	}
+	configDecl := src[idx : idx+end]
+	if !strings.Contains(configDecl, "EnrichInterval") {
+		t.Error("scheduler.Config must declare EnrichInterval so the cadence is configurable per deployment")
+	}
+	if !strings.Contains(configDecl, "time.Duration") {
+		t.Error("expected time.Duration somewhere in Config — the existing Duration fields are the model")
+	}
+}
+
+// TestEnrichIntervalDefaultIsSane pins a 30-minute default. Any caller
+// that constructs a Scheduler without setting EnrichInterval should get
+// a sensible cadence. Faster than 1 minute would re-create rate-limit
+// pressure; slower than 1 hour leaves enrichment lagging the fleet.
+func TestEnrichIntervalDefaultIsSane(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	// Look for a defaulting block in NewWithKeys or New.
+	if !strings.Contains(src, "EnrichInterval == 0") {
+		t.Error("scheduler.NewWithKeys must default EnrichInterval when it's zero — " +
+			"matching the pattern for PollInterval, RecollectAfter, OrgRefreshInterval")
+	}
+	if !strings.Contains(src, "30 * time.Minute") && !strings.Contains(src, "time.Minute * 30") {
+		// If a different default is used, this test will need updating; flag it.
+		t.Error("expected 30 * time.Minute as the EnrichInterval default — " +
+			"that's the value documented in the v0.18.29 plan")
+	}
+}

--- a/internal/scheduler/leftover_drain_background_test.go
+++ b/internal/scheduler/leftover_drain_background_test.go
@@ -1,0 +1,148 @@
+// Source-contract tests for v0.18.29 Fix 1: the leftover-staging drain
+// runs in a background goroutine instead of blocking scheduler.Run.
+//
+// Background: at v0.18.28, processLeftoverStaging is invoked synchronously
+// from Run() before fillWorkerSlots. On a fleet of 40K repos with backlogged
+// staging, ProcessRepo for one repo can take 30+ hours, and the for-loop
+// across 23 leftover repos blocked all 120 workers idle for ~3 days. The
+// fix moves the drain into its own goroutine.
+//
+// Safety invariant: a worker must NOT claim a queue row whose staging is
+// still draining, because CollectRepo's PurgeStagedForRepo would wipe the
+// in-flight rows. The fix lock-parks the drain set as
+// status='collecting', locked_by='<workerID>:drain' before launching the
+// goroutine. fillWorkerSlots's existing WHERE status='queued' filter
+// then naturally skips them, no other code change required. As each repo
+// finishes draining, it's released back to 'queued' (without touching
+// last_collected — see queue_drain_lock_test.go).
+
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLeftoverStagingRunsInBackground pins that processLeftoverStaging is
+// invoked via `go ` so Run() can proceed to fillWorkerSlots immediately.
+// A future refactor that re-introduces the synchronous call (without
+// removing the goroutine) would let the v0.18.26 multi-day stall back in.
+func TestLeftoverStagingRunsInBackground(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	body := extractRunBody(src)
+	if body == "" {
+		t.Fatal("could not locate scheduler.Run function body")
+	}
+
+	// The expected shape: `go s.processLeftoverStagingBackground(ctx, ...)`
+	// or `go func() { s.processLeftoverStaging(ctx) }()`. We accept either,
+	// but the synchronous call `s.processLeftoverStaging(ctx)` on its own
+	// line — without a preceding `go ` — must NOT exist after the fix.
+	syncCallExists := strings.Contains(body, "\n\ts.processLeftoverStaging(ctx)\n") ||
+		strings.Contains(body, "\n\t\ts.processLeftoverStaging(ctx)\n")
+	if syncCallExists {
+		t.Error("scheduler.Run must NOT call processLeftoverStaging synchronously — " +
+			"it blocks fillWorkerSlots for hours on a backlogged fleet. " +
+			"Wrap the call in a `go ` goroutine after lock-parking the drain set.")
+	}
+
+	hasGoroutine := strings.Contains(body, "go s.processLeftoverStagingBackground(") ||
+		strings.Contains(body, "go func()") &&
+			strings.Contains(body, "processLeftoverStaging(")
+	if !hasGoroutine {
+		t.Error("scheduler.Run must launch the leftover-staging drain in a goroutine " +
+			"so fillWorkerSlots can immediately claim queued repos that don't need drain.")
+	}
+}
+
+// TestDrainLockParkComesBeforeBackgroundLaunch enforces the safety
+// invariant: the drain set must be marked status='collecting' BEFORE the
+// goroutine starts, otherwise fillWorkerSlots could race the goroutine
+// and CollectRepo's PurgeStagedForRepo would wipe staging rows out from
+// under it.
+func TestDrainLockParkComesBeforeBackgroundLaunch(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	body := extractRunBody(src)
+	if body == "" {
+		t.Fatal("could not locate scheduler.Run function body")
+	}
+
+	lockIdx := strings.Index(body, "LockReposForDrain")
+	if lockIdx < 0 {
+		t.Error("scheduler.Run must call store.LockReposForDrain to atomically park " +
+			"the drain set as status='collecting' before launching the background drain. " +
+			"Without it, fillWorkerSlots can race the goroutine and PurgeStagedForRepo " +
+			"will wipe in-flight staging rows.")
+		return
+	}
+	goIdx := strings.Index(body, "go s.processLeftoverStagingBackground")
+	if goIdx < 0 {
+		// Fallback: any `go ` pointing at the drain.
+		goIdx = strings.Index(body, "go func()")
+	}
+	if goIdx < 0 {
+		t.Fatal("could not find background drain launch")
+	}
+	if lockIdx > goIdx {
+		t.Errorf("LockReposForDrain (byte %d) must come BEFORE the goroutine launch (byte %d). "+
+			"Otherwise fillWorkerSlots can claim a draining repo before it's parked.",
+			lockIdx, goIdx)
+	}
+}
+
+// TestProcessLeftoverStagingBackgroundExists asserts that the background
+// drain function is defined as a method on *Scheduler. The synchronous
+// processLeftoverStaging may stay (called by tests or admin tooling),
+// but a callable background variant must exist.
+func TestProcessLeftoverStagingBackgroundExists(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	if !strings.Contains(src, "func (s *Scheduler) processLeftoverStagingBackground(") {
+		t.Error("scheduler must define processLeftoverStagingBackground as the goroutine entry point. " +
+			"It should iterate the drain set, call ProcessRepo per repo, and release each " +
+			"repo's drain lock as draining completes.")
+	}
+}
+
+// TestBackgroundDrainReleasesPerRepo asserts that the drain function
+// releases the lock-park status as each repo finishes (not just at the
+// end). This matters operationally: a repo that finishes draining at hour
+// 2 of a 30-hour drain shouldn't have to wait for the entire drain to
+// complete before becoming queue-eligible.
+func TestBackgroundDrainReleasesPerRepo(t *testing.T) {
+	src := mustReadSchedulerSource(t)
+	idx := strings.Index(src, "func (s *Scheduler) processLeftoverStagingBackground(")
+	if idx < 0 {
+		t.Skip("processLeftoverStagingBackground not yet defined; covered by TestProcessLeftoverStagingBackgroundExists")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:end+1]
+	}
+	if !strings.Contains(body, "ReleaseDrainLock") {
+		t.Error("processLeftoverStagingBackground must call store.ReleaseDrainLock per repo " +
+			"so finished repos rejoin the queue mid-drain. Without per-repo release, a repo " +
+			"that completes draining at hour 2 has to wait for hour 30 before being collectable.")
+	}
+}
+
+func mustReadSchedulerSource(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatalf("read scheduler.go: %v", err)
+	}
+	return string(data)
+}
+
+func extractRunBody(src string) string {
+	idx := strings.Index(src, "func (s *Scheduler) Run(")
+	if idx < 0 {
+		return ""
+	}
+	rest := src[idx:]
+	if end := strings.Index(rest[1:], "\nfunc "); end > 0 {
+		return rest[:end+1]
+	}
+	return rest
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -40,6 +40,7 @@ type Config struct {
 	ListingMode         string        // "rest" (default) or "graphql" — routes issue+PR listing through ListIssuesAndPRs
 	ThreadingMode       string        // "single" (default) or "sharded" — fans out PR batch fetching across goroutines
 	ShardSize           int           // item-count threshold for spawning an additional shard (default 3000)
+	EnrichInterval      time.Duration // how often to run thin-contributor enrichment (default 30 min). v0.18.29 moved enrichment out of per-job processing into a periodic scheduler task.
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.
@@ -80,6 +81,9 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	}
 	if cfg.OrgRefreshInterval == 0 {
 		cfg.OrgRefreshInterval = 4 * time.Hour
+	}
+	if cfg.EnrichInterval == 0 {
+		cfg.EnrichInterval = 30 * time.Minute
 	}
 
 	hostname, _ := os.Hostname()
@@ -177,14 +181,32 @@ func (s *Scheduler) Run(ctx context.Context) {
 			"rows_updated", realigned, "recollect_after", s.cfg.RecollectAfter)
 	}
 
-	// Process leftover staging rows from a previous interrupted run.
-	// Runs AFTER lock recovery and due_at realignment so orphan locks and
-	// stale schedules don't wait on this multi-minute drain. Still
-	// synchronous: we must finish draining before fillWorkerSlots starts
-	// claiming new jobs, because PurgeStagedForRepo at the top of
-	// CollectRepo would wipe any unprocessed rows from the repo being
-	// re-claimed.
-	s.processLeftoverStaging(ctx)
+	// Identify the leftover-staging drain set and lock-park those repos
+	// as status='collecting', locked_by='<workerID>:drain' BEFORE
+	// launching the background drain. The lock keeps fillWorkerSlots
+	// (which only claims status='queued') from racing the goroutine
+	// and triggering CollectRepo.PurgeStagedForRepo, which would wipe
+	// the in-flight staging rows. As each repo finishes draining, the
+	// goroutine releases its lock so it rejoins the queue mid-drain.
+	//
+	// v0.18.29 change from v0.18.28: the drain used to run synchronously
+	// here, blocking fillWorkerSlots for hours on a backlogged fleet
+	// (production observed 33+ hours per repo, ~3 days total). Moving
+	// it to a goroutine unblocks worker scheduling immediately while
+	// keeping data-integrity intact via the lock-park.
+	drainSet, lockErr := s.identifyLeftoverDrainSet(ctx)
+	if lockErr != nil {
+		s.logger.Warn("failed to identify leftover drain set; skipping drain this cycle", "error", lockErr)
+	} else if len(drainSet) > 0 {
+		locked, lockErr := s.store.LockReposForDrain(ctx, drainSet, s.workerID)
+		if lockErr != nil {
+			s.logger.Error("failed to lock-park leftover drain set; falling back to synchronous drain to preserve data integrity", "error", lockErr)
+			s.processLeftoverStaging(ctx)
+		} else if len(locked) > 0 {
+			s.logger.Info("launching background leftover-staging drain", "repos", len(locked))
+			go s.processLeftoverStagingBackground(ctx, locked)
+		}
+	}
 
 	sem := make(chan struct{}, s.cfg.Workers)
 
@@ -217,6 +239,15 @@ func (s *Scheduler) Run(ctx context.Context) {
 	// Hourly keeps the bloat bounded with negligible overhead.
 	stagingCleanupTicker := time.NewTicker(1 * time.Hour)
 	defer stagingCleanupTicker.Stop()
+
+	// Thin contributor enrichment: runs on a single goroutine at a
+	// scheduled cadence (default 30 min). v0.18.29 moved this off the
+	// per-job hot path — running it inside runJob meant 120 workers
+	// each fired EnrichThinContributors(14000) after their tiny repo
+	// finished, attempting ~1.68M REST calls in parallel and
+	// exhausting all GitHub keys in ~11 minutes (production verified).
+	enrichTicker := time.NewTicker(s.cfg.EnrichInterval)
+	defer enrichTicker.Stop()
 
 	// Immediately fill worker slots on startup instead of waiting for the
 	// first poll tick (default 10s). With 30 workers and 78 queued repos,
@@ -265,6 +296,9 @@ func (s *Scheduler) Run(ctx context.Context) {
 		case <-stagingCleanupTicker.C:
 			go s.runStagingCleanup(ctx)
 
+		case <-enrichTicker.C:
+			go s.runEnrichment(ctx)
+
 		case <-pollTicker.C:
 			s.fillWorkerSlots(ctx, sem)
 			s.maybeStartMatviewRebuild(ctx, sem, &lastMatviewRebuild)
@@ -289,6 +323,30 @@ func (s *Scheduler) runStagingCleanup(ctx context.Context) {
 	if deleted > 0 {
 		s.logger.Info("staging cleanup complete", "rows_deleted", deleted)
 	}
+}
+
+// runEnrichment runs thin-contributor enrichment as a single periodic
+// task. Replaces the v0.18.28 per-job EnrichThinContributors call that
+// fired from every worker after every repo collection — that pattern
+// fanned out to ~120 concurrent EnrichThinContributors(14000) calls and
+// burned the GitHub key pool in ~11 minutes.
+//
+// Picks a single platform client per tick: GitHub when configured
+// (matching the production fleet's typical 70+ GitHub keys vs single
+// GitLab key); falls back to GitLab if no GitHub client is wired. A
+// future iteration could split the enrichment queue per platform if a
+// deployment needs symmetric coverage.
+func (s *Scheduler) runEnrichment(ctx context.Context) {
+	var client platform.Client
+	if s.ghClient != nil {
+		client = s.ghClient
+	} else if s.glClient != nil {
+		client = s.glClient
+	} else {
+		return
+	}
+	resolver := db.NewContributorResolver(s.store)
+	collector.EnrichThinContributors(ctx, s.store, resolver, client, s.logger)
 }
 
 // fillWorkerSlots fills all available semaphore slots with jobs from the queue.
@@ -452,12 +510,14 @@ func (s *Scheduler) runJob(ctx context.Context, job *db.QueueJob) {
 				}
 			}
 		}
-		// Enrich thin contributor profiles. Contributors from the Contributors
-		// API and lazy resolution only get basic data (login, avatar). This
-		// calls GET /users/{login} for company, location, email, name.
-		// Runs incrementally: up to 500 per pass.
-		resolver := db.NewContributorResolver(s.store)
-		collector.EnrichThinContributors(ctx, s.store, resolver, client, s.logger)
+		// v0.18.29: thin-contributor enrichment moved out of runJob into
+		// a periodic scheduler-level ticker (see Run's enrichTicker and
+		// runEnrichment). With 120 workers each enriching 14000 logins
+		// after finishing their tiny repo, the fleet attempted ~1.68M
+		// REST calls in parallel windows and exhausted all 73 GitHub
+		// keys in ~11 minutes. The periodic-task model runs the
+		// enrichment once per cycle, single goroutine, well under the
+		// rate-limit budget.
 	} else {
 		s.logger.Info("git-only repo, skipping API collection", "repo_id", job.RepoID)
 	}
@@ -812,16 +872,14 @@ func (s *Scheduler) generateSBOMs(ctx context.Context, repoID int64) {
 	collector.GenerateAndStoreSBOMs(ctx, s.store, repoID, s.logger)
 }
 
-// processLeftoverStaging drains any unprocessed staging rows from a previous
-// interrupted run. This ensures we don't lose data that was staged but never
-// processed into relational tables.
-func (s *Scheduler) processLeftoverStaging(ctx context.Context) {
-	// Find repos with unprocessed staging rows.
+// identifyLeftoverDrainSet returns the set of repo_ids with unprocessed
+// staging rows from a previous interrupted run. Used by Run() to feed
+// LockReposForDrain before launching the background drain.
+func (s *Scheduler) identifyLeftoverDrainSet(ctx context.Context) ([]int64, error) {
 	rows, err := s.store.Pool().Query(ctx, `
 		SELECT DISTINCT repo_id FROM aveloxis_ops.staging WHERE NOT processed`)
 	if err != nil {
-		s.logger.Warn("failed to check for leftover staging rows", "error", err)
-		return
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -832,25 +890,72 @@ func (s *Scheduler) processLeftoverStaging(ctx context.Context) {
 			repoIDs = append(repoIDs, id)
 		}
 	}
+	return repoIDs, rows.Err()
+}
 
+// processLeftoverStaging drains any unprocessed staging rows from a previous
+// interrupted run, synchronously. Kept as a fallback path for when the
+// drain-park lock fails (so we never lose data — better to block startup
+// than to risk PurgeStagedForRepo wiping in-flight rows). The normal path
+// is processLeftoverStagingBackground, called as a goroutine from Run().
+func (s *Scheduler) processLeftoverStaging(ctx context.Context) {
+	repoIDs, err := s.identifyLeftoverDrainSet(ctx)
+	if err != nil {
+		s.logger.Warn("failed to check for leftover staging rows", "error", err)
+		return
+	}
 	if len(repoIDs) == 0 {
 		return
 	}
 
-	s.logger.Info("processing leftover staging data from previous run", "repos", len(repoIDs))
+	s.logger.Info("processing leftover staging data from previous run (synchronous fallback)", "repos", len(repoIDs))
 	for _, repoID := range repoIDs {
-		repo, err := s.store.GetRepoByID(ctx, repoID)
-		if err != nil {
-			s.logger.Warn("failed to look up repo for leftover processing", "repo_id", repoID, "error", err)
-			continue
+		s.drainOneRepo(ctx, repoID)
+	}
+}
+
+// processLeftoverStagingBackground is the goroutine entry point for the
+// non-blocking drain path. The caller must have already lock-parked
+// drainSet via store.LockReposForDrain — those repos are status='collecting'
+// with locked_by='<workerID>:drain', invisible to fillWorkerSlots. As each
+// repo finishes draining, ReleaseDrainLock returns it to 'queued' so it
+// can be picked up for a fresh re-collection without waiting for the
+// rest of the drain set to complete.
+//
+// On context cancel (process shutting down), the loop exits cleanly. Any
+// repos still locked stay 'collecting' under the synthetic worker ID;
+// the next process startup's RecoverOtherWorkerLocks will release them
+// and the drain set will be re-identified and re-parked.
+func (s *Scheduler) processLeftoverStagingBackground(ctx context.Context, drainSet []int64) {
+	for i, repoID := range drainSet {
+		if ctx.Err() != nil {
+			s.logger.Info("background drain interrupted by ctx cancel; remaining repos will be re-parked on next startup",
+				"remaining", len(drainSet)-i)
+			return
 		}
-		proc := collector.NewProcessor(s.store, s.logger)
-		if err := proc.ProcessRepo(ctx, repoID, int16(repo.Platform)); err != nil {
-			s.logger.Warn("failed to process leftover staging", "repo_id", repoID, "error", err)
-		} else {
-			s.logger.Info("processed leftover staging data", "repo_id", repoID)
+		s.drainOneRepo(ctx, repoID)
+		if err := s.store.ReleaseDrainLock(ctx, repoID, s.workerID); err != nil {
+			s.logger.Warn("failed to release drain lock; repo stays locked until next restart's RecoverOtherWorkerLocks", "repo_id", repoID, "error", err)
 		}
 	}
+	s.logger.Info("background leftover-staging drain complete", "repos", len(drainSet))
+}
+
+// drainOneRepo processes one repo's leftover staging rows. Shared by the
+// synchronous fallback (processLeftoverStaging) and the background path
+// (processLeftoverStagingBackground).
+func (s *Scheduler) drainOneRepo(ctx context.Context, repoID int64) {
+	repo, err := s.store.GetRepoByID(ctx, repoID)
+	if err != nil {
+		s.logger.Warn("failed to look up repo for leftover processing", "repo_id", repoID, "error", err)
+		return
+	}
+	proc := collector.NewProcessor(s.store, s.logger)
+	if err := proc.ProcessRepo(ctx, repoID, int16(repo.Platform)); err != nil {
+		s.logger.Warn("failed to process leftover staging", "repo_id", repoID, "error", err)
+		return
+	}
+	s.logger.Info("processed leftover staging data", "repo_id", repoID)
 }
 
 // releaseOurLocks releases all queue locks held by this worker instance,


### PR DESCRIPTION
 Four fixes shipped, full TDD cycle, all tests green.                                                                                   
                                                                                                                                         
  RED → GREEN summary:                    
  - 17 new tests across 5 files (source-contract + integration-tier gated on AVELOXIS_TEST_DB)                                           
  - go test ./...: all 18 packages pass                                                                                                  
  - Build clean, version bumped 0.18.28 → 0.18.29
                                                                                                                                         
  Fix 1 — Background staging drain (internal/scheduler/scheduler.go, internal/db/queue_drain.go)                                         
  - processLeftoverStaging now runs in a goroutine via processLeftoverStagingBackground.                                                 
  - Drain set is lock-parked (status='collecting', locked_by='<workerID>:drain') BEFORE the goroutine launches, so fillWorkerSlots skips  them naturally and PurgeStagedForRepo cannot race the goroutine.                                                                       
  - LockReposForDrain / ReleaseDrainLock deliberately don't touch last_collected — first-collection invariant preserved through drain →  
  unlock → re-fetch cycle.                                                                                                               
  via collection.enrich_interval_minutes).
  - Single goroutine per tick. ~28K REST calls/hr instead of ~1.7M attempted in parallel.

  Fix 3 — ON CONFLICT (cntrb_id) for deterministic-UUID path (internal/db/contributors.go)
  - ContributorResolver.Resolve branches on userID > 0. Numeric-user path uses ON CONFLICT (cntrb_id) DO UPDATE and updates cntrb_login from EXCLUDED to handle login drift / renames.
  - userID == 0 (random UUID) path keeps ON CONFLICT (cntrb_login) WHERE cntrb_login != '' — login is the natural key there.

  Fix 4 — Batched contributor upserts (internal/collector/enrich.go, internal/collector/collector.go)
  - EnrichThinContributors accumulates into []model.Contributor and flushes once via UpsertContributorBatch.
  - Collector.collectContributors does the same — per-row UPSERT loop replaced with a single batch call.

  Docs
  - docs/guide/troubleshooting.md — three new sections: 3-day startup drain, REST burnout, contributors_pkey collisions, with grep snippets for confirming the fix is active.