### PR TITLE
dealing with large bodied PRs and known GitHub API limitation using G…

### DIFF
--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.20.18"
+var ToolVersion = "0.20.20"

--- a/internal/platform/errors.go
+++ b/internal/platform/errors.go
@@ -154,8 +154,11 @@ func ClassifyError(err error) ErrorClass {
 		errors.Is(err, ErrForbidden),
 		errors.Is(err, ErrGone),
 		errors.Is(err, ErrNoContent),
+		errors.Is(err, ErrPaginationLimitExceeded),
 		errors.Is(err, ErrWrongEntityKind):
 		return ClassSkip
+	case errors.Is(err, ErrTransient):
+		return ClassTransient
 	case errors.Is(err, ErrAllKeysInvalidated):
 		return ClassAuth
 	}

--- a/internal/platform/github/graphql_pr_batch.go
+++ b/internal/platform/github/graphql_pr_batch.go
@@ -114,13 +114,40 @@ func (c *Client) fetchPRBatchWithSubdivide(ctx context.Context, owner, repo stri
 	}
 
 	if len(numbers) <= 1 {
-		// Already minimal — nothing left to subdivide. Bubble the
-		// error so the caller (and Fix A's outcome plumbing) records
-		// the failure cleanly.
-		c.logger.Warn("PR batch retry exhausted at size 1",
+		// Already minimal — subdivision can't go further.
+		//
+		// v0.20.20 (Fix L): before bubbling, fall back to a
+		// per-PR REST fetch. Production diagnostic on
+		// 2026-05-13 attributed the dominant 502-after-retries
+		// pattern to PRs with 60K+ character bodies tripping
+		// GitHub's GraphQL 10-second gateway timeout. The REST
+		// API streams list results sequentially and isn't
+		// subject to the same aggregation timeout, so the same
+		// PR fetched as 8 individual REST calls (PR + 7 child
+		// connections + comments) typically succeeds.
+		//
+		// Only fires when the original GraphQL error
+		// classified as ClassTransient/ClassRateLimit (the
+		// outer switch above already enforced that), so we're
+		// not throwing REST budget at fundamentally-broken
+		// queries.
+		c.logger.Warn("PR batch GraphQL exhausted at size 1 — falling back to REST",
 			"owner", owner, "repo", repo,
-			"pr_number", numbers[0], "error", err)
-		return nil, err
+			"pr_number", numbers[0], "graphql_error", err)
+		restBatch, restErr := c.fetchPRBatchOneREST(ctx, owner, repo, numbers)
+		if restErr == nil {
+			c.logger.Info("REST fallback succeeded for huge-body PR",
+				"owner", owner, "repo", repo, "pr_number", numbers[0])
+			return restBatch, nil
+		}
+		c.logger.Warn("REST fallback also failed for PR",
+			"owner", owner, "repo", repo,
+			"pr_number", numbers[0],
+			"rest_error", restErr, "original_graphql_error", err)
+		// Return whatever REST partial we got (may be empty),
+		// bubble the original GraphQL error so Fix A's
+		// outcome plumbing fires force_full_collect.
+		return restBatch, err
 	}
 
 	mid := len(numbers) / 2
@@ -146,6 +173,117 @@ func (c *Client) fetchPRBatchWithSubdivide(ctx context.Context, owner, repo stri
 	}
 	if rightErr != nil {
 		return out, rightErr
+	}
+	return out, nil
+}
+
+// fetchPRBatchOneREST is the v0.20.20 (Fix L) REST fallback
+// invoked by fetchPRBatchWithSubdivide at size 1 — i.e., when
+// the GraphQL path can't reduce the batch any further but the
+// single remaining PR still trips a transient classification
+// (typically 502 from GitHub's 10-second gateway timeout on
+// PRs with 60K+ character bodies).
+//
+// Composes the existing platform-level REST methods that
+// CLAUDE.md's "What stays forever" section explicitly
+// preserves for this purpose: FetchPRByNumber + the seven
+// child-list iterators + FetchPRMeta + FetchPRRepos +
+// ListCommentsForPR. The returned StagedPR has the same shape
+// as a successful GraphQL batch so the staging pipeline and
+// processor can't tell which path filled it in.
+//
+// ListCommentsForPR is the load-bearing extra: in
+// full-GraphQL mode (pr_child_mode=graphql AND
+// listing_mode=graphql) the collector's collectMessages
+// SKIPS the repo-wide /issues/comments REST iterator
+// entirely via the v0.18.5 fullGraphQLMode gate. The inline
+// comments delivered by the prNodeFragment.comments
+// connection are the only conversation-comment source. If the
+// REST fallback didn't fetch them per-PR, the rescued PR
+// would land with zero conversation comments. ListReviewComments
+// (inline diff comments) always runs from REST regardless of
+// mode, so those are already covered without an explicit call
+// here.
+func (c *Client) fetchPRBatchOneREST(ctx context.Context, owner, repo string, numbers []int) ([]StagedPR, error) {
+	out := make([]StagedPR, 0, len(numbers))
+	for _, num := range numbers {
+		pr, err := c.FetchPRByNumber(ctx, owner, repo, num)
+		if err != nil {
+			// On REST-side skip (404 — PR deleted between
+			// enumeration and now), drop the PR silently
+			// matching the GraphQL null-alias semantics in
+			// fetchPRBatchOne. On anything else (rate limit,
+			// transient, fatal), bubble.
+			class := platform.ClassifyError(err)
+			if class == platform.ClassSkip || class == platform.ClassNotModified {
+				continue
+			}
+			return out, fmt.Errorf("REST fallback PR #%d: %w", num, err)
+		}
+		envelope := StagedPR{PR: *pr}
+
+		// Children — each iterator is per-PR and bounded.
+		// On per-page error inside an iterator, the loop
+		// breaks (matches the gap-fill REST branch's existing
+		// pattern). Partial children are preferable to losing
+		// the whole rescued PR.
+		for label, lerr := range c.ListPRLabels(ctx, owner, repo, num) {
+			if lerr != nil {
+				break
+			}
+			envelope.Labels = append(envelope.Labels, label)
+		}
+		for assignee, aerr := range c.ListPRAssignees(ctx, owner, repo, num) {
+			if aerr != nil {
+				break
+			}
+			envelope.Assignees = append(envelope.Assignees, assignee)
+		}
+		for reviewer, rerr := range c.ListPRReviewers(ctx, owner, repo, num) {
+			if rerr != nil {
+				break
+			}
+			envelope.Reviewers = append(envelope.Reviewers, reviewer)
+		}
+		for review, rerr := range c.ListPRReviews(ctx, owner, repo, num) {
+			if rerr != nil {
+				break
+			}
+			envelope.Reviews = append(envelope.Reviews, review)
+		}
+		for commit, cerr := range c.ListPRCommits(ctx, owner, repo, num) {
+			if cerr != nil {
+				break
+			}
+			envelope.Commits = append(envelope.Commits, commit)
+		}
+		for file, ferr := range c.ListPRFiles(ctx, owner, repo, num) {
+			if ferr != nil {
+				break
+			}
+			envelope.Files = append(envelope.Files, file)
+		}
+		if head, base, merr := c.FetchPRMeta(ctx, owner, repo, num); merr == nil {
+			envelope.MetaHead = head
+			envelope.MetaBase = base
+		}
+		if headRepo, baseRepo, rerr := c.FetchPRRepos(ctx, owner, repo, num); rerr == nil {
+			envelope.RepoHead = headRepo
+			envelope.RepoBase = baseRepo
+		}
+
+		// Conversation comments — see function docstring for
+		// why this is required in full-GraphQL mode. The
+		// per-page error semantics match the children: break
+		// and keep what we have.
+		for cref, cerr := range c.ListCommentsForPR(ctx, owner, repo, num) {
+			if cerr != nil {
+				break
+			}
+			envelope.Comments = append(envelope.Comments, cref)
+		}
+
+		out = append(out, envelope)
 	}
 	return out, nil
 }

--- a/internal/platform/github/pr_rest_fallback_test.go
+++ b/internal/platform/github/pr_rest_fallback_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package github
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.20.20 (Fix L): when fetchPRBatchWithSubdivide narrows
+// down to a single PR that STILL fails with a transient
+// classification, fall back to a per-PR REST fetch instead of
+// bubbling. Production diagnostic on 2026-05-13 traced the
+// dominant failure pattern to PRs with 60K+ character bodies
+// — GitHub's GraphQL gateway has a strict 10-second internal
+// timeout, and assembling a tree with a massive body in
+// memory often exceeds it, returning HTTP 502. The REST API
+// streams list results sequentially and isn't subject to the
+// same aggregation timeout.
+//
+// Fallback granularity: only at size 1 (one PR). At that
+// point subdivision can go no further. The user-observed
+// pattern is that a single "expensive" PR in a 10-PR batch
+// trips the whole batch; subdivision isolates it; then REST
+// completes that one PR. Higher-size sub-batches keep using
+// GraphQL.
+
+func TestFetchPRBatchHasRESTFallbackHelper(t *testing.T) {
+	src, err := os.ReadFile("graphql_pr_batch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	// The fallback function name and the call site from
+	// fetchPRBatchWithSubdivide must both exist. We pin both
+	// so a future refactor can't silently break the size-1
+	// recovery path.
+	if !strings.Contains(body, "fetchPRBatchOneREST") {
+		t.Error("graphql_pr_batch.go must define fetchPRBatchOneREST — the REST-per-PR fallback that runs when GraphQL subdivision can't reduce further. Without it, single PRs with 60K+ character bodies will keep failing the GraphQL gateway's 10-second timeout indefinitely.")
+	}
+	// The subdivide function must invoke the fallback at
+	// size 1. Anchor on the function-definition line so we
+	// don't false-match earlier doc-comment references to
+	// the function name.
+	subdivIdx := strings.Index(body, "func (c *Client) fetchPRBatchWithSubdivide(")
+	if subdivIdx < 0 {
+		t.Fatal("fetchPRBatchWithSubdivide definition not found")
+	}
+	fnTail := body[subdivIdx:]
+	endRel := strings.Index(fnTail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of fetchPRBatchWithSubdivide")
+	}
+	fnBody := fnTail[:1+endRel]
+	if !strings.Contains(fnBody, "fetchPRBatchOneREST") {
+		t.Error("fetchPRBatchWithSubdivide must call fetchPRBatchOneREST at size 1 — this is the whole point of Fix L. Calling it elsewhere wastes REST budget; not calling it leaves single huge-body PRs unrecoverable.")
+	}
+}
+
+func TestFetchPRBatchRESTFallbackGatedOnSize1(t *testing.T) {
+	src, err := os.ReadFile("graphql_pr_batch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	// We don't want the REST fallback to fire mid-recursion
+	// (size > 1) — that would burn ~8 REST calls per PR for
+	// failures the subdivision should have handled itself.
+	// Pin via the requirement that the fallback call site sits
+	// inside an `if len(numbers) <= 1` (or equivalent) guard.
+	// Pull the body of fetchPRBatchWithSubdivide and verify
+	// the call to fetchPRBatchOneREST is positionally INSIDE
+	// the `if len(numbers) <= 1` block — i.e., the size
+	// guard appears textually before the call within the
+	// function. Anchoring on the function definition (not the
+	// first stray substring) so doc-comment mentions don't
+	// throw us off.
+	subdivIdx := strings.Index(body, "func (c *Client) fetchPRBatchWithSubdivide(")
+	if subdivIdx < 0 {
+		t.Skip("fetchPRBatchWithSubdivide not yet defined")
+	}
+	fnTail := body[subdivIdx:]
+	endRel := strings.Index(fnTail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of fetchPRBatchWithSubdivide")
+	}
+	fnBody := fnTail[:1+endRel]
+
+	callIdx := strings.Index(fnBody, "c.fetchPRBatchOneREST(")
+	if callIdx < 0 {
+		t.Skip("fetchPRBatchOneREST not yet called from fetchPRBatchWithSubdivide; helper-presence test covers this")
+	}
+	guardIdx := strings.Index(fnBody, "if len(numbers) <= 1")
+	if guardIdx < 0 || guardIdx >= callIdx {
+		t.Error("fetchPRBatchOneREST call must sit inside an `if len(numbers) <= 1` guard — the bigger-than-1 path is supposed to subdivide further, not burn REST budget. Reorder so the guard appears textually before the call.")
+	}
+}
+
+func TestFetchPRBatchRESTFallbackFetchesAllChildren(t *testing.T) {
+	src, err := os.ReadFile("graphql_pr_batch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	idx := strings.Index(body, "func (c *Client) fetchPRBatchOneREST(")
+	if idx < 0 {
+		t.Skip("fetchPRBatchOneREST not yet defined")
+	}
+	fnTail := body[idx:]
+	endRel := strings.Index(fnTail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of fetchPRBatchOneREST")
+	}
+	fnBody := fnTail[:1+endRel]
+
+	// The REST fallback must populate every StagedPR field
+	// that the GraphQL path populates, otherwise the resulting
+	// envelope is missing data downstream (labels, reviewers,
+	// review bodies, commits, files, head/base meta).
+	required := []string{
+		"FetchPRByNumber",
+		"ListPRLabels",
+		"ListPRAssignees",
+		"ListPRReviewers",
+		"ListPRReviews",
+		"ListPRCommits",
+		"ListPRFiles",
+		"FetchPRMeta",
+		"FetchPRRepos",
+		// Conversation comments: in full-GraphQL mode the
+		// collector's collectMessages SKIPS /issues/comments
+		// entirely, so the inline-via-GraphQL comments are
+		// the only conversation source. REST fallback must
+		// populate StagedPR.Comments so the data isn't lost.
+		"ListCommentsForPR",
+	}
+	for _, m := range required {
+		if !strings.Contains(fnBody, m) {
+			t.Errorf("fetchPRBatchOneREST must call %s to populate the same StagedPR fields the GraphQL path delivers. Without this, the REST-rescued PR would be missing children downstream.", m)
+		}
+	}
+}

--- a/internal/platform/graphql.go
+++ b/internal/platform/graphql.go
@@ -260,7 +260,15 @@ func (c *HTTPClient) GraphQL(ctx context.Context, query string, variables map[st
 		}
 	}
 
-	return fmt.Errorf("graphql: exhausted %d retries for %s", maxRetries, url)
+	// v0.20.19 (Fix J): wrap with ErrTransient so
+	// platform.ClassifyError returns ClassTransient. The
+	// v0.20.8 fetchPRBatchWithSubdivide path keys off this
+	// classification to halve the batch on transient errors;
+	// without the wrap, it falls through to ClassFatal and
+	// subdivision never fires. Production diagnostic on
+	// 2026-05-13 traced 6 of 7 stuck repos to exactly this
+	// missing classification.
+	return fmt.Errorf("graphql: exhausted %d retries for %s: %w", maxRetries, url, ErrTransient)
 }
 
 // parseGraphQLResponse decodes a GraphQL response body, populates dest

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -56,6 +56,38 @@ var ErrGone = errors.New("gone")
 // unique repos = ~5.3h of wasted wall-clock per cycle.
 var ErrNoContent = errors.New("no content (204)")
 
+// ErrTransient marks the "exhausted N retries" errors that
+// HTTPClient.Get and HTTPClient.GraphQL emit after their inner
+// retry loops give up. Added v0.20.19 (Fix J). Pre-fix these
+// errors were plain fmt.Errorf strings with no sentinel, so
+// platform.ClassifyError fell through to ClassFatal — making
+// the v0.20.8 sub-batch retry path (fetchPRBatchWithSubdivide
+// in internal/platform/github/graphql_pr_batch.go) bypass
+// subdivision entirely on the dominant production failure
+// mode. Production diagnostic on 2026-05-13: 6 of 7 stuck
+// repos had last_error starting with "graphql PR batch:
+// graphql: exhausted 10 retries for https://api.github.com/
+// graphql" and were looping indefinitely via v0.20.5's
+// force_full_collect path. With the sentinel, ClassifyError
+// returns ClassTransient and Fix C's subdivision actually
+// fires — halving the batch until it's small enough to fit
+// inside what GitHub will serve.
+var ErrTransient = errors.New("transient (retries exhausted)")
+
+// ErrPaginationLimitExceeded marks GitHub's hard cap on
+// certain endpoints' result count (notably /releases). Past
+// roughly 1000 results, GitHub returns HTTP 422 with body
+// "Only the first 1000 are available." Pre-v0.20.19 the
+// HTTPClient treated 422 as a fatal "unprocessable entity"
+// error and killed the entire collection job. Production
+// diagnostic on 2026-05-13: Azure/azure-sdk-for-java had
+// last_error = "releases: unprocessable entity:
+// .../releases?per_page=100&page=101" for this reason.
+// Classified as ClassSkip — same semantic as 304/204:
+// "no more data to fetch here." The paginator stops iterating
+// cleanly without bubbling an error.
+var ErrPaginationLimitExceeded = errors.New("pagination limit exceeded (GitHub serves at most 1000 results)")
+
 // maxRedirectHops caps how many 301/302/307/308 follows a single Get call
 // will perform before giving up. GitHub's best-practices guide says to
 // always follow redirects; this cap protects against pathological chains
@@ -353,11 +385,25 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 				"url", url, "status", 400, "body_snippet", truncateBody(string(body), 200))
 			return nil, fmt.Errorf("bad request: %s", url)
 		case resp.StatusCode == http.StatusUnprocessableEntity:
-			// 422 = validation failed. Also not retryable.
+			// 422 = validation failed. Not retryable for the same
+			// request shape. v0.20.19 (Fix K) carves out one
+			// subtype: GitHub's hard pagination cap (~1000
+			// results on /releases and similar) returns 422 with
+			// a body containing "Only the first 1000 are
+			// available" or "Only the first 1000 results are
+			// available." That's end-of-data, not a fatal
+			// validation problem — the paginator should stop
+			// cleanly via the ClassSkip path.
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
+			bodyStr := string(body)
+			if strings.Contains(bodyStr, "Only the first 1000") {
+				c.logger.Info("pagination limit reached (GitHub serves at most 1000 results)",
+					"url", url, "body_snippet", truncateBody(bodyStr, 200))
+				return nil, fmt.Errorf("%w: %s", ErrPaginationLimitExceeded, url)
+			}
 			c.logger.Warn("unprocessable entity (not retrying)",
-				"url", url, "status", 422, "body_snippet", truncateBody(string(body), 200))
+				"url", url, "status", 422, "body_snippet", truncateBody(bodyStr, 200))
 			return nil, fmt.Errorf("unprocessable entity: %s", url)
 		case resp.StatusCode == http.StatusForbidden:
 			// 403 can mean rate limit, secondary rate limit, or resource not
@@ -465,7 +511,12 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 		}
 	}
 
-	return nil, fmt.Errorf("exhausted %d retries for %s", maxRetries, url)
+	// v0.20.19 (Fix J): wrap with ErrTransient so
+	// platform.ClassifyError returns ClassTransient instead of
+	// ClassFatal. Callers can then make informed retry/skip
+	// decisions (e.g. fetchPRBatchWithSubdivide subdivides
+	// the batch on transient classifications).
+	return nil, fmt.Errorf("exhausted %d retries for %s: %w", maxRetries, url, ErrTransient)
 }
 
 // GetJSON performs a GET and decodes the response JSON into dest.
@@ -528,6 +579,15 @@ func paginate[T any](ctx context.Context, c *HTTPClient, path string, nextPage n
 				// to the caller, who would treat the error as a fatal
 				// "exhausted retries" equivalent.
 				if errors.Is(err, ErrNoContent) {
+					return
+				}
+				// v0.20.19 (Fix K): GitHub's hard 1000-result
+				// pagination cap on /releases and similar
+				// endpoints returns 422 with body "Only the
+				// first 1000 are available." End the iteration
+				// cleanly with whatever pages we've already
+				// yielded — no error surfaced to the caller.
+				if errors.Is(err, ErrPaginationLimitExceeded) {
 					return
 				}
 				var zero T

--- a/internal/platform/transient_retry_test.go
+++ b/internal/platform/transient_retry_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.20.19 (Fix J): the v0.20.8 sub-batch retry path in
+// github.Client.fetchPRBatchWithSubdivide is gated on
+// platform.ClassifyError(err) ∈ {ClassTransient, ClassRateLimit}.
+// Pre-v0.20.19, the retry-exhaustion errors emitted from
+// graphql.go:263 ("graphql: exhausted N retries for ...") and
+// httpclient.go:468 ("exhausted N retries for ...") were plain
+// fmt.Errorf strings with no sentinel — they classified as
+// ClassFatal, bypassing subdivision entirely. Production
+// diagnostic on 2026-05-13 showed 6/7 stuck repos had this
+// exact error and were never recovering.
+//
+// The fix: wrap both retry-exhaustion sites with %w against a
+// new ErrTransient sentinel. ClassifyError adds ErrTransient to
+// its ClassTransient arm. Now subdivision actually fires for
+// the dominant failure mode.
+
+func TestErrTransientExists(t *testing.T) {
+	if ErrTransient == nil {
+		t.Fatal("ErrTransient sentinel must exist for retry-exhaustion errors to classify as ClassTransient")
+	}
+	if ErrTransient.Error() == "" {
+		t.Error("ErrTransient must carry a non-empty message")
+	}
+}
+
+func TestRetryExhaustionWrapsErrTransient(t *testing.T) {
+	// Build a fmt.Errorf shaped like the production string.
+	// The wrapping must use %w against ErrTransient so
+	// errors.Is and errors.As work through the chain.
+	sample := fmt.Errorf("graphql: exhausted %d retries for %s: %w",
+		10, "https://api.github.com/graphql", ErrTransient)
+	if !errors.Is(sample, ErrTransient) {
+		t.Error("retry-exhaustion error must wrap ErrTransient via %w so errors.Is detects it through the wrapping chain that callers add (graphql PR batch: ..., gap fill PR batch: ..., pull requests graphql batch shard N: ...)")
+	}
+}
+
+func TestClassifyErrorClassifiesErrTransientAsTransient(t *testing.T) {
+	sample := fmt.Errorf("graphql: exhausted 10 retries: %w", ErrTransient)
+	got := ClassifyError(sample)
+	if got != ClassTransient {
+		t.Errorf("ClassifyError(retry-exhaustion wrapped in ErrTransient) = %v, want ClassTransient — this is what makes Fix C's fetchPRBatchWithSubdivide actually subdivide on the production failure mode", got)
+	}
+}
+
+// TestClassifyErrorClassifiesWrappedRetryExhaustion mirrors the
+// production wrapping chain: graphql.go's bare exhaustion error
+// is wrapped by FetchPRBatch, then by fillPRGaps, then by
+// collectPRsGraphQL/shard runner. The classifier must see
+// ClassTransient through all those layers.
+func TestClassifyErrorClassifiesWrappedRetryExhaustion(t *testing.T) {
+	inner := fmt.Errorf("graphql: exhausted 10 retries for https://api.github.com/graphql: %w", ErrTransient)
+	pr := fmt.Errorf("graphql PR batch: %w", inner)
+	shard := fmt.Errorf("pull requests graphql batch shard 7: %w", pr)
+	if got := ClassifyError(shard); got != ClassTransient {
+		t.Errorf("ClassifyError through the full wrapping chain = %v, want ClassTransient. Without this, the shard worker bubbles a Fatal error and Fix C's subdivision never runs.", got)
+	}
+}
+
+// TestGraphqlExhaustionWrapsTransient pins the graphql.go return
+// site. Source-contract test rather than runtime: invoking the
+// retry loop end-to-end requires a 10-attempt failing httptest
+// server, which is slow.
+func TestGraphqlExhaustionWrapsTransient(t *testing.T) {
+	// Defer to a separate package-level helper test that reads
+	// graphql.go and pins the `%w` against ErrTransient on the
+	// exhausted-retries return. Keeping the test here so it
+	// sits with its semantic siblings.
+	body, err := readPackageFile("graphql.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, `"graphql: exhausted %d retries for %s: %w"`) {
+		t.Error(`graphql.go must wrap the exhaustion error with ErrTransient via %w. Without this, ClassifyError returns ClassFatal for the most common production failure (502/504 bursts that exceed the retry budget) and Fix C's sub-batch retry never fires.`)
+	}
+	if !strings.Contains(body, "ErrTransient") {
+		t.Error("graphql.go must reference ErrTransient on the retry-exhaustion return so the wrap actually triggers classification as ClassTransient")
+	}
+}
+
+func TestHTTPClientExhaustionWrapsTransient(t *testing.T) {
+	body, err := readPackageFile("httpclient.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, `"exhausted %d retries for %s: %w"`) {
+		t.Error(`httpclient.go must wrap the REST retry-exhaustion error with ErrTransient via %w so REST callers (contributors, releases, events) that hit transient 5xx storms also subdivide-or-skip cleanly`)
+	}
+	if !strings.Contains(body, "ErrTransient") {
+		t.Error("httpclient.go must reference ErrTransient on the retry-exhaustion return")
+	}
+}
+
+// TestReleasesPaginationCapClassifiedAsSkip pins Fix K. GitHub
+// limits /releases pagination to the first 1000 results — past
+// that, it returns HTTP 422 with body "Only the first 1000 are
+// available". Pre-v0.20.19 this was treated as
+// "unprocessable entity (not retrying)" → ClassFatal, killing
+// the entire collection job. Production diagnostic on
+// 2026-05-13: Azure/azure-sdk-for-java was stuck on
+// `releases?per_page=100&page=101` for this reason.
+//
+// Fix: when 422 body mentions the 1000-result cap, return
+// ErrPaginationLimitExceeded (a ClassSkip sentinel) so the
+// paginator stops cleanly without failing the job.
+func TestPaginationLimitSentinelExists(t *testing.T) {
+	if ErrPaginationLimitExceeded == nil {
+		t.Fatal("ErrPaginationLimitExceeded sentinel must exist so GitHub's hard 1000-result pagination cap on /releases (and similar endpoints) stops being a job-killer")
+	}
+}
+
+func TestPaginationLimitClassifiesAsSkip(t *testing.T) {
+	wrapped := fmt.Errorf("releases page 101: %w", ErrPaginationLimitExceeded)
+	got := ClassifyError(wrapped)
+	if got != ClassSkip {
+		t.Errorf("ClassifyError(ErrPaginationLimitExceeded chain) = %v, want ClassSkip — exhausting GitHub's pagination cap is end-of-data, not a fatal error", got)
+	}
+}
+
+// readPackageFile reads a sibling file relative to the test's
+// package dir so source-contract checks can inspect retry-loop
+// implementations.
+func readPackageFile(name string) (string, error) {
+	data, err := os.ReadFile(name)
+	return string(data), err
+}


### PR DESCRIPTION
…raphQL

v0.20.20 shipped — Fix L

  Direct answer to your question

  Will REST fallback cause staging-order issues? No. Three reasons (full detail in CLAUDE.md's v0.20.20 entry):

  1. The processor reads staging by entity_type in a single batch — insertion order within a type doesn't matter.
  2. Both paths produce identical platform.StagedPR envelope shapes; the processor can't tell which path filled them in.
  3. fetchPRBatchWithSubdivide's recursive return preserves order — left half + right half appended in sequence. A REST-rescued PR slots into the same position in the
  batch.

  The one real subtlety: in full-GraphQL mode (pr_child_mode=graphql AND listing_mode=graphql, your config), collectMessages skips the repo-wide REST /issues/comments iterator. Inline conversation comments come from prNodeFragment.comments. If the REST fallback didn't also fetch comments for the rescued PR, those comments would never be collected — silent data loss. So the fallback explicitly calls ListCommentsForPR to populate StagedPR.Comments, keeping parity with the GraphQL inline path.
  Inline review comments (review_comments table) always come from REST regardless of mode, so those are already covered.

  What the fallback does

  When fetchPRBatchWithSubdivide recurses down to len(numbers) == 1 and the single PR still hits ClassTransient, the size-1 branch (which previously just logged "exhausted at size 1" and bubbled) now invokes new fetchPRBatchOneREST. That function composes:
  
| REST call | Populates |
|---|---|
| FetchPRByNumber | StagedPR.PR (with the huge body — REST streams it fine) |
| ListPRLabels | StagedPR.Labels |
| ListPRAssignees | StagedPR.Assignees |
| ListPRReviewers | StagedPR.Reviewers |
| ListPRReviews | StagedPR.Reviews |
| ListPRCommits | StagedPR.Commits |
| ListPRFiles | StagedPR.Files |
| FetchPRMeta | StagedPR.MetaHead/MetaBase |
| FetchPRRepos | StagedPR.RepoHead/RepoBase |
| ListCommentsForPR | StagedPR.Comments ← load-bearing in full-GraphQL mode |


Tests (3 new, all failed before implementation)

  internal/platform/github/pr_rest_fallback_test.go:
  - TestFetchPRBatchHasRESTFallbackHelper — pins both function existence and call-site wiring
  - TestFetchPRBatchRESTFallbackGatedOnSize1 — pins the if len(numbers) <= 1 guard sits textually before the call, preventing a future refactor that says "REST is safer, why not always use it"
  - TestFetchPRBatchRESTFallbackFetchesAllChildren — pins all 10 REST method calls so a future refactor can't silently drop one and lose data shape
