### PR TITLE
contributor breadth worker fix

### DIFF
--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -37,6 +37,9 @@
     "enrich_interval_minutes": 30,
     "search_resolve_interval_minutes": 60,
     "affiliation_interval_minutes": 60,
+    "breadth_interval_minutes": 15,
+    "breadth_batch_size": 2000,
+    "breadth_cooldown_days": 7,
     "shutdown_grace_seconds": 10
   },
   "web": {

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -166,6 +166,9 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		EnrichInterval:        cfg.Collection.EnrichIntervalDuration(),
 		SearchResolveInterval: cfg.Collection.SearchResolveIntervalDuration(),
 		AffiliationInterval:   cfg.Collection.AffiliationIntervalDuration(),
+		BreadthInterval:       cfg.Collection.BreadthIntervalDuration(),
+		BreadthBatchSize:      cfg.Collection.BreadthBatchSizeOrDefault(),
+		BreadthCooldown:       cfg.Collection.BreadthCooldownDuration(),
 		ShutdownGrace:         cfg.Collection.ShutdownGraceDuration(),
 	})
 	go sched.Run(ctx)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -69,6 +69,9 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "enrich_interval_minutes": 30,
     "search_resolve_interval_minutes": 60,
     "affiliation_interval_minutes": 60,
+    "breadth_interval_minutes": 15,
+    "breadth_batch_size": 2000,
+    "breadth_cooldown_days": 7,
     "shutdown_grace_seconds": 10
   },
   "web": {
@@ -160,6 +163,9 @@ Periodic tickers that run on the scheduler. v0.16.5 / v0.18.29 / v0.19.7 moved e
 | `collection.enrich_interval_minutes` | integer | `30` | Cadence (minutes) of the thin-contributor profile enrichment ticker. Each tick processes one batch of up to 14,000 thin contributors via `GET /users/{login}`. With 14K candidates and 73 keys, even 60 minutes is well under the rate budget. |
 | `collection.search_resolve_interval_minutes` | integer | `60` | Cadence (minutes) of the v0.19.2 search-resolve ticker. Each tick takes 100 contributors with email-but-no-`gh_user_id` and calls GitHub's search API to backfill the identity. GitHub search is rate-limited to 30/min/token (separate budget from the 5000/hour core API), so this runs at a deliberately low cadence. |
 | `collection.affiliation_interval_minutes` | integer | `60` | Cadence (minutes) of the v0.19.7 affiliation-population ticker. Recomputes the global domain→company map from `contributor_affiliations`. Pre-v0.19.7 this fired from every worker after every repo and caused `UNIQUE (ca_domain)` ShareLock contention. |
+| `collection.breadth_interval_minutes` | integer | `15` | Cadence (minutes) of the v0.20.17 contributor breadth ticker. Each tick calls `/users/{login}/events` for up to `breadth_batch_size` contributors past their cooldown window and stamps `contributors.cntrb_last_breadth_at`. Pre-v0.20.17 this was hardcoded to 6 hours / 100 batch / no cooldown — first-pass coverage of a 1.4M-contributor fleet would have taken 9.6 years. At 15-min interval × 2000 batch the new throughput targets ~192K contributors/day → first pass in ~7 days on a 1.4M fleet. |
+| `collection.breadth_batch_size` | integer | `2000` | Maximum contributors processed per breadth tick. Each contributor takes 1–3 API calls (most users have ≤300 recent events fitting in one page). |
+| `collection.breadth_cooldown_days` | integer | `7` | Minimum interval between successive breadth attempts on the same contributor. After this window the contributor becomes eligible again via the `cntrb_last_breadth_at IS NULL OR < NOW() - interval` filter. Steady-state load with a 7-day cooldown over 1.4M contributors is ~200K/day = 8K/hour ≈ 2% of the 365K/hr budget of a 73-key fleet. |
 
 **Shutdown**
 

--- a/internal/collector/breadth.go
+++ b/internal/collector/breadth.go
@@ -48,13 +48,27 @@ type BreadthResult struct {
 }
 
 // Run processes contributors that need breadth collection.
-// It prioritizes contributors that have never been processed (NULL data_collection_date
-// in contributor_repo), then those with the oldest collection dates.
-// limit controls how many contributors to process per run (0 = all).
-func (bw *BreadthWorker) Run(ctx context.Context, limit int) (*BreadthResult, error) {
+//
+// v0.20.17 changes:
+//   - Cooldown-driven selection. GetContributorsForBreadth now
+//     filters by cntrb_last_breadth_at; contributors past the
+//     cooldown window are eligible regardless of whether their
+//     prior attempt yielded events.
+//   - MarkBreadthAttempted is called after EVERY contributor
+//     attempt, success or zero-events. Without this, contributors
+//     with no public activity stayed at the head of the queue
+//     forever (observed: 225/1.4M coverage on the live fleet).
+//   - The 200ms inter-contributor sleep is removed. HTTPClient
+//     rate limiting already paces requests via X-RateLimit-Remaining
+//     and 429 backoff; the sleep capped throughput at 5/sec
+//     single-threaded against a 73-key 365K/hr budget.
+//
+// limit and cooldown are caller-supplied; the scheduler passes
+// the configured BreadthBatchSize and BreadthCooldownDuration.
+func (bw *BreadthWorker) Run(ctx context.Context, limit int, cooldown time.Duration) (*BreadthResult, error) {
 	result := &BreadthResult{}
 
-	contribs, err := bw.store.GetContributorsForBreadth(ctx, limit)
+	contribs, err := bw.store.GetContributorsForBreadth(ctx, limit, cooldown)
 	if err != nil {
 		return result, fmt.Errorf("querying contributors for breadth: %w", err)
 	}
@@ -71,6 +85,18 @@ func (bw *BreadthWorker) Run(ctx context.Context, limit int) (*BreadthResult, er
 		}
 
 		n, err := bw.processContributor(ctx, c)
+
+		// Stamp the attempt timestamp BEFORE error handling so
+		// even fetch failures register as "we tried." Otherwise
+		// a contributor whose API call always errors stays at
+		// the front of the queue forever — exactly the spinning-
+		// on-dead-ends pattern Pre-v0.20.17 had with zero-event
+		// contributors.
+		if markErr := bw.store.MarkBreadthAttempted(ctx, c.ID); markErr != nil {
+			bw.logger.Debug("breadth: failed to mark contributor attempted",
+				"login", c.Login, "error", markErr)
+		}
+
 		if err != nil {
 			bw.logger.Warn("breadth: failed to process contributor",
 				"login", c.Login, "error", err)
@@ -80,9 +106,6 @@ func (bw *BreadthWorker) Run(ctx context.Context, limit int) (*BreadthResult, er
 
 		result.ContributorsProcessed++
 		result.EventsInserted += n
-
-		// Small delay between contributors to be respectful.
-		time.Sleep(200 * time.Millisecond)
 	}
 
 	bw.logger.Info("contributor breadth complete",

--- a/internal/collector/breadth_unconditional_test.go
+++ b/internal/collector/breadth_unconditional_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.20.17: BreadthWorker.Run must call MarkBreadthAttempted on
+// each contributor regardless of whether processContributor
+// found any events. The 200ms inter-contributor sleep is removed
+// — rate limiting in the HTTPClient already paces requests, and
+// the sleep was capping throughput to 5/sec single-threaded
+// while the 73-key fleet has 365K/hr available.
+
+func TestBreadthWorkerMarksAttemptedUnconditionally(t *testing.T) {
+	data, err := os.ReadFile("breadth.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Find Run's body so we don't false-match elsewhere.
+	idx := strings.Index(src, "func (bw *BreadthWorker) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find BreadthWorker.Run")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of Run")
+	}
+	body := tail[:1+endRel]
+
+	if !strings.Contains(body, "MarkBreadthAttempted") {
+		t.Error("BreadthWorker.Run must call store.MarkBreadthAttempted after each contributor regardless of success. Pre-v0.20.17 a contributor with zero events left no signal that we'd tried, and the worker kept reselecting them — 225/1.4M coverage after weeks of running.")
+	}
+}
+
+func TestBreadthWorkerDropsInterContributorSleep(t *testing.T) {
+	data, err := os.ReadFile("breadth.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Locate Run's body again for the narrow check.
+	idx := strings.Index(src, "func (bw *BreadthWorker) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find BreadthWorker.Run")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of Run")
+	}
+	body := tail[:1+endRel]
+
+	if strings.Contains(body, "time.Sleep(200 * time.Millisecond)") ||
+		strings.Contains(body, `time.Sleep(200*time.Millisecond)`) {
+		t.Error("BreadthWorker.Run must NOT sleep 200ms between contributors. The HTTPClient handles rate limiting via X-RateLimit headers + 429 backoff; the artificial sleep capped throughput to 5/sec single-threaded against a 73-key 365K/hr budget.")
+	}
+}

--- a/internal/config/breadth_knobs_test.go
+++ b/internal/config/breadth_knobs_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.20.17: breadth_interval_minutes, breadth_batch_size,
+// breadth_cooldown_days are now configurable. Pre-fix these
+// were hardcoded to 6h / 100 / no-cooldown, which capped
+// throughput to 400 contributors/day = 9.6 years to cover a
+// 1.4M-contributor fleet once.
+
+func TestCollectionConfigHasBreadthKnobs(t *testing.T) {
+	data, err := os.ReadFile("config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	needles := []string{
+		`BreadthIntervalMinutes`,
+		`"breadth_interval_minutes"`,
+		`BreadthBatchSize`,
+		`"breadth_batch_size"`,
+		`BreadthCooldownDays`,
+		`"breadth_cooldown_days"`,
+	}
+	for _, n := range needles {
+		if !strings.Contains(src, n) {
+			t.Errorf("config.go missing breadth knob %q — pre-v0.20.17 the breadth worker was hardcoded to 6h cycles + 100 batch + no cooldown, giving 400 contributors/day = 9.6 years for one pass over 1.4M contributors", n)
+		}
+	}
+}
+
+// TestBreadthIntervalDurationFallback pins the fallback default
+// (matches the EnrichInterval / SearchResolveInterval pattern).
+// Operators with an older aveloxis.json missing the new keys
+// still get sensible behavior.
+func TestBreadthIntervalDurationFallback(t *testing.T) {
+	c := &CollectionConfig{}
+	// 15-minute default matches the new throughput target
+	// (2000 batch × 96 ticks/day = 192K contribs/day).
+	got := c.BreadthIntervalDuration()
+	wantMins := 15
+	if int(got.Minutes()) != wantMins {
+		t.Errorf("BreadthIntervalDuration() default = %v, want %d minutes — first-pass coverage on a 1.4M-contributor fleet needs throughput around %d/day, which the 15-minute default achieves with the 2000 batch default", got, wantMins, wantMins)
+	}
+}
+
+func TestBreadthBatchSizeDefault(t *testing.T) {
+	c := &CollectionConfig{}
+	got := c.BreadthBatchSizeOrDefault()
+	if got != 2000 {
+		t.Errorf("BreadthBatchSizeOrDefault() default = %d, want 2000", got)
+	}
+}
+
+func TestBreadthCooldownDurationFallback(t *testing.T) {
+	c := &CollectionConfig{}
+	got := c.BreadthCooldownDuration()
+	wantHours := 24 * 7
+	if int(got.Hours()) != wantHours {
+		t.Errorf("BreadthCooldownDuration() default = %v, want 7 days (168 hours)", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,30 @@ type CollectionConfig struct {
 	// the 30-day enrichment cooldown. Default 60 (minutes) when unset.
 	AffiliationIntervalMinutes int `json:"affiliation_interval_minutes"`
 
+	// BreadthIntervalMinutes controls how often the contributor
+	// breadth worker ticks. v0.20.17: pre-fix the ticker was
+	// hardcoded to 6 hours and batch=100, capping throughput to
+	// 400 contributors/day — 9.6 years to cover a 1.4M-contributor
+	// fleet once. Combined with BreadthBatchSize=2000 the new
+	// 15-minute default targets ~192K contributors/day, putting
+	// first-pass coverage of a 1.4M fleet at about 7 days.
+	BreadthIntervalMinutes int `json:"breadth_interval_minutes"`
+
+	// BreadthBatchSize is the maximum number of contributors the
+	// breadth worker processes per tick. v0.20.17 default 2000.
+	// Each contributor takes 1–3 API calls (most users have ≤300
+	// recent events fitting in one page) so 2000 × 3 = 6000 API
+	// calls/tick is well under the 73-key budget at typical
+	// scheduler intervals.
+	BreadthBatchSize int `json:"breadth_batch_size"`
+
+	// BreadthCooldownDays is the minimum interval between
+	// successive attempts on the same contributor. v0.20.17
+	// default 7. Steady-state load with this cooldown over 1.4M
+	// contributors is 200K/day = 8K/hour ≈ 2% of the 365K/hr
+	// budget for a 73-key fleet.
+	BreadthCooldownDays int `json:"breadth_cooldown_days"`
+
 	// ShutdownGraceSeconds caps how long Scheduler.Run's ctx-cancel
 	// branch waits for in-flight workers to finish before closing the
 	// pgx pool. Default 10 (seconds) when unset. Pre-v0.20.0 the wait
@@ -278,6 +302,34 @@ func (c *CollectionConfig) ShutdownGraceDuration() time.Duration {
 		return 10 * time.Second
 	}
 	return time.Duration(c.ShutdownGraceSeconds) * time.Second
+}
+
+// BreadthIntervalDuration converts BreadthIntervalMinutes to a
+// time.Duration. Falls back to 15 minutes when unset — see field
+// comment for the throughput math behind that default.
+func (c *CollectionConfig) BreadthIntervalDuration() time.Duration {
+	if c.BreadthIntervalMinutes <= 0 {
+		return 15 * time.Minute
+	}
+	return time.Duration(c.BreadthIntervalMinutes) * time.Minute
+}
+
+// BreadthBatchSizeOrDefault returns BreadthBatchSize or 2000 when
+// unset.
+func (c *CollectionConfig) BreadthBatchSizeOrDefault() int {
+	if c.BreadthBatchSize <= 0 {
+		return 2000
+	}
+	return c.BreadthBatchSize
+}
+
+// BreadthCooldownDuration converts BreadthCooldownDays to a
+// time.Duration. Falls back to 7 days when unset.
+func (c *CollectionConfig) BreadthCooldownDuration() time.Duration {
+	if c.BreadthCooldownDays <= 0 {
+		return 7 * 24 * time.Hour
+	}
+	return time.Duration(c.BreadthCooldownDays) * 24 * time.Hour
 }
 
 // MailConfig configures the Gmail-backed transactional mailer

--- a/internal/db/breadth_cooldown_test.go
+++ b/internal/db/breadth_cooldown_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.20.17: the contributor breadth worker pre-fix only marked a
+// contributor as "processed" by inserting rows into
+// contributor_repo. A contributor whose /users/{login}/events
+// returned zero events left contributor_repo empty for them
+// forever, and GetContributorsForBreadth's NULLS-FIRST ordering
+// kept selecting them on every cycle — the worker spun on
+// dead-end contributors and never reached the other 1.4M.
+//
+// The fix adds an unconditional per-contributor attempt timestamp
+// (cntrb_last_breadth_at) that mirrors the existing
+// cntrb_last_enriched_at / cntrb_last_search_attempted_at pattern.
+// MarkBreadthAttempted updates it after EVERY attempt regardless
+// of whether events were found, and GetContributorsForBreadth
+// filters by it with a configurable cooldown.
+
+func TestSchemaHasCntrbLastBreadthAtColumn(t *testing.T) {
+	data, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "cntrb_last_breadth_at") {
+		t.Error("schema.sql must declare cntrb_last_breadth_at on aveloxis_data.contributors — pre-v0.20.17 the breadth worker had no per-contributor 'I tried, found nothing' signal and reprocessed dead-end contributors forever")
+	}
+}
+
+func TestMigrateAddsCntrbLastBreadthAtColumn(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	needle := `addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_breadth_at"`
+	if !strings.Contains(string(data), needle) {
+		t.Errorf("migrate.go must call addColumnIfMissing for aveloxis_data.contributors.cntrb_last_breadth_at — operators upgrading from <v0.20.17 need the column added automatically")
+	}
+}
+
+func TestMarkBreadthAttemptedExists(t *testing.T) {
+	data, err := os.ReadFile("breadth_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "func (s *PostgresStore) MarkBreadthAttempted(") {
+		t.Error("MarkBreadthAttempted store method must exist — the worker calls this after EVERY contributor attempt regardless of whether events were found, so contributors with zero public events still exit the unprocessed-queue")
+	}
+}
+
+func TestGetContributorsForBreadthFiltersByCooldown(t *testing.T) {
+	data, err := os.ReadFile("breadth_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Locate GetContributorsForBreadth's body.
+	idx := strings.Index(src, "func (s *PostgresStore) GetContributorsForBreadth(")
+	if idx < 0 {
+		t.Fatal("cannot find GetContributorsForBreadth")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of GetContributorsForBreadth")
+	}
+	body := tail[:1+endRel]
+
+	if !strings.Contains(body, "cntrb_last_breadth_at") {
+		t.Error("GetContributorsForBreadth must filter by cntrb_last_breadth_at so the cooldown semantics actually exclude recently-attempted contributors. Pre-v0.20.17 the query JOINed contributor_repo, which left zero-event contributors permanently at the front of the queue.")
+	}
+	// The query must exclude rows whose attempt is within the
+	// cooldown window. Acceptable shapes: "IS NULL OR <" or
+	// "NOT EXISTS"/COALESCE patterns. Pin via the cooldown
+	// parameter being part of the SQL.
+	if !strings.Contains(body, "INTERVAL") && !strings.Contains(body, "interval") &&
+		!strings.Contains(body, "NOW() -") {
+		t.Error("GetContributorsForBreadth must use a time-window filter (INTERVAL or NOW() - ...) so contributors recently attempted are excluded from the next batch")
+	}
+}

--- a/internal/db/breadth_store.go
+++ b/internal/db/breadth_store.go
@@ -27,28 +27,42 @@ type ContributorRepoRow struct {
 	CreatedAt time.Time
 }
 
-// GetContributorsForBreadth returns contributors that need breadth collection,
-// prioritizing those that have never been processed, then oldest.
-func (s *PostgresStore) GetContributorsForBreadth(ctx context.Context, limit int) ([]BreadthContributor, error) {
+// GetContributorsForBreadth returns contributors that need breadth
+// collection, prioritizing those never attempted (NULL
+// cntrb_last_breadth_at) then those past the cooldown window.
+//
+// v0.20.17: replaces the pre-fix JOIN against contributor_repo's
+// MAX(data_collection_date). The old query treated a contributor
+// as "processed" only if at least one event row had been
+// inserted, so contributors whose /users/{login}/events returned
+// empty stayed at the head of the queue forever and the worker
+// reprocessed the same dead-end users every cycle. The new query
+// filters by cntrb_last_breadth_at — which MarkBreadthAttempted
+// stamps after EVERY attempt regardless of events found — so
+// every contributor exits the queue after one attempt and
+// re-enters only when the cooldown expires.
+//
+// Filter on cntrb_deleted = 0 (since v0.20.2 logical merges) so
+// soft-deleted loser rows aren't re-attempted on every cycle.
+// Filter on gh_login IS NOT NULL AND != ” since the breadth
+// worker hits the GitHub user events API.
+func (s *PostgresStore) GetContributorsForBreadth(ctx context.Context, limit int, cooldown time.Duration) ([]BreadthContributor, error) {
 	if limit <= 0 {
-		limit = 100
+		limit = 2000
 	}
-	// Use a subquery to avoid the DISTINCT + ORDER BY mismatch.
-	// PostgreSQL requires ORDER BY columns in the SELECT list with DISTINCT.
+	if cooldown <= 0 {
+		cooldown = 7 * 24 * time.Hour
+	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT cntrb_id, gh_login FROM (
-			SELECT DISTINCT ON (c.cntrb_id) c.cntrb_id::text, c.gh_login, cr.last_collected
-			FROM aveloxis_data.contributors c
-			LEFT JOIN (
-				SELECT cntrb_id, MAX(data_collection_date) AS last_collected
-				FROM aveloxis_data.contributor_repo
-				GROUP BY cntrb_id
-			) cr ON cr.cntrb_id = c.cntrb_id
-			WHERE c.gh_login IS NOT NULL AND c.gh_login != ''
-			ORDER BY c.cntrb_id, cr.last_collected ASC NULLS FIRST
-		) sub
-		ORDER BY last_collected ASC NULLS FIRST
-		LIMIT $1`, limit)
+		SELECT cntrb_id::text, gh_login
+		FROM aveloxis_data.contributors
+		WHERE gh_login IS NOT NULL
+		  AND gh_login != ''
+		  AND COALESCE(cntrb_deleted, 0) = 0
+		  AND (cntrb_last_breadth_at IS NULL
+		       OR cntrb_last_breadth_at < NOW() - $2::interval)
+		ORDER BY cntrb_last_breadth_at ASC NULLS FIRST
+		LIMIT $1`, limit, cooldown.String())
 	if err != nil {
 		return nil, err
 	}
@@ -63,6 +77,21 @@ func (s *PostgresStore) GetContributorsForBreadth(ctx context.Context, limit int
 		result = append(result, c)
 	}
 	return result, rows.Err()
+}
+
+// MarkBreadthAttempted stamps cntrb_last_breadth_at = NOW() for a
+// contributor. The breadth worker calls this AFTER every attempt
+// regardless of whether events were found. The unconditional
+// stamp is what makes the cooldown-based queue actually drain —
+// a contributor with zero public events still exits the
+// unprocessed-queue and won't reappear until the cooldown window
+// passes.
+func (s *PostgresStore) MarkBreadthAttempted(ctx context.Context, cntrbID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.contributors
+		SET cntrb_last_breadth_at = NOW()
+		WHERE cntrb_id = $1::uuid`, cntrbID)
+	return err
 }
 
 // GetNewestContributorRepoEvent returns the most recent event timestamp

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -164,6 +164,19 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// 30/min/token search-API quota.
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_search_attempted_at", "TIMESTAMPTZ")
 
+	// Contributors: breadth tracking column (v0.20.17). The
+	// scheduler's runBreadth ticker takes contributors past the
+	// configured cooldown, calls /users/{login}/events, and stamps
+	// this column on every attempt — even when the response is
+	// empty. Pre-v0.20.17 the worker used
+	// MAX(contributor_repo.data_collection_date) NULLS FIRST as
+	// the "processed" signal, which left contributors with zero
+	// public events permanently at the front of the queue. With
+	// 1.4M contributors observed on the live aveloxis_large
+	// fleet, only 225 (0.016%) ever got events recorded because
+	// the worker kept reselecting the same dead-end users.
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_breadth_at", "TIMESTAMPTZ")
+
 	// Commits: deduplicate and add unique index (added in v0.7.5).
 	// Previous versions had no ON CONFLICT on commits INSERT, so re-collection
 	// created duplicate rows. Clean up first, then create the unique index.

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -127,6 +127,7 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.contributors (
     gl_id          BIGINT,
     cntrb_created_at TIMESTAMPTZ,
     cntrb_last_enriched_at TIMESTAMPTZ,
+    cntrb_last_breadth_at  TIMESTAMPTZ,
     tool_source    TEXT DEFAULT 'aveloxis',
     tool_version   TEXT DEFAULT '',
     data_source    TEXT DEFAULT '',

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.20.16"
+var ToolVersion = "0.20.17"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -47,6 +47,9 @@ type Config struct {
 	SearchResolveInterval time.Duration // how often to run the search-resolve background task (default 1 hour). v0.19.2 added this to backfill gh_user_id on contributors with email but no platform identity, using GitHub's search API at controlled rate.
 	AffiliationInterval   time.Duration // how often to run the periodic singleton PopulateAffiliations task (default 1 hour). v0.19.7 moved this off the per-job hot path to eliminate cross-worker contention on UNIQUE (ca_domain).
 	ShutdownGrace         time.Duration // how long to wait for in-flight workers to finish during ctx-cancel before closing the pgx pool (default 10s). v0.20.0. Bounds shutdown wall-clock time so a single long UPDATE can't block stop indefinitely.
+	BreadthInterval       time.Duration // how often the contributor breadth worker ticks (default 15min). v0.20.17. Was hardcoded to 6h, capping coverage to 400/day = 9.6 years for 1.4M contribs.
+	BreadthBatchSize      int           // maximum contributors per breadth tick (default 2000). v0.20.17.
+	BreadthCooldown       time.Duration // minimum interval between successive attempts on the same contributor (default 7 days). v0.20.17. Replaces the pre-fix "spin on dead-end contributors forever" pattern.
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.
@@ -96,6 +99,15 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	}
 	if cfg.AffiliationInterval == 0 {
 		cfg.AffiliationInterval = 1 * time.Hour
+	}
+	if cfg.BreadthInterval == 0 {
+		cfg.BreadthInterval = 15 * time.Minute
+	}
+	if cfg.BreadthBatchSize == 0 {
+		cfg.BreadthBatchSize = 2000
+	}
+	if cfg.BreadthCooldown == 0 {
+		cfg.BreadthCooldown = 7 * 24 * time.Hour
 	}
 	if cfg.ShutdownGrace == 0 {
 		cfg.ShutdownGrace = 10 * time.Second
@@ -236,8 +248,14 @@ func (s *Scheduler) Run(ctx context.Context) {
 	// Run org refresh once on startup too.
 	go s.refreshOrgs(ctx)
 
-	// Contributor breadth: run every 6 hours to discover cross-repo activity.
-	breadthTicker := time.NewTicker(6 * time.Hour)
+	// Contributor breadth: discovers cross-repo activity for
+	// every contributor with a gh_login. v0.20.17: cadence and
+	// batch size are now config-driven (default 15min / 2000
+	// per tick / 7-day cooldown). The pre-fix hardcoded
+	// 6h/100/no-cooldown capped throughput to 400 contribs/day
+	// and left zero-event contributors stuck at the queue head
+	// forever.
+	breadthTicker := time.NewTicker(s.cfg.BreadthInterval)
 	defer breadthTicker.Stop()
 
 	// Materialized view rebuild: check hourly, run on Saturdays.
@@ -1572,7 +1590,7 @@ func (s *Scheduler) runBreadth(ctx context.Context) {
 		return
 	}
 	bw := collector.NewBreadthWorker(s.store, s.ghKeys, s.logger)
-	result, err := bw.Run(ctx, 100) // process up to 100 contributors per cycle
+	result, err := bw.Run(ctx, s.cfg.BreadthBatchSize, s.cfg.BreadthCooldown)
 	if err != nil {
 		s.logger.Warn("breadth worker failed", "error", err)
 		return


### PR DESCRIPTION
The two bugs

  1. Zero-event contributors stayed at queue head forever. processContributor only marked progress by inserting rows into contributor_repo. A contributor whose /users/{login}/events returned empty left the table empty for them, so MAX(data_collection_date) NULLS FIRST kept reselecting them on every cycle. The 225 you saw were almost certainly contributors who happened to yield events on their first attempt; everyone else was either never reached OR was a dead-end that the worker kept revisiting.

  2. Throughput cap. 6-hour ticker + 100 batch + 200ms inter-contributor sleep = 400 contributors/day = 9.6 years to cover 1.4M once.

The fix — mirror the v0.19.2 cooldown pattern

  - Schema: new cntrb_last_breadth_at TIMESTAMPTZ on aveloxis_data.contributors via addColumnIfMissing (joins the existing cntrb_last_enriched_at / cntrb_last_search_attempted_at family).
  - Store: new MarkBreadthAttempted(cntrbID) called unconditionally after every attempt — success, zero events, even fetch error. That's what makes the queue actually drain.
  - Store: GetContributorsForBreadth(limit, cooldown) filters cntrb_last_breadth_at IS NULL OR < NOW() - cooldown directly on the contributors table. One indexed scan, no JOIN.
  - Worker: drops the 200ms sleep, accepts the configured batch + cooldown.
  - Config: three new JSON knobs (defaults shown):
    - breadth_interval_minutes: 15 (was hardcoded to 360)
    - breadth_batch_size: 2000 (was hardcoded to 100)
    - breadth_cooldown_days: 7 (new concept)

Throughput at defaults

2000 × 96 ticks/day = 192K contributors/day. First-pass coverage of your 1.4M-contributor fleet in ~7 days. Steady-state load with the 7-day cooldown: ~200K/day = 8K/hour ≈ 2% of your 73-key 365K/hr budget. Modest enough to not impact main collection.