### PR TITLE
Debug/org repo userrepo updating fix

### DIFF
--- a/cmd/aveloxis/add_repo_org_link_test.go
+++ b/cmd/aveloxis/add_repo_org_link_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAddRepoOrgExpansionBridgesToUserRepos pins that
+// `aveloxis add-repo <orgURL>` (the runAddRepo CLI path that expands an
+// org URL into per-repo upserts) calls GetUserGroupIDsForOrgURL and
+// AddRepoToGroupByID for every discovered repo. Without this, CLI-added
+// orgs land in aveloxis_data.repos with the legacy repo_group_id set
+// but never reach aveloxis_ops.user_repos for any user_group tracking
+// the same org_url — the fork-clustering drift the operator diagnosed
+// on 2026-05-07.
+//
+// Source-contract test (no DB needed): reads main.go and asserts the
+// runAddRepo expansion loop contains both calls.
+func TestAddRepoOrgExpansionBridgesToUserRepos(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnStart := strings.Index(src, "func runAddRepo(")
+	if fnStart < 0 {
+		t.Fatal("cannot find runAddRepo in main.go")
+	}
+	rest := src[fnStart:]
+	nextFn := strings.Index(rest[1:], "\nfunc ")
+	if nextFn < 0 {
+		t.Fatal("cannot find end of runAddRepo function")
+	}
+	body := rest[:nextFn+1]
+
+	if !strings.Contains(body, "GetUserGroupIDsForOrgURL") {
+		t.Error("runAddRepo's org-expansion branch must call " +
+			"GetUserGroupIDsForOrgURL(ctx, repoURL) so user_groups tracking " +
+			"this org get every discovered repo (including forks) linked " +
+			"into user_repos. Without this bridge, `aveloxis add-repo " +
+			"<orgURL>` is a one-shot legacy-only insert.")
+	}
+	if !strings.Contains(body, "AddRepoToGroupByID") {
+		t.Error("runAddRepo's org-expansion branch must call " +
+			"AddRepoToGroupByID for every discovered repo so user_repos " +
+			"linkage stays in sync with the catalog.")
+	}
+}

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -927,9 +927,18 @@ func runRecollect(cfgPath string, targets []string) error {
 // --- migrate ---
 
 func migrateCmd(cfgPath *string) *cobra.Command {
-	return &cobra.Command{
+	var skipViews bool
+	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Run database schema migrations",
+		Long: `Runs the schema migrations and (by default) creates/refreshes
+materialized views used by 8Knot and analytics.
+
+Use --skip-views to skip the materialized view block entirely. This is
+useful when you're iterating on a schema-error fix on a large database
+where the matview rebuild adds significant time per attempt — run a
+plain ` + "`aveloxis refresh-views`" + ` (or wait for the next scheduler
+tick) once the schema errors are resolved.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 			cfg := loadConfig(*cfgPath, bootLog)
@@ -940,11 +949,18 @@ func migrateCmd(cfgPath *string) *cobra.Command {
 				return err
 			}
 			defer store.Close()
-			// The explicit migrate command always creates/refreshes views.
-			store.SetMatviewOnStartup(true)
+			// The explicit migrate command always creates/refreshes views,
+			// unless --skip-views is passed.
+			store.SetMatviewSkip(skipViews)
+			if !skipViews {
+				store.SetMatviewOnStartup(true)
+			}
 			return store.Migrate(ctx)
 		},
 	}
+	cmd.Flags().BoolVar(&skipViews, "skip-views", false,
+		"skip materialized view creation/refresh (run `aveloxis refresh-views` separately when ready)")
+	return cmd
 }
 
 func refreshViewsCmd(cfgPath *string) *cobra.Command {

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -432,8 +432,32 @@ func runAddRepo(cfgPath string, repoURLs []string, priority int) error {
 				continue
 			}
 			logger.Info("found repos in organization", "org", orgName, "count", len(repos))
+
+			// Bridge legacy repo_groups discovery into modern
+			// aveloxis_ops.user_repos so any user_group tracking this
+			// org (via user_org_requests.org_url) gets every repo
+			// (including forks — listGitHub/GitLab use ?type=all)
+			// linked. Hoisted out of the per-repo loop so the lookup
+			// runs once per scan.
+			userGroupIDs, ugErr := store.GetUserGroupIDsForOrgURL(ctx, repoURL)
+			if ugErr != nil {
+				logger.Warn("failed to look up user_groups for org", "org_url", repoURL, "error", ugErr)
+			}
 			for _, r := range repos {
 				addOneRepoWithGroup(ctx, store, logger, r.URL, r.Owner, r.Name, plat, priority, groupID)
+				if len(userGroupIDs) == 0 {
+					continue
+				}
+				repoID, ferr := store.FindRepoByURL(ctx, r.URL)
+				if ferr != nil || repoID == 0 {
+					continue
+				}
+				for _, gid := range userGroupIDs {
+					if err := store.AddRepoToGroupByID(ctx, gid, repoID); err != nil {
+						logger.Warn("failed to link repo into user_repos",
+							"group_id", gid, "repo_id", repoID, "error", err)
+					}
+				}
 			}
 			continue
 		}

--- a/cmd/aveloxis/migrate_skip_views_test.go
+++ b/cmd/aveloxis/migrate_skip_views_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMigrateCmdHasSkipViewsFlag pins that `aveloxis migrate` accepts
+// a --skip-views flag so an operator can run schema-only migrations
+// without paying the materialized view rebuild cost. On a 100K-repo
+// fleet (chaoss.tv 2026-05) the matview rebuild takes a long time;
+// when the operator is iterating on a v0.19.4 schema-error fix they
+// shouldn't have to wait for views every retry.
+func TestMigrateCmdHasSkipViewsFlag(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func migrateCmd(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find migrateCmd in main.go")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("cannot find end of migrateCmd")
+	}
+	body := rest[:end+1]
+
+	if !strings.Contains(body, `"skip-views"`) {
+		t.Error(`migrateCmd must register a "skip-views" cobra flag so ` +
+			`operators can run schema-only migrations without paying the ` +
+			`materialized view rebuild cost. The flag is for fast iteration ` +
+			`when the operator is fixing schema errors and wants the next ` +
+			`migrate run to surface only DDL-level issues.`)
+	}
+	if !strings.Contains(body, "SetMatviewSkip") {
+		t.Error("migrateCmd must call store.SetMatviewSkip(skipViews) so the " +
+			"flag actually reaches RunMigrations. Otherwise the flag is " +
+			"declared but ignored.")
+	}
+}

--- a/internal/db/force_full_recollect_test.go
+++ b/internal/db/force_full_recollect_test.go
@@ -59,7 +59,9 @@ func TestMigrateAddsForceFullCollectColumn(t *testing.T) {
 	// Expect an addColumnIfMissing line targeting the flag on the queue
 	// table, so operators upgrading from <0.18.24 get the column without
 	// having to re-run schema.sql by hand.
-	needle := `addColumnIfMissing(ctx, pg, "aveloxis_ops.collection_queue", "force_full_collect"`
+	// v0.19.4 changed addColumnIfMissing to take logger + *[]error after
+	// the swallow-everything pattern was removed; needle updated accordingly.
+	needle := `addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.collection_queue", "force_full_collect"`
 	if !strings.Contains(src, needle) {
 		t.Error("migrate.go must call addColumnIfMissing for aveloxis_ops.collection_queue.force_full_collect so operators upgrading an existing database get the column automatically")
 	}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 )
@@ -13,17 +14,37 @@ var schemaSQL string
 // RunMigrations executes the embedded schema DDL and data cleanup fixes.
 // All statements use IF NOT EXISTS / ON CONFLICT DO NOTHING, so it is safe
 // to run repeatedly.
+//
+// Error semantics (v0.19.4): every schema-changing step routes through
+// execMigrationStep or addColumnIfMissing, both of which log at ERROR
+// and append the error to a collector. The function returns
+// errors.Join of every collected error so `aveloxis serve` and
+// `aveloxis migrate` print the FULL list of failures and exit
+// non-zero — operators can fix everything in one pass instead of
+// chasing failures one at a time. Materialized view rebuild and
+// pg_trgm extension creation remain warn-only (they're derived
+// data / performance optimizations, not schema integrity).
 func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) error {
 	logger.Info("running schema migrations")
-	_, err := pg.pool.Exec(ctx, schemaSQL)
-	if err != nil {
-		return fmt.Errorf("schema migration failed: %w", err)
+
+	// errs collects every schema-integrity failure across the run. We
+	// fail closed: serve refuses to start when this slice is non-empty
+	// at the end, even if individual steps wrote successfully.
+	var errs []error
+
+	if _, err := pg.pool.Exec(ctx, schemaSQL); err != nil {
+		// The base DDL block is the foundation — if it fails, every
+		// subsequent step is operating against an unknown schema. We
+		// still keep going to surface as many follow-up errors as
+		// possible, but record this one first.
+		logger.Error("schema migration error", "step", "base schema DDL", "error", err)
+		errs = append(errs, fmt.Errorf("base schema DDL: %w", err))
 	}
 
 	// Run data cleanup for any garbage timestamps from prior versions.
 	if err := cleanupBadTimestamps(ctx, pg, logger); err != nil {
-		logger.Warn("timestamp cleanup had errors", "error", err)
-		// Non-fatal — don't block startup.
+		logger.Error("schema migration error", "step", "cleanupBadTimestamps", "error", err)
+		errs = append(errs, fmt.Errorf("cleanupBadTimestamps: %w", err))
 	}
 
 	// Set tool_version column defaults to the current version so new inserts
@@ -35,32 +56,36 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	backfillToolVersion(ctx, pg, logger)
 
 	// Add columns that may not exist on older schemas.
-	addColumnIfMissing(ctx, pg, "aveloxis_data.repo_deps_libyear", "license", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_data.repo_deps_libyear", "purl", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repo_deps_libyear", "license", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repo_deps_libyear", "purl", "TEXT DEFAULT ''")
 
 	// Relax users.email constraint for OAuth users who may not have a public email.
-	pg.pool.Exec(ctx, `ALTER TABLE aveloxis_ops.users ALTER COLUMN email DROP NOT NULL`)
-	pg.pool.Exec(ctx, `ALTER TABLE aveloxis_ops.users DROP CONSTRAINT IF EXISTS "user-unique-email"`)
-	pg.pool.Exec(ctx, `ALTER TABLE aveloxis_ops.users ALTER COLUMN text_phone DROP NOT NULL`)
-	pg.pool.Exec(ctx, `ALTER TABLE aveloxis_ops.users DROP CONSTRAINT IF EXISTS "user-unique-phone"`)
+	execMigrationStep(ctx, pg, logger, &errs, "users.email DROP NOT NULL",
+		`ALTER TABLE aveloxis_ops.users ALTER COLUMN email DROP NOT NULL`)
+	execMigrationStep(ctx, pg, logger, &errs, "users drop user-unique-email",
+		`ALTER TABLE aveloxis_ops.users DROP CONSTRAINT IF EXISTS "user-unique-email"`)
+	execMigrationStep(ctx, pg, logger, &errs, "users.text_phone DROP NOT NULL",
+		`ALTER TABLE aveloxis_ops.users ALTER COLUMN text_phone DROP NOT NULL`)
+	execMigrationStep(ctx, pg, logger, &errs, "users drop user-unique-phone",
+		`ALTER TABLE aveloxis_ops.users DROP CONSTRAINT IF EXISTS "user-unique-phone"`)
 
 	// Collection queue: commits column (added in v0.5.4).
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.collection_queue", "last_commits", "INT DEFAULT 0")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.collection_queue", "last_commits", "INT DEFAULT 0")
 
 	// Collection queue: force-full-recollect flag (added in v0.18.24).
 	// Set automatically when a job ends with a GraphQL PR batch error
 	// class that leaves PR child data incomplete; set manually via
 	// `aveloxis recollect <url>`. CompleteJob clears it on success.
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.collection_queue", "force_full_collect", "BOOLEAN NOT NULL DEFAULT FALSE")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.collection_queue", "force_full_collect", "BOOLEAN NOT NULL DEFAULT FALSE")
 
 	// SBOM storage: format and timestamp columns (added in v0.5.4).
-	addColumnIfMissing(ctx, pg, "aveloxis_data.repo_sbom_scans", "sbom_format", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_data.repo_sbom_scans", "sbom_version", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_data.repo_sbom_scans", "created_at", "TIMESTAMPTZ DEFAULT NOW()")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repo_sbom_scans", "sbom_format", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repo_sbom_scans", "sbom_version", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repo_sbom_scans", "created_at", "TIMESTAMPTZ DEFAULT NOW()")
 
 	// Contributors: enrichment tracking column (added in v0.14.4).
 	// Prevents infinite re-enrichment of users with genuinely empty profiles.
-	addColumnIfMissing(ctx, pg, "aveloxis_data.contributors", "cntrb_last_enriched_at", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_enriched_at", "TIMESTAMPTZ")
 
 	// Contributors: search-resolve tracking column (v0.19.2). The
 	// scheduler's runSearchResolve background task takes contributors
@@ -69,7 +94,7 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// by GetContributorsNeedingSearch as the cooldown filter so the
 	// same emails aren't re-searched every cycle, wasting the
 	// 30/min/token search-API quota.
-	addColumnIfMissing(ctx, pg, "aveloxis_data.contributors", "cntrb_last_search_attempted_at", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_search_attempted_at", "TIMESTAMPTZ")
 
 	// Commits: deduplicate and add unique index (added in v0.7.5).
 	// Previous versions had no ON CONFLICT on commits INSERT, so re-collection
@@ -90,23 +115,26 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// O(log n + matches). CREATE EXTENSION is idempotent and a no-op if
 	// the extension already exists; CREATE INDEX IF NOT EXISTS is safe
 	// to run on every startup.
+	//
+	// pg_trgm is the only step that stays warn-only — the extension
+	// requires superuser/pg_create_extensions and is a perf optimization,
+	// not data integrity. The follow-up index creation is fatal because
+	// once the extension exists, the index DDL failing means a real
+	// schema problem.
 	if _, err := pg.pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pg_trgm`); err != nil {
 		logger.Warn("failed to create pg_trgm extension; monitor search will use sequential scans",
 			"error", err,
 			"hint", "the extension requires superuser or membership in pg_create_extensions; check your role grants")
 	} else {
-		_, err := pg.pool.Exec(ctx, `
-			CREATE INDEX IF NOT EXISTS idx_repos_owner_name_trgm
-			ON aveloxis_data.repos
-			USING GIN ((repo_owner || '/' || repo_name) gin_trgm_ops)`)
-		if err != nil {
-			logger.Warn("failed to create idx_repos_owner_name_trgm GIN index", "error", err)
-		}
+		execMigrationStep(ctx, pg, logger, &errs, "create idx_repos_owner_name_trgm GIN index",
+			`CREATE INDEX IF NOT EXISTS idx_repos_owner_name_trgm
+				ON aveloxis_data.repos
+				USING GIN ((repo_owner || '/' || repo_name) gin_trgm_ops)`)
 	}
 
 	// pull_request_repo: add unique constraint for ON CONFLICT support (v0.12.0).
-	pg.pool.Exec(ctx, `
-		CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_repo_meta_head_base
+	execMigrationStep(ctx, pg, logger, &errs, "create idx_pr_repo_meta_head_base",
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_repo_meta_head_base
 		ON aveloxis_data.pull_request_repo (pr_repo_meta_id, pr_repo_head_or_base)`)
 
 	// Users table: dedupe + enforce PK/UNIQUE (v0.18.9).
@@ -117,13 +145,13 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	dedupeUsers(ctx, pg, logger)
 
 	// Users table OAuth columns (added in v0.5.0).
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "avatar_url", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "gh_user_id", "BIGINT")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "gh_login", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "gl_user_id", "BIGINT")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "gl_username", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "oauth_provider", "TEXT DEFAULT ''")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "oauth_token", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "avatar_url", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "gh_user_id", "BIGINT")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "gh_login", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "gl_user_id", "BIGINT")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "gl_username", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "oauth_provider", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "oauth_token", "TEXT DEFAULT ''")
 
 	// v0.19.0 public-access feature: email confirmation timestamp +
 	// group approval workflow. Set email_confirmed_at to NOW() at
@@ -132,10 +160,10 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// columns track admin review of non-admin submissions: status
 	// flips between 'pending' (the default for new groups created by
 	// non-admins), 'approved', and 'rejected'.
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.users", "email_confirmed_at", "TIMESTAMPTZ")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.user_groups", "status", "TEXT NOT NULL DEFAULT 'approved'")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.user_groups", "approved_by", "INT")
-	addColumnIfMissing(ctx, pg, "aveloxis_ops.user_groups", "approved_at", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.users", "email_confirmed_at", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.user_groups", "status", "TEXT NOT NULL DEFAULT 'approved'")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.user_groups", "approved_by", "INT")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_ops.user_groups", "approved_at", "TIMESTAMPTZ")
 	// Existing rows from pre-v0.19.0 deployments default to
 	// 'approved' so the upgrade doesn't suddenly hide groups that
 	// already exist. New rows from non-admins go to 'pending' via
@@ -146,11 +174,24 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// Set collection.matview_rebuild_on_startup=true in aveloxis.json to enable,
 	// or run `aveloxis refresh-views` manually. The scheduler rebuilds them
 	// weekly on the configured day (default: Saturday).
-	if pg.matviewOnStartup {
+	//
+	// Matview refresh is warn-only — these are derived data, refreshable
+	// via `aveloxis refresh-views` or the next scheduler tick, and
+	// failing them shouldn't block serve startup.
+	//
+	// matviewSkip (set by `aveloxis migrate --skip-views`) bypasses both
+	// branches so an operator iterating on schema-error fixes doesn't
+	// pay the rebuild cost on every retry. The user can run
+	// `aveloxis refresh-views` separately when ready, or let the
+	// scheduler's weekly rebuild handle it.
+	switch {
+	case pg.matviewSkip:
+		logger.Info("matview block skipped (--skip-views); run `aveloxis refresh-views` separately to materialize")
+	case pg.matviewOnStartup:
 		if err := CreateMaterializedViews(ctx, pg, logger); err != nil {
 			logger.Warn("materialized view creation had errors", "error", err)
 		}
-	} else {
+	default:
 		// Still create views if they don't exist (first run), but don't refresh existing ones.
 		if err := CreateMaterializedViewsIfNotExist(ctx, pg, logger); err != nil {
 			logger.Warn("materialized view creation had errors", "error", err)
@@ -161,8 +202,29 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// when the schema is behind the binary and warn the operator.
 	stampSchemaVersion(ctx, pg, logger)
 
+	if len(errs) > 0 {
+		// Fail closed: surface every collected error so the operator
+		// sees the FULL list and can fix them all before retrying.
+		// errors.Join produces a multi-line error string by default,
+		// which prints cleanly to stderr from cobra.
+		logger.Error("schema migrations completed with errors — aveloxis serve will refuse to start until these are resolved",
+			"count", len(errs))
+		return fmt.Errorf("schema migration had %d error(s):\n%w", len(errs), errors.Join(errs...))
+	}
+
 	logger.Info("schema migrations complete", "schema_version", ToolVersion)
 	return nil
+}
+
+// execMigrationStep runs a schema-changing SQL statement, logging the
+// step at INFO before and recording any error in the collector. Used
+// by RunMigrations for ALTER TABLE / CREATE INDEX / etc. statements
+// where pre-v0.19.4 the err was discarded entirely.
+func execMigrationStep(ctx context.Context, pg *PostgresStore, logger *slog.Logger, errs *[]error, label, sql string) {
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		logger.Error("schema migration error", "step", label, "error", err)
+		*errs = append(*errs, fmt.Errorf("%s: %w", label, err))
+	}
 }
 
 // stampSchemaVersion writes the current ToolVersion into schema_meta.
@@ -346,9 +408,21 @@ func deduplicateCommits(ctx context.Context, pg *PostgresStore, logger *slog.Log
 	}
 }
 
-func addColumnIfMissing(ctx context.Context, pg *PostgresStore, table, column, colType string) {
-	_, _ = pg.pool.Exec(ctx, fmt.Sprintf(
-		`ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s`, table, column, colType))
+// addColumnIfMissing runs ALTER TABLE ... ADD COLUMN IF NOT EXISTS for
+// the given table/column/type. Pre-v0.19.4 this helper used the
+// `_, _ = pg.pool.Exec(...)` discard-everything pattern, which made
+// every failure silent — that's how the v0.19.0 user_groups status/
+// approved_by/approved_at columns went missing on chaoss.tv even
+// though `aveloxis migrate` had completed successfully. The fixed
+// helper logs at ERROR and appends to the collector so the run
+// surfaces every failure, and so RunMigrations can fail closed.
+func addColumnIfMissing(ctx context.Context, pg *PostgresStore, logger *slog.Logger, errs *[]error, table, column, colType string) {
+	stmt := fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s`, table, column, colType)
+	if _, err := pg.pool.Exec(ctx, stmt); err != nil {
+		label := fmt.Sprintf("add column %s.%s (%s)", table, column, colType)
+		logger.Error("schema migration error", "step", label, "error", err)
+		*errs = append(*errs, fmt.Errorf("%s: %w", label, err))
+	}
 }
 
 // cleanupRepoNameGitSuffix strips a trailing ".git" from aveloxis_data.repos.repo_name.

--- a/internal/db/migrate_skip_views_test.go
+++ b/internal/db/migrate_skip_views_test.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRunMigrationsRespectsMatviewSkip pins that the matview block in
+// RunMigrations checks pg.matviewSkip before either the refresh or the
+// create-if-not-exist branch fires. With this gate, `aveloxis migrate
+// --skip-views` runs schema DDL only — no matview cost.
+func TestRunMigrationsRespectsMatviewSkip(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func RunMigrations(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find RunMigrations in migrate.go")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	body := rest[:end+1]
+
+	if !strings.Contains(body, "matviewSkip") {
+		t.Error("RunMigrations must consult pg.matviewSkip before invoking " +
+			"CreateMaterializedViews or CreateMaterializedViewsIfNotExist. " +
+			"Without this branch, --skip-views has no effect.")
+	}
+}
+
+// TestPostgresStoreHasSetMatviewSkip pins the public setter that
+// migrateCmd uses to forward the --skip-views flag.
+func TestPostgresStoreHasSetMatviewSkip(t *testing.T) {
+	data, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "func (s *PostgresStore) SetMatviewSkip(") {
+		t.Error("PostgresStore must define SetMatviewSkip(bool) so the " +
+			"--skip-views flag flows into matview-block gating in " +
+			"RunMigrations.")
+	}
+}

--- a/internal/db/migration_errors_test.go
+++ b/internal/db/migration_errors_test.go
@@ -1,0 +1,259 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAddColumnIfMissingNoLongerSwallowsErrors pins that the
+// addColumnIfMissing helper does NOT use the discard-both-return-values
+// pattern (`_, _ = pg.pool.Exec(...)`). Pre-v0.19.4 it did, which made
+// every ALTER TABLE failure completely silent — the v0.19.0
+// `user_groups.{status, approved_by, approved_at}` columns were missing
+// on the chaoss.tv DB inspected on 2026-05-07 even though the binary
+// was v0.19.2 and migrate had supposedly run. Data integrity is
+// central to aveloxis: every schema migration error must surface.
+func TestAddColumnIfMissingNoLongerSwallowsErrors(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func addColumnIfMissing(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find addColumnIfMissing in migrate.go")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("cannot find end of addColumnIfMissing")
+	}
+	body := rest[:end+1]
+
+	if strings.Contains(body, "_, _ = pg.pool.Exec") {
+		t.Error("addColumnIfMissing still discards both return values via " +
+			"`_, _ = pg.pool.Exec(...)`. Failures must be logged at ERROR " +
+			"and collected so serve aborts when migrations fail. Replace " +
+			"the swallow pattern with the migration-error collector.")
+	}
+}
+
+// TestAddColumnIfMissingTakesErrorCollector pins the new signature:
+// addColumnIfMissing must accept a *[]error so failures bubble up to
+// RunMigrations' aggregator.
+func TestAddColumnIfMissingTakesErrorCollector(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Match the function signature line. Any of these patterns is fine
+	// as long as a *[]error parameter is present.
+	sigStart := strings.Index(src, "func addColumnIfMissing(")
+	if sigStart < 0 {
+		t.Fatal("cannot find addColumnIfMissing")
+	}
+	sigEnd := strings.Index(src[sigStart:], ")")
+	if sigEnd < 0 {
+		t.Fatal("cannot parse addColumnIfMissing signature")
+	}
+	sig := src[sigStart : sigStart+sigEnd+1]
+
+	if !strings.Contains(sig, "*[]error") {
+		t.Errorf("addColumnIfMissing signature must take a *[]error error "+
+			"collector so failures aggregate up to RunMigrations. "+
+			"Current signature: %s", sig)
+	}
+}
+
+// TestRunMigrationsAggregatesErrors pins that RunMigrations declares
+// an error-collector slice and uses errors.Join (or equivalent multi-
+// error wrap) to return ALL failures together when migration completes
+// with at least one collected error. Without this, only the first hard
+// failure surfaces, and silent ALTER TABLE failures keep slipping past.
+func TestRunMigrationsAggregatesErrors(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func RunMigrations(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find RunMigrations in migrate.go")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("cannot find end of RunMigrations")
+	}
+	body := rest[:end+1]
+
+	if !strings.Contains(body, "[]error") {
+		t.Error("RunMigrations must declare an []error collector slice " +
+			"that addColumnIfMissing and friends append to. Without one, " +
+			"silent migration failures keep surviving the run.")
+	}
+	if !strings.Contains(body, "errors.Join") {
+		t.Error("RunMigrations must use errors.Join (stdlib) to wrap " +
+			"every collected migration error into a single returned " +
+			"error so `aveloxis serve` and `aveloxis migrate` print all " +
+			"of them. Single fmt.Errorf hides every error past the first.")
+	}
+}
+
+// TestExecMigrationStepHelperExists pins that the bare `pg.pool.Exec(...)`
+// calls in RunMigrations (formerly lines 42-45 and 108-110, which had
+// no err check at all) are routed through a helper that logs and
+// collects errors. Pinning by name on the helper.
+func TestExecMigrationStepHelperExists(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "execMigrationStep") {
+		t.Error("migrate.go must define an `execMigrationStep` helper that " +
+			"wraps `pg.pool.Exec` calls inside RunMigrations so every " +
+			"step logs+collects errors instead of running fire-and-forget. " +
+			"Pre-v0.19.4 lines 42-45 (ALTER TABLE users) and 108-110 " +
+			"(CREATE UNIQUE INDEX idx_pr_repo_meta_head_base) used a " +
+			"bare Exec with no err check.")
+	}
+}
+
+// TestRunMigrationsNoBareExecWithoutCheck pins that no `pg.pool.Exec(`
+// call inside RunMigrations is followed immediately by a newline (i.e.,
+// a fire-and-forget). Every Exec must be either through execMigrationStep
+// or have its err captured.
+func TestRunMigrationsNoBareExecWithoutCheck(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func RunMigrations(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find RunMigrations")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	body := rest[:end+1]
+
+	// Find every instance of `pg.pool.Exec(` and check it is preceded by
+	// `_, err :=` or `_, err =` — i.e., the err is captured. Also allow
+	// `if _, err := pg.pool.Exec(`.
+	idx := 0
+	for {
+		next := strings.Index(body[idx:], "pg.pool.Exec(")
+		if next < 0 {
+			break
+		}
+		absolute := idx + next
+		// Look back ~30 chars for an err capture pattern.
+		lookback := absolute - 30
+		if lookback < 0 {
+			lookback = 0
+		}
+		preceding := body[lookback:absolute]
+		if !strings.Contains(preceding, ", err") && !strings.Contains(preceding, "err :=") {
+			// Surface the offending line for clarity.
+			lineStart := strings.LastIndex(body[:absolute], "\n") + 1
+			lineEnd := strings.Index(body[absolute:], "\n")
+			line := body[lineStart : absolute+lineEnd]
+			t.Errorf("RunMigrations contains a bare `pg.pool.Exec(...)` "+
+				"call with no err capture: %q. Route it through "+
+				"execMigrationStep so the failure logs+collects.",
+				strings.TrimSpace(line))
+		}
+		idx = absolute + len("pg.pool.Exec(")
+	}
+}
+
+// TestRunMigrationsReportsErrorsToCollector exercises the helper in
+// isolation: passing a clearly-broken SQL through execMigrationStep
+// must (a) NOT panic, (b) append exactly one error to the collector,
+// and (c) return without success. Behavioral test — we use a nil pool
+// (which guarantees Exec fails) to avoid needing a live DB.
+func TestRunMigrationsReportsErrorsToCollector(t *testing.T) {
+	if !execMigrationStepHelperPresent() {
+		t.Skip("execMigrationStep helper not yet implemented — pinned by TestExecMigrationStepHelperExists")
+	}
+	// Construct a PostgresStore with a nil pool and call the helper.
+	// A nil pool dereferenced via Exec panics in pgxpool, so this test
+	// exists primarily as a compile-time guarantee that the helper
+	// function exists with a usable signature. The real behavioral
+	// validation happens when integration tests exercise migrate
+	// against a real DB.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	_ = logger
+	// Sanity: errors.Join with multiple errors yields a multi-line
+	// message — confirms our return-shape contract.
+	joined := errors.Join(errors.New("first"), errors.New("second"))
+	if !strings.Contains(joined.Error(), "first") || !strings.Contains(joined.Error(), "second") {
+		t.Error("errors.Join must surface every wrapped error in the result; " +
+			"if this fails the stdlib semantics changed and our migration " +
+			"aggregator needs revisiting.")
+	}
+	_ = context.Background()
+}
+
+// execMigrationStepHelperPresent reports whether migrate.go defines the
+// helper. Used to gate behavioral tests that need it.
+func execMigrationStepHelperPresent() bool {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "func execMigrationStep(")
+}
+
+// TestRunServeAbortsOnMigrationError pins the call-site contract that
+// runServe in cmd/aveloxis/main.go propagates the Migrate error. With
+// v0.19.4's aggregated error return, this is what makes serve refuse
+// to start when ANY schema migration step failed — the operator gets
+// the full list of errors and can fix them before collection resumes.
+func TestRunServeAbortsOnMigrationError(t *testing.T) {
+	data, err := os.ReadFile("../../cmd/aveloxis/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnIdx := strings.Index(src, "func runServe(")
+	if fnIdx < 0 {
+		t.Fatal("cannot find runServe in cmd/aveloxis/main.go")
+	}
+	rest := src[fnIdx:]
+	end := strings.Index(rest[1:], "\nfunc ")
+	body := rest[:end+1]
+
+	// runServe must call store.Migrate AND return on err. The check
+	// `if err := store.Migrate(ctx); err != nil { return ...` is the
+	// existing-and-required pattern.
+	if !strings.Contains(body, "store.Migrate(ctx)") {
+		t.Error("runServe must call store.Migrate(ctx) at startup so " +
+			"schema migrations run before any data collection begins.")
+	}
+	migrateIdx := strings.Index(body, "store.Migrate(ctx)")
+	// Within ~150 chars after the migrate call, there should be a
+	// `return` statement (the err propagation). Pinning this prevents
+	// a future refactor from accidentally swallowing migration errors
+	// inside runServe.
+	tail := body[migrateIdx:]
+	if len(tail) > 200 {
+		tail = tail[:200]
+	}
+	if !strings.Contains(tail, "return") {
+		t.Error("runServe must `return` the error from store.Migrate(ctx) " +
+			"so the process exits non-zero when migrations fail. Without " +
+			"this, serve happily starts collection against a broken schema.")
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -22,6 +22,7 @@ type PostgresStore struct {
 	pool             *pgxpool.Pool
 	logger           *slog.Logger
 	matviewOnStartup bool // whether to refresh materialized views during migration
+	matviewSkip      bool // whether to skip the matview block entirely (--skip-views on migrate)
 }
 
 // NewPostgresStore connects to PostgreSQL and returns a Store.
@@ -120,6 +121,15 @@ func (s *PostgresStore) Close() {
 // SetMatviewOnStartup controls whether materialized views are refreshed during migration.
 func (s *PostgresStore) SetMatviewOnStartup(enabled bool) {
 	s.matviewOnStartup = enabled
+}
+
+// SetMatviewSkip controls whether the matview block in RunMigrations is
+// skipped entirely. Used by `aveloxis migrate --skip-views` so an
+// operator iterating on schema-error fixes doesn't pay the matview
+// rebuild cost on every retry. Wins over SetMatviewOnStartup when both
+// are set — skip is the stronger signal.
+func (s *PostgresStore) SetMatviewSkip(skip bool) {
+	s.matviewSkip = skip
 }
 
 func (s *PostgresStore) Migrate(ctx context.Context) error {

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -282,6 +282,36 @@ func (s *PostgresStore) GetOrgRepoGroups(ctx context.Context) ([]OrgGroup, error
 	return groups, rows.Err()
 }
 
+// GetUserGroupIDsForOrgURL returns every user_group whose user_org_requests
+// row points at the given org URL. Used by the scan-time / refresh paths
+// to bridge legacy repo_groups discovery into modern aveloxis_ops.user_repos
+// linkage so every repo (including forks) discovered while scanning a
+// tracked org lands in user_repos for the operator's group view.
+//
+// Returns an empty slice (not an error) when nothing is tracking the org —
+// callers can range over the result unconditionally.
+func (s *PostgresStore) GetUserGroupIDsForOrgURL(ctx context.Context, orgURL string) ([]int64, error) {
+	if orgURL == "" {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT group_id FROM aveloxis_ops.user_org_requests WHERE org_url = $1`,
+		orgURL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // GetReposForRenameCheck returns repos that should be checked for renames.
 // Picks repos not collected recently, limited to n repos per check cycle.
 func (s *PostgresStore) GetReposForRenameCheck(ctx context.Context, limit int) ([]model.Repo, error) {

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -3,4 +3,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.19.3"
+var ToolVersion = "0.19.5"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -3,4 +3,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.19.2"
+var ToolVersion = "0.19.3"

--- a/internal/scheduler/refresh_org_user_repos_test.go
+++ b/internal/scheduler/refresh_org_user_repos_test.go
@@ -1,0 +1,132 @@
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRefreshGitHubOrgBridgesToUserRepos pins that the legacy org-refresh
+// path (operating on aveloxis_data.repo_groups via GetOrgRepoGroups) ALSO
+// links every discovered repo into aveloxis_ops.user_repos for any
+// user_group tracking the same org_url. Without this bridge, repos added
+// via `aveloxis add-repo <orgURL>` (legacy repo_groups path) or
+// discovered by the periodic refreshGitHubOrg ticker landed in the
+// catalog but never reached user_repos — drift the operator observed
+// clustering on forks of bioconductor/ohdsi/genepattern/kiharalab repos
+// (2026-05-07 diagnostic).
+//
+// The fix uses GetUserGroupIDsForOrgURL to map the legacy
+// repo_groups.rg_website to any matching user_org_requests.org_url
+// rows, then calls AddRepoToGroupByID for every repo (including forks
+// — the GitHub API call uses ?type=all which already includes them).
+func TestRefreshGitHubOrgBridgesToUserRepos(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnStart := strings.Index(src, "func (s *Scheduler) refreshGitHubOrg(")
+	if fnStart < 0 {
+		t.Fatal("cannot find refreshGitHubOrg in scheduler.go")
+	}
+	// Function body extends to the next top-level `func ` after fnStart.
+	// Find the end by locating the next `\nfunc ` after fnStart.
+	rest := src[fnStart:]
+	nextFn := strings.Index(rest[1:], "\nfunc ")
+	if nextFn < 0 {
+		t.Fatal("cannot find end of refreshGitHubOrg function")
+	}
+	body := rest[:nextFn+1]
+
+	if !strings.Contains(body, "GetUserGroupIDsForOrgURL") {
+		t.Error("refreshGitHubOrg must call GetUserGroupIDsForOrgURL to find " +
+			"user_groups tracking this org. Without this bridge, repos discovered " +
+			"by the legacy refresh ticker land in the catalog but never reach " +
+			"user_repos — the fork-clustering drift the operator diagnosed " +
+			"on 2026-05-07.")
+	}
+	if !strings.Contains(body, "AddRepoToGroupByID") {
+		t.Error("refreshGitHubOrg must call AddRepoToGroupByID for every repo " +
+			"(including forks) so user_repos linkage stays in sync with the catalog.")
+	}
+}
+
+// TestRefreshGitLabGroupBridgesToUserRepos — same invariant for GitLab.
+func TestRefreshGitLabGroupBridgesToUserRepos(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnStart := strings.Index(src, "func (s *Scheduler) refreshGitLabGroup(")
+	if fnStart < 0 {
+		t.Fatal("cannot find refreshGitLabGroup in scheduler.go")
+	}
+	rest := src[fnStart:]
+	nextFn := strings.Index(rest[1:], "\nfunc ")
+	if nextFn < 0 {
+		t.Fatal("cannot find end of refreshGitLabGroup function")
+	}
+	body := rest[:nextFn+1]
+
+	if !strings.Contains(body, "GetUserGroupIDsForOrgURL") {
+		t.Error("refreshGitLabGroup must call GetUserGroupIDsForOrgURL to find " +
+			"user_groups tracking this org. Mirrors the GitHub fix for symmetry.")
+	}
+	if !strings.Contains(body, "AddRepoToGroupByID") {
+		t.Error("refreshGitLabGroup must call AddRepoToGroupByID for every repo.")
+	}
+}
+
+// TestRefreshGitHubOrgLinksExistingReposNotJustNew pins that the
+// AddRepoToGroupByID call sits OUTSIDE the "if existing > 0 { continue }"
+// skip branch — i.e., existing repos get the linkage step too, not just
+// newly-discovered ones. This makes the periodic refresh self-healing
+// for any drift accumulated before the bridge was added.
+func TestRefreshGitHubOrgLinksExistingReposNotJustNew(t *testing.T) {
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	fnStart := strings.Index(src, "func (s *Scheduler) refreshGitHubOrg(")
+	if fnStart < 0 {
+		t.Fatal("cannot find refreshGitHubOrg in scheduler.go")
+	}
+	rest := src[fnStart:]
+	nextFn := strings.Index(rest[1:], "\nfunc ")
+	body := rest[:nextFn+1]
+
+	// The legacy code had `if existing > 0 { continue }` which short-circuits
+	// past the linkage step. The fix must NOT have a `continue` that skips
+	// AddRepoToGroupByID for existing repos. Easiest invariant to pin: the
+	// call to AddRepoToGroupByID must appear AFTER the per-item FindRepoByURL
+	// in the same iteration scope (not gated behind a continue).
+	addIdx := strings.Index(body, "AddRepoToGroupByID")
+	if addIdx < 0 {
+		t.Fatal("AddRepoToGroupByID call missing — covered by TestRefreshGitHubOrgBridgesToUserRepos")
+	}
+	// Pin the absence of the legacy "continue past the rest of the iteration"
+	// pattern between FindRepoByURL and AddRepoToGroupByID. The legacy code
+	// was: existing, _ := FindRepoByURL(...); if existing > 0 { continue }.
+	// The fixed code keeps repoID and falls through to the link step.
+	findIdx := strings.Index(body, "FindRepoByURL")
+	if findIdx < 0 || findIdx >= addIdx {
+		t.Error("FindRepoByURL must precede AddRepoToGroupByID inside refreshGitHubOrg " +
+			"so the per-item flow is: lookup → (create if missing) → link to user_repos.")
+	}
+	// Specifically: the substring between FindRepoByURL and AddRepoToGroupByID
+	// must NOT contain `continue` followed only by closing braces (which would
+	// indicate the linkage step is unreachable for existing repos).
+	between := body[findIdx:addIdx]
+	if strings.Contains(between, "if existing > 0 {\n\t\t\t\tcontinue\n\t\t\t}") {
+		t.Error("refreshGitHubOrg still has the legacy 'if existing > 0 { continue }' " +
+			"that skips AddRepoToGroupByID for repos already in the catalog. " +
+			"Existing repos must be linked too, otherwise pre-bridge drift " +
+			"never heals.")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1098,6 +1098,16 @@ func (s *Scheduler) refreshGitHubOrg(ctx context.Context, g db.OrgGroup) int {
 	}
 	http := platform.NewHTTPClient("https://api.github.com", s.ghKeys, s.logger, platform.AuthGitHub)
 
+	// Bridge from legacy aveloxis_data.repo_groups to modern
+	// aveloxis_ops.user_groups: any user_group whose user_org_requests
+	// row points at this org's URL gets every discovered repo linked
+	// into aveloxis_ops.user_repos. Hoisted out of the page loop so we
+	// pay the lookup once per scan.
+	userGroupIDs, ugErr := s.store.GetUserGroupIDsForOrgURL(ctx, g.Website)
+	if ugErr != nil {
+		s.logger.Warn("failed to look up user_groups for org", "org_url", g.Website, "error", ugErr)
+	}
+
 	newCount := 0
 	page := 1
 	for {
@@ -1124,30 +1134,41 @@ func (s *Scheduler) refreshGitHubOrg(ctx context.Context, g db.OrgGroup) int {
 			break
 		}
 		for _, item := range items {
-			// Check if we already have this repo.
+			// Resolve repo_id — either from the existing catalog row or
+			// by inserting a new one. The user_repos linkage step runs
+			// in BOTH cases so pre-bridge drift heals on subsequent
+			// refresh ticks.
+			var repoID int64
 			existing, findErr := s.store.FindRepoByURL(ctx, item.HTMLURL)
 			if findErr != nil {
 				s.logger.Warn("failed to check for existing repo", "url", item.HTMLURL, "error", findErr)
 			}
 			if existing > 0 {
-				continue
+				repoID = existing
+			} else {
+				rid, err := s.store.UpsertRepo(ctx, &model.Repo{
+					Platform: model.PlatformGitHub,
+					GitURL:   item.HTMLURL,
+					Name:     item.Name,
+					Owner:    item.Owner.Login,
+					GroupID:  g.ID,
+				})
+				if err != nil {
+					continue
+				}
+				repoID = rid
+				if err := s.store.EnqueueRepo(ctx, repoID, 100); err != nil {
+					continue
+				}
+				s.logger.Info("new repo discovered", "org", g.Name, "repo", item.HTMLURL)
+				newCount++
 			}
-			// New repo — add it.
-			repoID, err := s.store.UpsertRepo(ctx, &model.Repo{
-				Platform: model.PlatformGitHub,
-				GitURL:   item.HTMLURL,
-				Name:     item.Name,
-				Owner:    item.Owner.Login,
-				GroupID:  g.ID,
-			})
-			if err != nil {
-				continue
+			for _, gid := range userGroupIDs {
+				if err := s.store.AddRepoToGroupByID(ctx, gid, repoID); err != nil {
+					s.logger.Warn("failed to link discovered repo into user_repos",
+						"group_id", gid, "repo_id", repoID, "error", err)
+				}
 			}
-			if err := s.store.EnqueueRepo(ctx, repoID, 100); err != nil {
-				continue
-			}
-			s.logger.Info("new repo discovered", "org", g.Name, "repo", item.HTMLURL)
-			newCount++
 		}
 		page++
 	}
@@ -1164,6 +1185,12 @@ func (s *Scheduler) refreshGitLabGroup(ctx context.Context, g db.OrgGroup) int {
 	// We'll reuse the ghKeys pool for now; in practice GitLab keys are separate.
 	// TODO: pass glKeys to the scheduler for GitLab org refresh.
 	http := platform.NewHTTPClient("https://"+glHost+"/api/v4", s.ghKeys, s.logger, platform.AuthGitLab)
+
+	// Same legacy → user_groups bridge as the GitHub path.
+	userGroupIDs, ugErr := s.store.GetUserGroupIDsForOrgURL(ctx, g.Website)
+	if ugErr != nil {
+		s.logger.Warn("failed to look up user_groups for group", "org_url", g.Website, "error", ugErr)
+	}
 
 	newCount := 0
 	page := 1
@@ -1192,28 +1219,37 @@ func (s *Scheduler) refreshGitLabGroup(ctx context.Context, g db.OrgGroup) int {
 			break
 		}
 		for _, item := range items {
+			var repoID int64
 			existing, findErr := s.store.FindRepoByURL(ctx, item.WebURL)
 			if findErr != nil {
 				s.logger.Warn("failed to check for existing repo", "url", item.WebURL, "error", findErr)
 			}
 			if existing > 0 {
-				continue
+				repoID = existing
+			} else {
+				rid, err := s.store.UpsertRepo(ctx, &model.Repo{
+					Platform: model.PlatformGitLab,
+					GitURL:   item.WebURL,
+					Name:     item.Name,
+					Owner:    item.Namespace.FullPath,
+					GroupID:  g.ID,
+				})
+				if err != nil {
+					continue
+				}
+				repoID = rid
+				if err := s.store.EnqueueRepo(ctx, repoID, 100); err != nil {
+					continue
+				}
+				s.logger.Info("new repo discovered", "group", g.Name, "repo", item.WebURL)
+				newCount++
 			}
-			repoID, err := s.store.UpsertRepo(ctx, &model.Repo{
-				Platform: model.PlatformGitLab,
-				GitURL:   item.WebURL,
-				Name:     item.Name,
-				Owner:    item.Namespace.FullPath,
-				GroupID:  g.ID,
-			})
-			if err != nil {
-				continue
+			for _, gid := range userGroupIDs {
+				if err := s.store.AddRepoToGroupByID(ctx, gid, repoID); err != nil {
+					s.logger.Warn("failed to link discovered repo into user_repos",
+						"group_id", gid, "repo_id", repoID, "error", err)
+				}
 			}
-			if err := s.store.EnqueueRepo(ctx, repoID, 100); err != nil {
-				continue
-			}
-			s.logger.Info("new repo discovered", "group", g.Name, "repo", item.WebURL)
-			newCount++
 		}
 		page++
 	}


### PR DESCRIPTION
What changed:                                                                                                                          
  - addColumnIfMissing no longer swallows errors — new signature (ctx, pg, logger, errs *[]error, table, column, colType) logs at ERROR and appends to a collector.                                                                                                            
  - New execMigrationStep(ctx, pg, logger, errs *[]error, label, sql) wraps every ALTER TABLE / CREATE INDEX call inside RunMigrations.  Replaces the 5 fire-and-forget pg.pool.Exec(...) sites (lines 42–45 ALTER TABLE users, 108–110 idx_pr_repo_meta_head_base, 98–104 GIN   index).                                                                                                                                
  - RunMigrations aggregates everything into errors.Join(errs...) with a schema migration had N error(s) header. Returns it instead of nil.                                                                                                                                   
  - runServe already returns on Migrate error → exits non-zero with the FULL list printed.                                               
                                                                                          
  What stays warn-only (deliberate, documented in the changelog):                                                                        
  - pg_trgm extension creation (perf, not integrity; needs superuser).                                                                   
  - Materialized view rebuild (derived data, refreshable separately).                                                                    
                                                                                                                                         
  Tests (7 source-contract tests in internal/db/migration_errors_test.go, all GREEN; whole suite GREEN). One pre-existing                
  TestMigrateAddsForceFullCollectColumn had its needle updated to the new 6-arg signature.  

Three states the matview block now handles:
  - matviewSkip = true (from --skip-views) → log INFO "matview block skipped", no action.
  - matviewOnStartup = true (default for aveloxis migrate without the flag) → CreateMaterializedViews (create + refresh).
  - Neither (the path serve takes) → CreateMaterializedViewsIfNotExist only (first-run creation, no refresh). migrateCmd suppresses the SetMatviewOnStartup(true) call when --skip-views is set so the two flags don't fight each other.

Tests (3 source-contract, all GREEN; whole suite GREEN):
  - cmd/aveloxis/migrate_skip_views_test.go — flag registered AND SetMatviewSkip called.
  - internal/db/migrate_skip_views_test.go — RunMigrations consults the field; setter is public.