### PR TITLE
migration safety / speed

### DIFF
--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -932,6 +932,7 @@ func runRecollect(cfgPath string, targets []string) error {
 
 func migrateCmd(cfgPath *string) *cobra.Command {
 	var skipViews bool
+	var noWait bool
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Run database schema migrations",
@@ -942,13 +943,19 @@ Use --skip-views to skip the materialized view block entirely. This is
 useful when you're iterating on a schema-error fix on a large database
 where the matview rebuild adds significant time per attempt — run a
 plain ` + "`aveloxis refresh-views`" + ` (or wait for the next scheduler
-tick) once the schema errors are resolved.`,
+tick) once the schema errors are resolved.
+
+Use --no-wait to fail fast if another aveloxis migration is already in
+progress (rather than blocking on the advisory lock until the holder
+releases). Useful in CI and ` + "`aveloxis stop all && aveloxis start all`" + `
+flows where you want a clear error if a stale process is still
+running migrations.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 			cfg := loadConfig(*cfgPath, bootLog)
 			logger := newLogger(cfg)
 			ctx := context.Background()
-			store, err := db.NewPostgresStore(ctx, cfg.Database.ConnectionString(), logger)
+			store, err := db.NewPostgresStore(ctx, cfg.Database.ConnectionStringWithAppName("aveloxis-migrate"), logger)
 			if err != nil {
 				return err
 			}
@@ -959,11 +966,14 @@ tick) once the schema errors are resolved.`,
 			if !skipViews {
 				store.SetMatviewOnStartup(true)
 			}
+			store.SetMigrateNoWait(noWait)
 			return store.Migrate(ctx)
 		},
 	}
 	cmd.Flags().BoolVar(&skipViews, "skip-views", false,
 		"skip materialized view creation/refresh (run `aveloxis refresh-views` separately when ready)")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false,
+		"fail fast if another aveloxis migration is in progress (don't block on the advisory lock)")
 	return cmd
 }
 

--- a/internal/db/gh_login_index_test.go
+++ b/internal/db/gh_login_index_test.go
@@ -43,27 +43,28 @@ func TestMigrationCreatesGhLoginIndex(t *testing.T) {
 			"writers were removed and this cost surfaced.")
 	}
 
-	// Pin that the index creation goes through execMigrationStep —
-	// per the v0.19.4 fail-closed contract, every schema-changing
-	// statement in RunMigrations must log+collect errors so a
-	// permission failure surfaces instead of being swallowed.
+	// Pin that the index creation goes through one of the
+	// error-collecting helpers (execMigrationStep OR
+	// execCreateIndexConcurrently — v0.20.1 swapped to the latter
+	// for CONCURRENTLY support). Both helpers honor the v0.19.4
+	// fail-closed contract: log at ERROR + append to the errs
+	// collector + cause RunMigrations to return a non-nil error.
 	idxPos := strings.Index(src, "idx_contributors_gh_login")
 	if idxPos < 0 {
 		return
 	}
-	// Look back ~600 chars for the call wrapper. execMigrationStep
-	// is on the line above the inline SQL string most of the time.
 	lookback := idxPos - 600
 	if lookback < 0 {
 		lookback = 0
 	}
 	preceding := src[lookback:idxPos]
-	if !strings.Contains(preceding, "execMigrationStep") {
+	if !strings.Contains(preceding, "execMigrationStep") &&
+		!strings.Contains(preceding, "execCreateIndexConcurrently") {
 		t.Error("idx_contributors_gh_login creation must be wrapped in " +
-			"execMigrationStep so a permission failure (e.g., role lacking " +
-			"CREATE on the schema) surfaces as a fatal migration error " +
-			"per the v0.19.4 fail-closed contract instead of being " +
-			"silently swallowed.")
+			"execMigrationStep OR execCreateIndexConcurrently so a " +
+			"permission failure (e.g., role lacking CREATE on the schema) " +
+			"surfaces as a fatal migration error per the v0.19.4 " +
+			"fail-closed contract instead of being silently swallowed.")
 	}
 
 	// Pin partial-index condition. Without WHERE gh_login != '' the

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -28,6 +28,56 @@ var schemaSQL string
 func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) error {
 	logger.Info("running schema migrations")
 
+	// v0.20.1: acquire a postgres advisory lock so two `aveloxis
+	// migrate` processes (or migrate + serve's startup-migrate) can't
+	// race on table-level locks. The lock is held on a dedicated pool
+	// connection for the entire migration; released via defer.
+	//
+	// Without this, two concurrent migrations contend on schema-level
+	// locks and produce the kind of confusion the 2026-05-08 incident
+	// surfaced (orphan UPDATE blocking a CREATE INDEX, with no clean
+	// way to tell which migrate is doing what).
+	lockConn, err := pg.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire migration advisory-lock connection: %w", err)
+	}
+	defer lockConn.Release()
+
+	if pg.migrateNoWait {
+		var ok bool
+		if err := lockConn.QueryRow(ctx,
+			`SELECT pg_try_advisory_lock($1)`, MigrateAdvisoryLockID).Scan(&ok); err != nil {
+			return fmt.Errorf("try advisory lock: %w", err)
+		}
+		if !ok {
+			return fmt.Errorf("another aveloxis migration is in progress (advisory lock held); use without --no-wait to wait, or check pg_stat_activity for the holder")
+		}
+	} else {
+		// Blocking acquire. Log if it takes more than 5 seconds so
+		// the operator knows we're waiting on someone else.
+		acquireDone := make(chan struct{})
+		go func() {
+			t := time.NewTimer(5 * time.Second)
+			defer t.Stop()
+			select {
+			case <-acquireDone:
+			case <-t.C:
+				logger.Info("waiting for migration advisory lock — another aveloxis migration is in progress")
+			}
+		}()
+		if _, err := lockConn.Exec(ctx, `SELECT pg_advisory_lock($1)`, MigrateAdvisoryLockID); err != nil {
+			close(acquireDone)
+			return fmt.Errorf("acquire advisory lock: %w", err)
+		}
+		close(acquireDone)
+	}
+	defer func() {
+		// Best-effort release. If this fails, the lock release happens
+		// on connection close (lockConn.Release returns to pool, where
+		// pgxpool's reset handlers eventually close idle connections).
+		_, _ = lockConn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, MigrateAdvisoryLockID)
+	}()
+
 	// errs collects every schema-integrity failure across the run. We
 	// fail closed: serve refuses to start when this slice is non-empty
 	// at the end, even if individual steps wrote successfully.
@@ -141,15 +191,17 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 			"error", err,
 			"hint", "the extension requires superuser or membership in pg_create_extensions; check your role grants")
 	} else {
-		execMigrationStep(ctx, pg, logger, &errs, "create idx_repos_owner_name_trgm GIN index",
-			`CREATE INDEX IF NOT EXISTS idx_repos_owner_name_trgm
+		execCreateIndexConcurrently(ctx, pg, logger, &errs,
+			"aveloxis_data", "idx_repos_owner_name_trgm",
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_owner_name_trgm
 				ON aveloxis_data.repos
 				USING GIN ((repo_owner || '/' || repo_name) gin_trgm_ops)`)
 	}
 
 	// pull_request_repo: add unique constraint for ON CONFLICT support (v0.12.0).
-	execMigrationStep(ctx, pg, logger, &errs, "create idx_pr_repo_meta_head_base",
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_repo_meta_head_base
+	execCreateIndexConcurrently(ctx, pg, logger, &errs,
+		"aveloxis_data", "idx_pr_repo_meta_head_base",
+		`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_pr_repo_meta_head_base
 		ON aveloxis_data.pull_request_repo (pr_repo_meta_id, pr_repo_head_or_base)`)
 
 	// contributors.gh_login partial index (v0.19.9). The 2026-05-08
@@ -164,8 +216,9 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// contributors table, producing 2:30-minute UPDATE durations.
 	// Partial — `WHERE gh_login != ''` excludes the email-only
 	// contributor cohort, mirroring the idx_contributors_login pattern.
-	execMigrationStep(ctx, pg, logger, &errs, "create idx_contributors_gh_login",
-		`CREATE INDEX IF NOT EXISTS idx_contributors_gh_login
+	execCreateIndexConcurrently(ctx, pg, logger, &errs,
+		"aveloxis_data", "idx_contributors_gh_login",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_gh_login
 		ON aveloxis_data.contributors (gh_login) WHERE gh_login != ''`)
 
 	// collection_queue.last_commits backfill (v0.19.11). Pre-v0.19.11
@@ -273,6 +326,53 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 
 	logger.Info("schema migrations complete", "schema_version", ToolVersion)
 	return nil
+}
+
+// MigrateAdvisoryLockID is the postgres advisory-lock id used by
+// RunMigrations to coordinate with concurrent migrate processes (and
+// `aveloxis serve`'s startup migrate). Stable constant — chosen once
+// in v0.20.1, must not change across versions or different aveloxis
+// instances pointing at the same DB will fail to coordinate.
+//
+// Value chosen as ASCII "AVELOXIS" packed into 64 bits (just memorable;
+// any stable int64 would do).
+const MigrateAdvisoryLockID int64 = 0x4156454C4F584953
+
+// execCreateIndexConcurrently wraps a CREATE INDEX CONCURRENTLY
+// statement with self-healing INVALID-index cleanup. CONCURRENTLY's
+// failure mode (interrupt mid-build, network blip, OOM) leaves an
+// INVALID index — `CREATE INDEX CONCURRENTLY IF NOT EXISTS` then
+// fails with "relation already exists" forever. This helper detects
+// the INVALID index via pg_index.indisvalid = false and DROPs it
+// before retrying the create, so operators don't have to manually
+// intervene.
+//
+// The schema and indexName are passed separately (rather than parsing
+// from the SQL) because the helper needs them for the indisvalid
+// query.
+func execCreateIndexConcurrently(ctx context.Context, pg *PostgresStore, logger *slog.Logger, errs *[]error, schema, indexName, sql string) {
+	var isInvalid bool
+	err := pg.pool.QueryRow(ctx, `
+		SELECT NOT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1 AND c.relname = $2`,
+		schema, indexName).Scan(&isInvalid)
+	if err == nil && isInvalid {
+		logger.Warn("dropping invalid index from prior interrupted CONCURRENT build",
+			"index", schema+"."+indexName)
+		if _, derr := pg.pool.Exec(ctx, fmt.Sprintf(`DROP INDEX IF EXISTS %s.%s`, schema, indexName)); derr != nil {
+			logger.Error("schema migration error", "step", "drop invalid "+indexName, "error", derr)
+			*errs = append(*errs, fmt.Errorf("drop invalid %s: %w", indexName, derr))
+			return
+		}
+	}
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		label := "create index " + indexName
+		logger.Error("schema migration error", "step", label, "error", err)
+		*errs = append(*errs, fmt.Errorf("%s: %w", label, err))
+	}
 }
 
 // watchBlockers periodically polls pg_stat_activity for aveloxis
@@ -530,9 +630,24 @@ func deduplicateCommits(ctx context.Context, pg *PostgresStore, logger *slog.Log
 		logger.Info("deduplicated commits", "rows_removed", tag.RowsAffected())
 	}
 
-	// Create the unique index now that duplicates are gone.
+	// Create the unique index now that duplicates are gone. v0.20.1
+	// uses CONCURRENTLY so the index build doesn't ShareLock the
+	// commits table while the scheduler is running. deduplicateCommits
+	// itself is warn-only (this isn't through the err-collector), so
+	// keep that behavior here too.
+	var existsInvalid bool
+	pg.pool.QueryRow(ctx, `
+		SELECT NOT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'aveloxis_data' AND c.relname = 'idx_commits_repo_hash_file'`).Scan(&existsInvalid)
+	if existsInvalid {
+		logger.Warn("dropping invalid idx_commits_repo_hash_file from prior interrupted CONCURRENT build")
+		pg.pool.Exec(ctx, `DROP INDEX IF EXISTS aveloxis_data.idx_commits_repo_hash_file`)
+	}
 	_, err := pg.pool.Exec(ctx, `
-		CREATE UNIQUE INDEX IF NOT EXISTS idx_commits_repo_hash_file
+		CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_commits_repo_hash_file
 		ON aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename)`)
 	if err != nil {
 		logger.Warn("failed to create commits unique index", "error", err)

--- a/internal/db/migrate_concurrently_test.go
+++ b/internal/db/migrate_concurrently_test.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMigrationsUseCreateIndexConcurrently pins that all four index
+// migrations use `CREATE INDEX CONCURRENTLY` rather than locking
+// `CREATE INDEX`. v0.20.1 makes index creation safe to run alongside
+// active collection workers — the pre-v0.20.1 ShareLock-on-table
+// pattern (caught on 2026-05-08 when the new serve's startup migrate
+// was blocked behind a 14-minute UPDATE) goes away.
+//
+// CONCURRENTLY doubles wall-clock build time on a single index but
+// avoids blocking writes on the target table. Tradeoff is right for
+// production fleets where serve is frequently in motion.
+func TestMigrationsUseCreateIndexConcurrently(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Each of these index names corresponds to a CREATE INDEX site
+	// that must be CONCURRENTLY by v0.20.1.
+	for _, indexName := range []string{
+		"idx_repos_owner_name_trgm",
+		"idx_pr_repo_meta_head_base",
+		"idx_contributors_gh_login",
+		"idx_commits_repo_hash_file",
+	} {
+		// Find the line(s) referencing this index in a CREATE statement.
+		// Look for the substring `CREATE ... INDEX ... <name>` and assert
+		// CONCURRENTLY appears in the same statement.
+		idx := 0
+		found := false
+		for {
+			pos := strings.Index(src[idx:], indexName)
+			if pos < 0 {
+				break
+			}
+			absolute := idx + pos
+			// Check ~120 chars before and after for a CREATE INDEX
+			// statement context.
+			start := absolute - 120
+			if start < 0 {
+				start = 0
+			}
+			end := absolute + 120
+			if end > len(src) {
+				end = len(src)
+			}
+			window := src[start:end]
+			if strings.Contains(window, "CREATE") && strings.Contains(window, "INDEX") &&
+				strings.Contains(window, "CONCURRENTLY") {
+				found = true
+				break
+			}
+			idx = absolute + len(indexName)
+		}
+		if !found {
+			t.Errorf("migrate.go's CREATE INDEX statement for %q must use "+
+				"CONCURRENTLY so the index build doesn't ShareLock the "+
+				"target table while collection workers are mid-INSERT. "+
+				"Without this, running migrate concurrent with serve "+
+				"can block writes for the full index-build duration.",
+				indexName)
+		}
+	}
+}
+
+// TestExecCreateIndexConcurrentlyHelperExists pins the new helper that
+// wraps `CREATE INDEX CONCURRENTLY` with a self-healing INVALID-index
+// cleanup. CONCURRENTLY's failure mode is a leftover INVALID index;
+// the helper detects and drops it before retrying. Without this,
+// operators have to manually `DROP INDEX` after every interrupted
+// migration.
+func TestExecCreateIndexConcurrentlyHelperExists(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	if !strings.Contains(src, "execCreateIndexConcurrently") {
+		t.Error("migrate.go must define execCreateIndexConcurrently helper " +
+			"that wraps CREATE INDEX CONCURRENTLY with self-healing " +
+			"INVALID-index cleanup. Operators shouldn't need to manually " +
+			"DROP INDEX after an interrupted migration.")
+	}
+	if !strings.Contains(src, "indisvalid") {
+		t.Error("the helper must check pg_index.indisvalid = false to " +
+			"detect INVALID indexes left over from interrupted CONCURRENT " +
+			"builds.")
+	}
+}
+
+// TestRunMigrationsAcquiresAdvisoryLock pins the v0.20.1 advisory-lock
+// coordination. Two `aveloxis migrate` processes (or migrate +
+// startup-migrate from `aveloxis serve`) racing on the same DB used
+// to contend on table-level locks (see the 2026-05-08 incident).
+// With the advisory lock, the second process blocks until the first
+// completes — politely, with a clear log line — then proceeds.
+func TestRunMigrationsAcquiresAdvisoryLock(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	if !strings.Contains(src, "pg_advisory_lock") && !strings.Contains(src, "pg_try_advisory_lock") {
+		t.Error("RunMigrations must acquire a pg_advisory_lock at the " +
+			"start of the migration run, so concurrent migrate / serve-" +
+			"startup-migrate processes coordinate gracefully instead of " +
+			"contending on table-level locks.")
+	}
+	if !strings.Contains(src, "pg_advisory_unlock") {
+		t.Error("RunMigrations must release the advisory lock at the end " +
+			"of the migration run (typically via defer).")
+	}
+	// Pin a stable lock-id constant — bare integers in code without a
+	// named constant make it hard to coordinate across deploys.
+	if !strings.Contains(src, "MigrateAdvisoryLockID") {
+		t.Error("migrate.go should define a named constant " +
+			"MigrateAdvisoryLockID for the lock id, so it stays stable " +
+			"across versions and is easy to find/change.")
+	}
+}
+
+// TestMigrateCmdHasNoWaitFlag pins the operator-facing flag that
+// turns the blocking advisory-lock acquire into a try-acquire that
+// fails fast.
+func TestMigrateCmdHasNoWaitFlag(t *testing.T) {
+	data, err := os.ReadFile("../../cmd/aveloxis/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, `"no-wait"`) {
+		t.Error("migrateCmd must register a --no-wait flag so operators " +
+			"can fail fast when another migration is in progress, instead " +
+			"of blocking indefinitely on the advisory lock.")
+	}
+	if !strings.Contains(src, "SetMigrateNoWait") {
+		t.Error("migrateCmd must call store.SetMigrateNoWait(noWait) " +
+			"to forward the flag into RunMigrations.")
+	}
+}
+
+// TestPostgresStoreHasSetMigrateNoWait pins the public setter that
+// migrateCmd calls to forward the --no-wait flag.
+func TestPostgresStoreHasSetMigrateNoWait(t *testing.T) {
+	data, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "func (s *PostgresStore) SetMigrateNoWait(") {
+		t.Error("PostgresStore must define SetMigrateNoWait(bool) so the " +
+			"--no-wait flag flows from migrateCmd into RunMigrations' " +
+			"advisory-lock acquisition path.")
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -23,6 +23,7 @@ type PostgresStore struct {
 	logger           *slog.Logger
 	matviewOnStartup bool // whether to refresh materialized views during migration
 	matviewSkip      bool // whether to skip the matview block entirely (--skip-views on migrate)
+	migrateNoWait    bool // whether to fail fast on advisory-lock contention (--no-wait on migrate)
 }
 
 // NewPostgresStore connects to PostgreSQL and returns a Store.
@@ -158,6 +159,16 @@ func (s *PostgresStore) SetMatviewOnStartup(enabled bool) {
 // are set — skip is the stronger signal.
 func (s *PostgresStore) SetMatviewSkip(skip bool) {
 	s.matviewSkip = skip
+}
+
+// SetMigrateNoWait controls how RunMigrations handles advisory-lock
+// contention with another in-flight migration (or serve's startup
+// migrate). When false (default), the advisory-lock acquire blocks
+// until the holder releases. When true, RunMigrations fails fast with
+// a clear error if the lock is held. Set by `aveloxis migrate
+// --no-wait`.
+func (s *PostgresStore) SetMigrateNoWait(noWait bool) {
+	s.migrateNoWait = noWait
 }
 
 func (s *PostgresStore) Migrate(ctx context.Context) error {

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -3,4 +3,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.20.0"
+var ToolVersion = "0.20.1"


### PR DESCRIPTION
REATE INDEX CONCURRENTLY everywhere:                                                                                         
  - All four index migrations now use CONCURRENTLY: idx_repos_owner_name_trgm, idx_pr_repo_meta_head_base, idx_contributors_gh_login,  idx_commits_repo_hash_file                                                                                                             
  - New helper execCreateIndexConcurrently(ctx, pg, logger, errs, schema, indexName, sql) self-heals leftover INVALID indexes from interrupted prior builds via pg_index.indisvalid check + DROP INDEX IF EXISTS before retrying                                          
  - Honors the v0.19.4 fail-closed contract through the same errs collector                                                              
   
  Item 5 — Advisory-lock coordination:                                                                                                   
  - New MigrateAdvisoryLockID = 0x4156454C4F584953 ("AVELOXIS" packed) — stable across versions
  - RunMigrations acquires the lock on a dedicated lockConn from the pool, releases on defer                                             
  - Blocking acquire by default; logs "waiting for migration advisory lock" if the wait exceeds 5 seconds
  - --no-wait flag turns it into pg_try_advisory_lock for fail-fast (CI / stop all && start all flows)                                   
  - migrateCmd now tags as aveloxis-migrate so the v0.20.0 blocker watcher catches it too — full integration with the v0.20.0 work       
                                                                                                                                         
  5 source-contract tests pin the architecture. Pre-existing v0.19.9 test (TestMigrationCreatesGhLoginIndex) updated to accept either execMigrationStep or execCreateIndexConcurrently since both honor the fail-closed contract. 