### PR TITLE
Factored scancode out of primary collection path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ aveloxis start serve
 
 Create `aveloxis.json` (or copy from `aveloxis.example.json`).
 
-**The canonical reference for every supported `aveloxis.json` field** lives at [`docs/getting-started/configuration.md`](./docs/getting-started/configuration.md) (also rendered at the ReadTheDocs site). That document has the full table — 6 top-level sections, 29 fields — including all the v0.18.x REST→GraphQL options (`pr_child_mode`, `listing_mode`, `threading_mode`, `shard_size`), the v0.18.29+ periodic-task cadence knobs (`enrich_interval_minutes`, `search_resolve_interval_minutes`, `affiliation_interval_minutes`), v0.20.0's `shutdown_grace_seconds`, and the v0.19.0 Gmail-SMTP `mail` block.
+**The canonical reference for every supported `aveloxis.json` field** lives at [`docs/getting-started/configuration.md`](./docs/getting-started/configuration.md) (also rendered at the ReadTheDocs site). That document has the full table — 6 top-level sections, 34 fields — including all the v0.18.x REST→GraphQL options (`pr_child_mode`, `listing_mode`, `threading_mode`, `shard_size`), the v0.18.29+ periodic-task cadence knobs (`enrich_interval_minutes`, `search_resolve_interval_minutes`, `affiliation_interval_minutes`), v0.20.0's `shutdown_grace_seconds`, v0.21.0's decoupled scancode worker (`scancode_workers`, `scancode_cadence_days`, `scancode_start_interval_s`, `scancode_clone_dir`, `scancode_shutdown_grace_minutes` — see [`docs/architecture/scancode.md`](./docs/architecture/scancode.md) for the design), and the v0.19.0 Gmail-SMTP `mail` block.
 
 A minimal example to get started; see `aveloxis.example.json` for an all-fields template and the doc above for the full reference:
 

--- a/aveloxis-shadow-graphql.json
+++ b/aveloxis-shadow-graphql.json
@@ -26,7 +26,12 @@
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "sharded",
-    "shard_size": 500
+    "shard_size": 500,
+    "scancode_workers": 2,
+    "scancode_start_interval_s": 90,
+    "scancode_cadence_days": 180,
+    "scancode_clone_dir": "/tmp/aveloxis-scancode-shadow",
+    "scancode_shutdown_grace_minutes": 30
   },
   "web": {
     "addr": ":9082",

--- a/aveloxis.docker.example.json
+++ b/aveloxis.docker.example.json
@@ -21,7 +21,12 @@
     "workers": 12,
     "repo_clone_dir": "/data",
     "matview_rebuild_day": "saturday",
-    "matview_rebuild_on_startup": false
+    "matview_rebuild_on_startup": false,
+    "scancode_workers": 2,
+    "scancode_start_interval_s": 90,
+    "scancode_cadence_days": 180,
+    "scancode_clone_dir": "/tmp/aveloxis-scancode",
+    "scancode_shutdown_grace_minutes": 30
   },
   "web": {
     "addr": ":8082",

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -39,7 +39,12 @@
     "breadth_interval_minutes": 15,
     "breadth_batch_size": 2000,
     "breadth_cooldown_days": 7,
-    "shutdown_grace_seconds": 10
+    "shutdown_grace_seconds": 10,
+    "scancode_workers": 2,
+    "scancode_start_interval_s": 90,
+    "scancode_cadence_days": 180,
+    "scancode_clone_dir": "/tmp/aveloxis-scancode",
+    "scancode_shutdown_grace_minutes": 30
   },
   "web": {
     "addr": ":8082",

--- a/aveloxis.sharded.example.json
+++ b/aveloxis.sharded.example.json
@@ -35,8 +35,13 @@
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "sharded",
-    "shard_size": 2000, 
-    "shutdown_grace_seconds": 40
+    "shard_size": 2000,
+    "shutdown_grace_seconds": 40,
+    "scancode_workers": 12,
+    "scancode_start_interval_s": 90,
+    "scancode_cadence_days": 180,
+    "scancode_clone_dir": "/tmp/aveloxis-scancode",
+    "scancode_shutdown_grace_minutes": 30
   },
   "web": {
     "addr": ":8082",

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -170,6 +170,13 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		BreadthBatchSize:      cfg.Collection.BreadthBatchSizeOrDefault(),
 		BreadthCooldown:       cfg.Collection.BreadthCooldownDuration(),
 		ShutdownGrace:         cfg.Collection.ShutdownGraceDuration(),
+		// v0.21.0 ScancodeWorker knobs. See
+		// docs/architecture/scancode.md.
+		ScancodeWorkers:       cfg.Collection.ScancodeWorkersOrDefault(),
+		ScancodeStartInterval: cfg.Collection.ScancodeStartInterval(),
+		ScancodeCadence:       cfg.Collection.ScancodeCadence(),
+		ScancodeCloneDir:      cfg.Collection.ScancodeCloneDirOrDefault(),
+		ScancodeShutdownGrace: cfg.Collection.ScancodeShutdownGrace(),
 	})
 	go sched.Run(ctx)
 

--- a/docs/architecture/scancode.md
+++ b/docs/architecture/scancode.md
@@ -1,0 +1,225 @@
+# ScanCode Worker (v0.21.0+)
+
+Per-file license + copyright + package detection is performed by ScanCode Toolkit ([aboutcode-org/scancode-toolkit](https://github.com/aboutcode-org/scancode-toolkit)) in a dedicated worker pool inside `aveloxis serve`, decoupled from the per-repo collection pipeline.
+
+This document covers the design and operation of that worker. Operator-facing tuning lives in [`docs/getting-started/configuration.md`](../getting-started/configuration.md#scancode-worker-v0210); this file explains *why* the system looks the way it does.
+
+## 1. What scancode does (and doesn't)
+
+Scancode walks a working-tree checkout of a repository and emits per-file findings:
+
+- License expression(s) detected — both raw and normalized SPDX.
+- Copyright statements and the holder names extracted from them.
+- Package manifests detected and their declared dependencies.
+- Detection metadata (line numbers, match percentage, etc.).
+
+Results land in `aveloxis_scan.scancode_scans` (one row per scan run) and `aveloxis_scan.scancode_file_results` (one row per file with at least one detection). Previous rows are rotated to `*_history` tables before each new scan.
+
+**Scancode does NOT generate SBOMs.** SPDX and CycloneDX SBOMs are produced by Phase 6 of the per-repo collection pipeline (`internal/collector/sbom.go`) and refreshed on every collection cycle. SBOM generation uses scancode's license data as enrichment when available, but the SBOM artifact itself is regenerated independently.
+
+## 2. Why the worker was decoupled (the 2026-05-14 incident)
+
+Pre-v0.21.0 scancode ran inline in `AnalysisCollector.AnalyzeRepo` as Phase 4 of the per-repo collection pipeline, gated by a package-level 2-slot semaphore in `internal/collector/scancode.go`.
+
+At fleet scale this shape doesn't work. On 2026-05-14, operator-side investigation of a 180-worker production fleet found 177 of 180 worker goroutines parked at `scancode.go:114` (the semaphore acquire) for 7+ hours. The two slot-holders were Linux-kernel-scale repos whose scans legitimately took hours; the other 177 worker goroutines were holding their `collection_queue` row locks the whole time, blocking other operations on those repos.
+
+This is the same architectural anti-pattern v0.19.7 fixed for `PopulateAffiliations`: doing work-that-doesn't-fit-the-per-job-budget inside per-job code paths inevitably stalls the worker pool at scale. The fix follows the same pattern — move the work to a dedicated periodic ticker / worker pool.
+
+The v0.21.0 worker:
+
+- Runs in goroutines independent of the main collection pool. A slow scancode run can't park collection workers.
+- Has its own concurrency cap (`collection.scancode_workers`, default 2) so operators can dial it independently of the collection worker count.
+- Re-clones each repo (`git clone --depth 1`) instead of sharing the facade's bare clone, eliminating cross-worker filesystem-lock hazards.
+- Defaults to a 6-month cadence (was 30 days inline) because per-file license headers in source code change rarely on that timescale.
+
+## 3. Architecture
+
+### 3.1 Components
+
+```
+                              aveloxis_data.repos
+                              ├── scancode_last_run
+                              ├── scancode_version
+                              ├── scancode_locked_at
+                              ├── scancode_locked_pid
+                              ├── scancode_locked_boot_id
+                              └── scancode_output_path
+                                       ▲
+                                       │
+              ┌────────────────────────┼───────────────────────┐
+              │                        │                       │
+              ▼                        ▼                       ▼
+       claim query              record lock state      mark complete /
+   (FOR UPDATE SKIP LOCKED)     (after cmd.Start)        clear lock
+              │                        │                       ▲
+              │                        │                       │
+              ▼                        ▼                       │
+        ┌───────────┐             ┌─────────┐             ┌────────┐
+        │dispatcher │──jobs chan─▶│ runner  │──exec──────▶│scancode│
+        │ (90s tic) │             │  pool   │             │  proc  │
+        └───────────┘             │ (N=2)   │             └────────┘
+                                  └─────────┘
+              ▲
+              │
+              │ on Run() startup
+        ┌─────────────┐
+        │ recover     │  reads ListLockedScancodeRows,
+        │ Orphans     │  applies 4-state decision (§5)
+        └─────────────┘
+```
+
+### 3.2 The lifecycle of a single scan
+
+1. **Dispatcher tick** (every `scancode_start_interval_s`, default 90s): the dispatcher calls `ClaimNextScancodeRepo(ctx, cadence)`. The SQL uses `FOR UPDATE SKIP LOCKED` against `aveloxis_data.repos` filtered by:
+   - `collection_queue.last_collected IS NOT NULL` — the repo has been collected at least once. Newly-added repos collect basic metrics first; scancode runs against them only after the first collection completes.
+   - `repo_archived = FALSE` (or NULL).
+   - `scancode_last_run IS NULL OR < NOW() - cadence` — cadence gate.
+   - `scancode_locked_at IS NULL OR < NOW() - 12h` — stale-lock fallback (the silent-corpse safety net; the explicit `recoverOrphans` pass is the primary recovery path).
+2. **Lock acquired**: the same SQL statement sets `scancode_locked_at = NOW()` on the candidate row and returns the (repo_id, owner, name, git_url) tuple. The row is now claimed atomically.
+3. **Job sent to runner channel**: dispatcher writes the job; if no runner slot is free the dispatcher blocks until one is — this is the documented concurrency cap.
+4. **Runner picks up job**:
+   - Creates a fresh shallow clone: `git clone --depth 1 <repo_git> <scancode_clone_dir>/repo_<id>_<unix_ts>`. The shallow clone is enough for scancode (it walks current file state, not history).
+   - Spawns scancode via `exec.CommandContext(ctx, "scancode", "-clpi", "--json", outputPath, ...)`.
+   - Calls `cmd.Start()` (NOT `cmd.Run()`) so the OS PID is available *immediately*. Calls `cmd.Wait()` next to actually wait for completion.
+   - Between `Start` and `Wait`, calls `store.RecordScancodeLockState(repoID, pid, bootID, outputPath)`. **This is the critical step** that makes crash recovery work — if aveloxis is killed before `cmd.Wait()` returns, the next aveloxis startup has the (pid, boot_id, output_path) tuple in the DB and can recover (see §5).
+5. **Scan completes**: runner parses the JSON output, calls `ingestScancodeOutput()` to write `scancode_scans` + `scancode_file_results` (with history rotation), and calls `store.MarkScancodeComplete(repoID, version)`. That UPDATE atomically:
+   - Sets `scancode_last_run = NOW()` and `scancode_version = $version`.
+   - Clears all four lock columns (`scancode_locked_at`, `scancode_locked_pid`, `scancode_locked_boot_id`, `scancode_output_path`).
+6. **Cleanup**: the runner's deferred `os.RemoveAll(tempDir)` removes the clone directory.
+
+On any failure path (clone error, scancode crash, JSON parse error, ingest error), the runner calls `store.ClearScancodeLock(repoID)` to release the lock without setting `scancode_last_run`. The row becomes eligible for re-claim on the next dispatcher tick.
+
+## 4. Cadence rationale (180 days default)
+
+Per-file license + copyright headers in source files are near-immutable on the timescale that matters. A 6-month cadence catches:
+
+- New files added to the repo since the last scan.
+- Wholesale license changes (rare — but they happen, e.g. a project changes from GPL to MIT).
+- Scancode version improvements (newer scancode versions detect licenses older versions missed).
+
+It does NOT catch dependency-license changes, but those don't flow through scancode anyway — they're handled by Phase 4 dependency scanning + Phase 6 SBOM generation, both per-cycle.
+
+Pre-v0.21.0 the inline cadence was 30 days, which produced one full re-scan of the whole fleet every month. At fleet scale (100K+ repos), that's a large continuous load for almost no fresh data. 180 days is a reasonable default; operators can dial via `collection.scancode_cadence_days`.
+
+## 5. Crash recovery — the four-state table
+
+On `aveloxis serve` startup, `ScancodeWorker.Run()` calls `recoverOrphans(ctx)` *before* the dispatcher starts claiming new jobs. The recovery pass examines every row with `scancode_locked_at IS NOT NULL` and applies one of four decisions:
+
+| State | Detection | Action |
+|---|---|---|
+| **Reboot survivor** | stored `boot_id` ≠ current `/proc/sys/kernel/random/boot_id` | Scancode subprocess is definitively dead (the kernel that hosted it no longer exists). Clear all lock columns. |
+| **Live orphan** | boot_id matches AND `kill(-0, pid)` succeeds | Subprocess survived a previous aveloxis crash and is now an orphan of init. Spawn a monitor goroutine that polls every 30s; when the PID dies, attempt to ingest the output file if present. |
+| **Recoverable corpse** | boot_id matches, PID is dead, output file exists and parses | Scan finished but aveloxis crashed before ingest. Ingest the orphaned output, then clear the lock. |
+| **Lost run** | boot_id matches, PID dead, no usable output | Scan died mid-flight. Clear the lock; the row will re-run on the next cadence tick. |
+
+The boot_id check is what makes the PID check reliable. Linux PIDs are reused — a stored PID of 12345 from before a reboot could legitimately match an unrelated process after the reboot. The boot_id (kernel-generated UUID, changes on every boot) lets the recovery pass decide unambiguously.
+
+On non-Linux dev machines (e.g. macOS) the `/proc` path is absent and `readBootID()` returns an empty string. The recovery pass treats empty boot_id as "unknown" and falls through to the PID check; correctness is preserved (PID reuse is rare on a single boot).
+
+## 6. Graceful shutdown
+
+When the scheduler's context is cancelled (`aveloxis stop serve`):
+
+1. The dispatcher exits immediately on its `<-ctx.Done()` arm. No new claims happen.
+2. The dispatcher closes the jobs channel.
+3. Runners that were idle return immediately (their `range jobs` loop terminates).
+4. Runners that were mid-scan keep going. The runner's `cmd.Wait()` is blocking on the scancode subprocess, which is NOT killed by the ctx cancel (Go's `exec.CommandContext` only kills the subprocess when the cmd object is garbage collected OR explicitly killed via `cmd.Process.Kill()`).
+5. `Run()` waits up to `collection.scancode_shutdown_grace_minutes` (default 30 min) for all runners to finish.
+6. If the grace expires with runners still active, `Run()` returns. The outstanding subprocesses become orphans — but they're tracked in the DB via the `(pid, boot_id, output_path)` triple recorded in step 4 of §3.2, so the next aveloxis startup's `recoverOrphans` pass will adopt them as live orphans (case 2 of §5).
+
+The grace bound exists because Linux-kernel-sized scans can legitimately run for hours; without a bound, `aveloxis stop` would wait indefinitely on the slowest scancode. The trade-off is clear: lose the in-flight scan data on grace expiry vs. wait hours on stop. Operators who want a different balance can dial the grace.
+
+## 7. Force-rerun cookbook
+
+Cadence is enforced at claim time via the `scancode_last_run` column. To force a rescan, clear that column:
+
+```sql
+-- Single repo
+UPDATE aveloxis_data.repos SET scancode_last_run = NULL
+WHERE repo_owner = 'apache' AND repo_name = 'doris';
+
+-- All repos that ran on a specific scancode version (e.g. after upgrade)
+UPDATE aveloxis_data.repos SET scancode_last_run = NULL
+WHERE scancode_version = '32.5.0';
+
+-- Whole fleet
+UPDATE aveloxis_data.repos SET scancode_last_run = NULL;
+```
+
+The claim query orders by `scancode_last_run NULLS FIRST`, so cleared repos move to the head of the queue and get claimed on subsequent dispatcher ticks. The order between cleared repos is `repo_id ASC` (stable).
+
+## 8. Configuration reference
+
+All five knobs live under the `collection` block in `aveloxis.json`:
+
+| Key | Default | Purpose |
+|---|---|---|
+| `scancode_workers` | `2` | Max concurrent scancode subprocesses. Raise on machines with spare CPU cores. |
+| `scancode_start_interval_s` | `90` | Minimum seconds between dispatcher claim attempts. Bounds clone-bandwidth bursts on restart. |
+| `scancode_cadence_days` | `180` | Minimum days between successive scans on the same repo. Per-file licenses change rarely. |
+| `scancode_clone_dir` | `/tmp/aveloxis-scancode` | Parent directory for per-run shallow clones. Size for ~50 MB × workers peak. |
+| `scancode_shutdown_grace_minutes` | `30` | Wait budget for in-flight scans on `aveloxis stop`. Outstanding scans become live-orphans (see §5) if not finished. |
+
+See [`docs/getting-started/configuration.md`](../getting-started/configuration.md#scancode-worker-v0210) for the tuning rationale per knob.
+
+## 9. UX: the "last run" signal
+
+The repo detail page in the web GUI shows:
+
+> **Last run:** 2026-04-08 (scancode 32.5.0)
+
+Or, for never-scanned repos:
+
+> **Last run:** *not yet run — will run in the next scancode worker cycle*
+
+The data flows from `aveloxis_data.repos.scancode_last_run` (written by `MarkScancodeComplete`) through the `/api/v1/repos/{id}/scancode-licenses` endpoint's `last_run` field to the rendered HTML.
+
+## 10. Observability — what to grep in `aveloxis.log`
+
+| Log line | When it fires | Meaning |
+|---|---|---|
+| `scancode worker started workers=N start_interval=...` | Once at startup | The pool is alive with N runners. If absent, scancode is disabled (binary not installed or `mkdir scancode_clone_dir` failed). |
+| `scancode binary not installed; ScancodeWorker disabled` | Startup | Install with `pipx install scancode-toolkit` then restart serve. |
+| `scancode recoverOrphans: examining locked rows count=...` | Startup | Recovery pass found stale locks. Followed by per-row decisions. |
+| `scancode recover: reboot survivor — clearing lock` | Startup | Case 1 of §5. |
+| `scancode recover: live orphan detected — spawning monitor` | Startup | Case 2 of §5. Monitor goroutine will log on completion. |
+| `scancode recover: ingested orphaned scancode result` | Startup or monitor | Case 3 of §5 — orphaned data recovered. |
+| `running ScanCode repo_id=... owner=... pid=...` | Per scan | Scan started; PID is the subprocess we're tracking. |
+| `scancode worker complete repo_id=... version=...` | Per scan | Scan succeeded and was ingested. |
+| `scancode runOne: scancode subprocess failed ... pid=...` | Per scan failure | Lock will be cleared. |
+| `scancode worker shutdown grace expired ...` | On stop | Outstanding scans become live-orphans on next startup. |
+
+## 11. Code map
+
+| File | Purpose |
+|---|---|
+| `internal/collector/scancode_worker.go` | The worker itself: `ScancodeWorker` struct, `Run`, `dispatcher`, `runner`, `runOne`, `recoverOrphans`, `monitorOrphan`. |
+| `internal/collector/scancode.go` | JSON parsing + ingest (`ingestScancodeOutput`). Shared between the worker and any future direct caller. |
+| `internal/db/scancode_worker_store.go` | Store methods: `ClaimNextScancodeRepo`, `RecordScancodeLockState`, `MarkScancodeComplete`, `ClearScancodeLock`, `ListLockedScancodeRows`. |
+| `internal/db/scancode_store.go` | Pre-existing scancode data access (file results, freshness reads). `ScancodeFreshness` is new in v0.21.0. |
+| `internal/db/migrate.go` | Six column additions + partial index + backfill from `aveloxis_scan.scancode_scans`. |
+| `internal/scheduler/scheduler.go` | `Config.Scancode*` fields, default values, goroutine spawn in `Run()`. |
+| `internal/config/config.go` | `CollectionConfig.Scancode*` fields and accessor methods. |
+| `internal/api/server.go` | `handleScancodeLicenses` returns `last_run` + `scancode_version` in addition to licenses + copyrights. |
+| `internal/web/templates.go` | Repo detail page renders the freshness signal above the source-code-licenses table. |
+
+## 12. Regression guards
+
+The v0.21.0 work added these tests as architectural pins. A future refactor that breaks any of them fails the build before it ships:
+
+| Test | Pins |
+|---|---|
+| `TestAnalyzeRepoNoLongerInvokesScancode` | `AnalyzeRepo` does NOT call `scanScanCode`. |
+| `TestScancodeSemaphoreNoLongerExists` | `scancode.go` does NOT declare `scancodeSem`. |
+| `TestScancodeNoLongerHas30DaySkipCheck` | `scancode.go` does NOT contain the inline cadence check. |
+| `TestRunOneSplitsStartFromWait` | `runOne` calls `cmd.Start()` + `cmd.Wait()`, NOT `cmd.Run()`. |
+| `TestRunOnePersistsPidAndBootId` | `runOne` calls `RecordScancodeLockState` between Start and Wait. |
+| `TestRunOneClearsLockOnSuccess` / `TestRunOneClearsLockOnFailure` | Lock-clear paths exist on both branches. |
+| `TestClaimUsesForUpdateSkipLocked` | Claim SQL uses `FOR UPDATE SKIP LOCKED`. |
+| `TestClaimGatesOnLastCollected` | Claim filters on `last_collected IS NOT NULL`. |
+| `TestClaimGatesOnCadenceAndStaleLock` | Claim respects both the cadence config and the 12h stale-lock fallback. |
+| `TestClaimExcludesArchivedRepos` | Claim WHERE clause matches the partial-index predicate. |
+| `TestScancodeWorkerCallsRecoverBeforeDispatcher` | Recovery runs before any new claim. |
+| `TestSchedulerRunStartsScancodeWorker` | Scheduler spawns the worker. |
+| `TestMainWiresScancodeConfig` | `cmd/aveloxis/main.go` reads the config knobs. |
+| `TestScancodeLicensesEndpointReturnsFreshness` | API surfaces the freshness signal. |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -71,7 +71,12 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "breadth_interval_minutes": 15,
     "breadth_batch_size": 2000,
     "breadth_cooldown_days": 7,
-    "shutdown_grace_seconds": 10
+    "shutdown_grace_seconds": 10,
+    "scancode_workers": 2,
+    "scancode_start_interval_s": 90,
+    "scancode_cadence_days": 180,
+    "scancode_clone_dir": "/tmp/aveloxis-scancode",
+    "scancode_shutdown_grace_minutes": 30
   },
   "web": {
     "addr": ":8082",
@@ -170,6 +175,30 @@ Periodic tickers that run on the scheduler. v0.16.5 / v0.18.29 / v0.19.7 moved e
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `collection.shutdown_grace_seconds` | integer | `10` | v0.20.0: ctx-cancel grace window for in-flight workers before `Scheduler.Run` closes the pgx pool. Pre-v0.20.0 the wait was unbounded — a 26-minute `commits` UPDATE blocked shutdown for the full duration. Setting this too low means worker transactions abort mid-flight (Postgres rolls them back safely but logs are noisy); too high means slow shutdown. |
+
+**Scancode worker (v0.21.0)**
+
+The scancode per-file license + copyright + package scan is run by a dedicated `ScancodeWorker` pool, decoupled from the per-repo collection pipeline. Pre-v0.21.0 scancode ran inline in `AnalysisCollector.AnalyzeRepo` gated by a 2-slot package-level semaphore; the 2026-05-14 production incident showed that shape doesn't survive fleet-scale operation (177 of 180 collection workers parked behind the semaphore for 7+ hours). The decoupled pool fixes the structural problem and adds operator-tunable cadence + concurrency. See `docs/architecture/scancode.md` for the full architecture write-up.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `collection.scancode_workers` | integer | `2` | Maximum concurrent scancode invocations. Pre-v0.21.0 the limit was hardcoded to 2; the default matches that so upgrading operators don't see a sudden change in scancode CPU load. Operators with spare CPU cores should raise this (the user running the fleet that surfaced the 2026-05-14 incident has tested 12 against 64 cores). |
+| `collection.scancode_start_interval_s` | integer | `90` | Minimum seconds between consecutive scancode CLAIM operations. The dispatcher's ticker fires every `scancode_start_interval_s` seconds; if a worker slot is free, one eligible repo is claimed; if no slot is free, the tick is a no-op. The pacing prevents new shallow clones from bursting the network/disk on operator restart with hundreds of eligible repos. |
+| `collection.scancode_cadence_days` | integer | `180` | Minimum days between successive scancode runs on the same repo. Pre-v0.21.0 was 30 days; the change reflects that per-file license + copyright headers in source files change rarely on the timescale that matters, and the I/O cost of scanning a Linux-kernel-scale mirror doesn't justify monthly re-scans. Dependency-level licenses (which DO change as packages update) still flow through the per-cycle Phase 4 dependency scan + Phase 6 SBOM generation. |
+| `collection.scancode_clone_dir` | string | `"/tmp/aveloxis-scancode"` | Parent directory for per-run shallow clones. Each scan creates `<dir>/repo_<id>_<unix_ts>` and removes it on completion (success or failure). Size budget: each clone is the working tree only (`git clone --depth 1`), so ≈ checked-out repo size. With default 2 workers and average ~50 MB clones, ~100 MB peak; raise expectations for big-repo / many-worker installs. |
+| `collection.scancode_shutdown_grace_minutes` | integer | `30` | Time the `ScancodeWorker` waits for in-flight scans to finish on `aveloxis stop`. Within the grace window, runners complete naturally (parse JSON output, write DB, clear lock columns). At grace expiry, `cmd.Process.Kill()` is invoked on the still-running scancode subprocess; `cmd.Wait()` returns with an error, the runner's lock-clear path fires, no orphaned scans from graceful shutdown. Separate from `shutdown_grace_seconds` (which paces the main scheduler) because scancode scans are intrinsically long-running. |
+
+**Force-rerun cookbook** — to invalidate the cadence gate and trigger a fresh scan on the next worker tick, set `scancode_last_run` back to NULL:
+
+```sql
+-- Single repo:
+UPDATE aveloxis_data.repos SET scancode_last_run = NULL WHERE repo_owner = 'apache' AND repo_name = 'doris';
+
+-- Whole fleet (e.g. after a scancode major-version upgrade):
+UPDATE aveloxis_data.repos SET scancode_last_run = NULL;
+```
+
+The worker's claim query orders `NULLS FIRST`, so cleared repos move to the front of the queue.
 
 ### Web (OAuth + GUI)
 

--- a/internal/api/scancode_freshness_test.go
+++ b/internal/api/scancode_freshness_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.0 — The decoupled ScancodeWorker means scan freshness is
+// now an operator-visible property (was always 30 days inline
+// before; could now be anywhere from "today" to "180 days ago"
+// depending on cadence config and queue depth). The UX must
+// surface the last-run date so users don't see stale data without
+// any indication of why.
+//
+// The contract: /api/v1/repos/{id}/scancode-licenses returns
+// last_run and version alongside the existing licenses +
+// copyrights arrays. The web template fetches the endpoint already
+// (it's the source of the source-code-licenses table); adding the
+// freshness fields to the same payload avoids a second round trip.
+
+func TestScancodeLicensesEndpointReturnsFreshness(t *testing.T) {
+	data, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// The handler must return `last_run` and `version` in its JSON
+	// response. Match on the JSON-tag-or-key text so a future
+	// refactor that swaps the struct doesn't false-pass.
+	for _, needle := range []string{
+		"last_run",
+		"scancode_version",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("handleScancodeLicenses must include %q in its JSON response payload. Pre-v0.21.0 scancode freshness was effectively always-30-days; with the decoupled worker the operator-visible date matters and the UX needs the data.", needle)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -232,12 +232,31 @@ func (s *Server) handleScancodeLicenses(w http.ResponseWriter, r *http.Request) 
 		s.logger.Warn("failed to get scancode copyrights", "repo_id", repoID, "error", err)
 	}
 
+	// v0.21.0 — Freshness fields surface the cadence/run state of
+	// the decoupled ScancodeWorker. Web UI uses these to render
+	// "Last run YYYY-MM-DD" above the per-file table. NULL
+	// last_run on the repos row means scancode hasn't yet run for
+	// this repo and the dashboard should say "Not yet run" instead
+	// of "Loading...".
+	lastRun, scancodeVer, err := s.store.ScancodeFreshness(r.Context(), repoID)
+	if err != nil {
+		s.logger.Warn("failed to get scancode freshness", "repo_id", repoID, "error", err)
+	}
+	var lastRunStr string
+	if !lastRun.IsZero() {
+		lastRunStr = lastRun.UTC().Format("2006-01-02")
+	}
+
 	resp := struct {
-		Licenses   []db.ScancodeSourceLicense   `json:"licenses"`
-		Copyrights []db.ScancodeSourceCopyright `json:"copyrights"`
+		Licenses        []db.ScancodeSourceLicense   `json:"licenses"`
+		Copyrights      []db.ScancodeSourceCopyright `json:"copyrights"`
+		LastRun         string                       `json:"last_run"`
+		ScancodeVersion string                       `json:"scancode_version"`
 	}{
-		Licenses:   licenses,
-		Copyrights: copyrights,
+		Licenses:        licenses,
+		Copyrights:      copyrights,
+		LastRun:         lastRunStr,
+		ScancodeVersion: scancodeVer,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/collector/analysis.go
+++ b/internal/collector/analysis.go
@@ -118,12 +118,18 @@ func (ac *AnalysisCollector) AnalyzeRepo(ctx context.Context, repoID int64) (*An
 		result.Errors = append(result.Errors, fmt.Errorf("scc: %w", err))
 	}
 
-	// Phase 4: ScanCode — license, copyright, and package detection (if installed).
-	// Runs every 30 days per repo. Skipped if scancode is not installed or if
-	// the last scan was recent.
-	if err := ac.scanScanCode(ctx, repoID, workDir, result); err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("scancode: %w", err))
-	}
+	// Phase 4: ScanCode removed from the analysis pipeline in v0.21.0.
+	// Scancode is now run by a dedicated ScancodeWorker pool in
+	// internal/collector/scancode_worker.go, claimed via FOR UPDATE
+	// SKIP LOCKED against aveloxis_data.repos, paced by
+	// collection.scancode_start_interval_s, and run with a
+	// configurable cadence of (default) 180 days. The 2026-05-14
+	// production incident showed that running scancode inline here
+	// with a 2-slot semaphore parked 177 of 180 collection workers
+	// for 7+ hours. Do NOT put scancode back on this path — see
+	// docs/architecture/scancode.md for the architectural rationale
+	// and TestAnalyzeRepoNoLongerInvokesScancode for the regression
+	// guard.
 
 	// When RetainClone is true, hand the clone path to the caller for
 	// post-analysis work (e.g., local scorecard execution).
@@ -3012,16 +3018,8 @@ func ListRepoFiles(ctx context.Context, barePath string) ([]string, error) {
 	return files, scanner.Err()
 }
 
-// scanScanCode runs ScanCode Toolkit for per-file license and copyright detection.
-// Delegates to RunScanCode which handles the 30-day skip check, CLI invocation,
-// JSON parsing, and database storage.
-func (ac *AnalysisCollector) scanScanCode(ctx context.Context, repoID int64, workDir string, result *AnalysisResult) error {
-	scResult, err := RunScanCode(ctx, ac.store, repoID, workDir, ac.logger)
-	if err != nil {
-		return err
-	}
-	if scResult != nil {
-		result.ScancodeFiles = scResult.FilesWithFindings
-	}
-	return nil
-}
+// scanScanCode was the v0.20-and-earlier per-job wrapper around
+// RunScanCode. Removed in v0.21.0 along with RunScanCode itself
+// when scancode moved to the dedicated ScancodeWorker pool. See
+// internal/collector/scancode_worker.go and
+// docs/architecture/scancode.md.

--- a/internal/collector/analysis_no_scancode_test.go
+++ b/internal/collector/analysis_no_scancode_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAnalyzeRepoNoLongerInvokesScancode is the regression guard
+// against the 2026-05-14 incident pattern. v0.21.0 moves scancode
+// out of the per-job AnalysisCollector.AnalyzeRepo path entirely
+// and into a dedicated ScancodeWorker pool. If a future refactor
+// accidentally re-couples scancode to AnalyzeRepo, this test fires
+// before the change ships.
+//
+// Why this is a separate test (not a comment in analysis.go):
+// production once parked 177 of 180 workers behind a 2-slot scancode
+// semaphore for 7+ hours. A code comment that "scancode is now done
+// elsewhere" wouldn't catch the next well-intentioned developer who
+// re-adds a per-job scancode call. A test does.
+func TestAnalyzeRepoNoLongerInvokesScancode(t *testing.T) {
+	data, err := os.ReadFile("analysis.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Locate AnalyzeRepo's body.
+	idx := strings.Index(src, "func (ac *AnalysisCollector) AnalyzeRepo(")
+	if idx < 0 {
+		t.Fatal("cannot find AnalysisCollector.AnalyzeRepo")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	if strings.Contains(body, "ac.scanScanCode(") {
+		t.Error("AnalysisCollector.AnalyzeRepo must NOT call ac.scanScanCode(). The v0.21.0 ScancodeWorker pool owns scancode entirely; calling it from the per-job analysis phase re-introduces the 2-slot semaphore bottleneck that stalled 177 of 180 workers for 7+ hours on 2026-05-14. If you genuinely need per-job scancode (rare — discuss in a design doc first), call RunScanCode directly with an opt-in flag rather than putting it back in the default path.")
+	}
+}
+
+// TestScancodeSemaphoreNoLongerExists pins the removal of the
+// package-level scancodeSem channel. The semaphore was the
+// architectural anti-pattern that caused the 2026-05-14 incident:
+// a 2-slot channel that blocked every additional caller for the
+// duration of the in-flight scans. The v0.21.0 worker uses its own
+// channel-based dispatcher with the explicit ScancodeWorkers
+// config knob, so the global semaphore no longer has a role.
+//
+// If a future refactor reintroduces `var scancodeSem = make(chan
+// struct{}, N)` in this package, it's almost certainly putting
+// scancode back on the per-job hot path. This test catches that.
+func TestScancodeSemaphoreNoLongerExists(t *testing.T) {
+	data, err := os.ReadFile("scancode.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if strings.Contains(src, "var scancodeSem ") {
+		t.Error("scancode.go must NOT declare a package-level scancodeSem channel. Pre-v0.21.0 this 2-slot semaphore was the bottleneck that stalled 177 of 180 workers on 2026-05-14. The v0.21.0 ScancodeWorker uses its own channel-based dispatcher with the configurable scancode_workers count. If you need to limit scancode concurrency, raise/lower that config value.")
+	}
+}
+
+// TestScancodeNoLongerHas30DaySkipCheck pins the removal of the
+// in-function cadence check from RunScanCode. The cadence is now
+// enforced at the worker's claim query level — checking it again
+// inside RunScanCode would (a) cause a confusing double-gate where
+// operators couldn't force a rescan even via UPDATE
+// scancode_last_run=NULL, and (b) leave the worker holding a
+// claimed row while the scan no-ops out, then having to clear the
+// lock with no useful state captured.
+func TestScancodeNoLongerHas30DaySkipCheck(t *testing.T) {
+	data, err := os.ReadFile("scancode.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if strings.Contains(src, "ScancodeRunInterval") && strings.Contains(src, "time.Since(lastRun)") {
+		t.Error("scancode.go must not contain the time.Since(lastRun) < ScancodeRunInterval skip check. The v0.21.0 ScancodeWorker enforces cadence at claim time via collection.scancode_cadence_days. Keeping the inline check causes a double-gate where operators can't force a rescan from the SQL side and the worker pays a wasted claim → no-op → clear cycle for already-fresh rows.")
+	}
+}

--- a/internal/collector/scancode.go
+++ b/internal/collector/scancode.go
@@ -1,32 +1,29 @@
 // SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
 // SPDX-License-Identifier: MIT
 
-// Package collector — scancode.go runs ScanCode Toolkit against a local
-// repository checkout to detect licenses, copyrights, and packages per file.
+// Package collector — scancode.go provides scancode JSON output
+// parsing and ingest into aveloxis_scan tables.
 //
-// ScanCode (https://github.com/aboutcode-org/scancode-toolkit) is a Python
-// tool installed via `pipx install scancode-toolkit`. If not installed on
-// PATH, this phase is silently skipped.
+// The actual scancode subprocess invocation lives in
+// scancode_worker.go (v0.21.0). Pre-v0.21.0 this file also owned
+// the subprocess invocation + a 2-slot package-level semaphore +
+// a 30-day inline skip check; all of that moved into the
+// ScancodeWorker pool after the 2026-05-14 incident showed the
+// semaphore stalled 177 of 180 collection workers for 7+ hours.
+// See docs/architecture/scancode.md for the architectural
+// rationale and the four-state recovery table.
 //
-// ScanCode only needs to run every 30 days per repo — license and copyright
-// data changes infrequently. The last-run timestamp is checked via
-// ScancodeLastRun before invoking the tool.
-//
-// Results are stored in the aveloxis_scan schema:
-//   - scancode_scans: one row per scan run (metadata, duration, file count)
-//   - scancode_file_results: per-file license, copyright, and package findings
-//   - History tables rotate previous results before each new scan.
-//
-// Assumptions:
-//   - The `scancode` binary is installed and on PATH
-//   - ScanCode is invoked with -clpi (copyright, license, package, info)
-//   - --only-findings reduces output to files with actual detections
-//   - --quiet suppresses progress output
-//   - --timeout 300 gives 5 min per file (some files are pathological)
-//   - --processes 2 limits internal Python parallelism (default is 1-per-core)
-//   - --max-in-memory 5000 caps memory for large repos
-//   - A package-level semaphore limits concurrent ScanCode invocations to 2
-//   - Output goes to a temp JSON file, parsed after completion
+// What stays here:
+//   - The scancode JSON output struct definitions (scancodeOutput,
+//     scancodeHeader, scancodeFile) — these are the wire format
+//     scancode emits to its --json output file.
+//   - hasFindings(f) — returns true if a parsed file entry has any
+//     detection worth persisting.
+//   - ingestScancodeOutput — parses the JSON output file at the
+//     given path and writes the results to aveloxis_scan tables
+//     (with history rotation). Called from scancode_worker.runOne
+//     after cmd.Wait() succeeds, and from the recovery monitor for
+//     orphaned scans that exited while aveloxis was down.
 package collector
 
 import (
@@ -35,214 +32,71 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"time"
 
 	"github.com/aveloxis/aveloxis/internal/db"
 )
 
-// scancodeSem limits concurrent ScanCode invocations across all scheduler
-// workers. ScanCode is a Python tool that spawns multiple child processes
-// internally (controlled by --processes). Without this semaphore, 40 scheduler
-// workers could each launch ScanCode simultaneously, creating hundreds of
-// Python processes. Default: 2 concurrent scans.
-var scancodeSem = make(chan struct{}, 2)
-
-// ScancodeRunInterval is how often ScanCode should run per repo.
-// License and copyright data changes infrequently, so 30 days is sufficient.
-const ScancodeRunInterval = 30 * 24 * time.Hour
-
-// ScancodeResult holds the parsed summary from a ScanCode run.
-type ScancodeResult struct {
-	ScancodeVersion   string
-	FilesScanned      int
-	FilesWithFindings int
-	DurationSecs      float64
-	FileResults       []ScancodeFileResult
-	Errors            []string
-}
-
-// ScancodeFileResult holds per-file findings from ScanCode.
-type ScancodeFileResult struct {
-	Path                          string
-	FileType                      string
-	ProgrammingLanguage           string
-	DetectedLicenseExpression     string
-	DetectedLicenseExpressionSPDX string
-	PercentageOfLicenseText       float64
-	Copyrights                    json.RawMessage // JSONB array of {copyright, start_line, end_line}
-	Holders                       json.RawMessage // JSONB array of {holder, start_line, end_line}
-	LicenseDetections             json.RawMessage // JSONB array of detection details
-	PackageData                   json.RawMessage // JSONB array of package metadata
-	ScanErrors                    json.RawMessage // JSONB array of error strings
-}
-
-// RunScanCode executes ScanCode Toolkit against a local checkout and stores
-// results in the aveloxis_scan schema. Skips if scancode is not installed or
-// if the last scan was within 30 days.
+// ingestScancodeOutput parses a scancode JSON output file and
+// writes scancode_scans + scancode_file_results, rotating any
+// previous results to the *_history tables first. Returns the
+// scancode binary version that produced the output (from the
+// JSON's headers).
 //
-// The localPath must point to an existing checkout (the temp analysis clone).
-func RunScanCode(ctx context.Context, store *db.PostgresStore, repoID int64, localPath string, logger *slog.Logger) (*ScancodeResult, error) {
-	// Check if scancode is installed.
-	scancodePath, err := exec.LookPath("scancode")
+// Safe to call from multiple goroutines on different repoIDs
+// because all writes target rows keyed by repoID with appropriate
+// per-row history rotation.
+func ingestScancodeOutput(ctx context.Context, store *db.PostgresStore, repoID int64, outputPath string, logger *slog.Logger) (string, error) {
+	data, err := os.ReadFile(outputPath)
 	if err != nil {
-		logger.Info("scancode not installed, skipping ScanCode analysis",
-			"install", "pipx install scancode-toolkit")
-		return nil, nil
+		return "", fmt.Errorf("reading scancode output: %w", err)
 	}
-
-	// Check if we ran scancode within the last 30 days for this repo.
-	lastRun, err := store.ScancodeLastRun(ctx, repoID)
-	if err == nil && !lastRun.IsZero() && time.Since(lastRun) < ScancodeRunInterval {
-		logger.Info("scancode ran recently, skipping",
-			"repo_id", repoID,
-			"last_run", lastRun,
-			"next_due", lastRun.Add(ScancodeRunInterval).Format("2006-01-02"))
-		return nil, nil
-	}
-
-	if localPath == "" {
-		logger.Warn("scancode skipped: no local clone path", "repo_id", repoID)
-		return nil, nil
-	}
-
-	// Acquire the concurrency semaphore — blocks if too many ScanCode instances
-	// are already running. Respects context cancellation while waiting.
-	select {
-	case scancodeSem <- struct{}{}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-	defer func() { <-scancodeSem }()
-
-	logger.Info("running ScanCode", "repo_id", repoID, "path", localPath)
-
-	// Limit ScanCode's internal parallelism. By default ScanCode spawns one
-	// Python worker per CPU core, which is fine for a single invocation but
-	// catastrophic when the scheduler runs 40 concurrent collections.
-	// Cap at 2 processes per invocation (or 1 on single-core machines).
-	procs := 2
-	if runtime.NumCPU() < 2 {
-		procs = 1
-	}
-
-	// Write output to a temp file — scancode writes JSON to a file, not stdout.
-	outputFile := filepath.Join(os.TempDir(), fmt.Sprintf("aveloxis-scancode-%d-%d.json", repoID, time.Now().UnixNano()))
-	defer os.Remove(outputFile)
-
-	cmd := exec.CommandContext(ctx, scancodePath,
-		"-clpi",
-		"--only-findings",
-		"--json", outputFile,
-		"--quiet",
-		"--timeout", "300",
-		"--processes", strconv.Itoa(procs),
-		"--max-in-memory", "5000",
-		localPath,
-	)
-	var stderrBuf []byte
-	cmd.Stderr = nil // scancode writes progress to stderr; --quiet suppresses it
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("scancode failed: %w", err)
-	}
-
-	// Read and parse the output file.
-	data, err := os.ReadFile(outputFile)
-	if err != nil {
-		return nil, fmt.Errorf("reading scancode output: %w", err)
-	}
-	// stderrBuf is declared for future error context capture but currently unused.
-	if len(stderrBuf) > 0 {
-		logger.Debug("scancode stderr output", "repo_id", repoID, "stderr", string(stderrBuf))
-	}
-
 	var raw scancodeOutput
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing scancode output: %w", err)
+		return "", fmt.Errorf("parsing scancode output: %w", err)
 	}
 
-	// Build result from parsed output.
-	result := &ScancodeResult{}
+	var version string
+	var duration float64
+	var filesScanned int
 	if len(raw.Headers) > 0 {
-		result.ScancodeVersion = raw.Headers[0].ToolVersion
-		result.DurationSecs = raw.Headers[0].Duration
+		version = raw.Headers[0].ToolVersion
+		duration = raw.Headers[0].Duration
 		if raw.Headers[0].ExtraData.FilesCount > 0 {
-			result.FilesScanned = raw.Headers[0].ExtraData.FilesCount
+			filesScanned = raw.Headers[0].ExtraData.FilesCount
 		}
 	}
 
-	// Rotate previous results to history before inserting.
 	if err := store.RotateScancodeToHistory(ctx, repoID); err != nil {
 		logger.Warn("failed to rotate scancode history", "repo_id", repoID, "error", err)
 	}
 
-	// Insert scan metadata.
-	for _, f := range raw.Files {
-		if f.Type != "file" {
-			continue // skip directory entries
-		}
-		if hasFindings(f) {
-			result.FilesWithFindings++
-		}
-	}
-
-	scanID, err := store.InsertScancodeScan(ctx, repoID, result.ScancodeVersion,
-		result.FilesScanned, result.FilesWithFindings, result.DurationSecs, nil)
-	if err != nil {
-		return result, fmt.Errorf("inserting scancode scan: %w", err)
-	}
-	logger.Debug("scancode scan recorded", "repo_id", repoID, "scan_id", scanID)
-
-	// Collect file results for batch insert.
-	var fileResults []ScancodeFileResult
-	var dbRows []*db.ScancodeFileRow
+	var filesWithFindings int
 	for _, f := range raw.Files {
 		if f.Type != "file" {
 			continue
 		}
-		if !hasFindings(f) {
-			continue // --only-findings should filter, but double-check
+		if hasFindings(f) {
+			filesWithFindings++
 		}
+	}
 
-		copyrightsJSON, err := json.Marshal(f.Copyrights)
-		if err != nil {
-			logger.Warn("failed to marshal copyrights", "path", f.Path, "error", err)
-		}
-		holdersJSON, err := json.Marshal(f.Holders)
-		if err != nil {
-			logger.Warn("failed to marshal holders", "path", f.Path, "error", err)
-		}
-		licenseDetJSON, err := json.Marshal(f.LicenseDetections)
-		if err != nil {
-			logger.Warn("failed to marshal license detections", "path", f.Path, "error", err)
-		}
-		packageJSON, err := json.Marshal(f.PackageData)
-		if err != nil {
-			logger.Warn("failed to marshal package data", "path", f.Path, "error", err)
-		}
-		errorsJSON, err := json.Marshal(f.ScanErrors)
-		if err != nil {
-			logger.Warn("failed to marshal scan errors", "path", f.Path, "error", err)
-		}
+	scanID, err := store.InsertScancodeScan(ctx, repoID, version,
+		filesScanned, filesWithFindings, duration, nil)
+	if err != nil {
+		return version, fmt.Errorf("inserting scancode scan: %w", err)
+	}
+	logger.Debug("scancode scan recorded", "repo_id", repoID, "scan_id", scanID)
 
-		fileResults = append(fileResults, ScancodeFileResult{
-			Path:                          f.Path,
-			FileType:                      f.FileType,
-			ProgrammingLanguage:           f.ProgrammingLanguage,
-			DetectedLicenseExpression:     f.DetectedLicenseExpression,
-			DetectedLicenseExpressionSPDX: f.DetectedLicenseExpressionSPDX,
-			PercentageOfLicenseText:       f.PercentageOfLicenseText,
-			Copyrights:                    copyrightsJSON,
-			Holders:                       holdersJSON,
-			LicenseDetections:             licenseDetJSON,
-			PackageData:                   packageJSON,
-			ScanErrors:                    errorsJSON,
-		})
-
+	var dbRows []*db.ScancodeFileRow
+	for _, f := range raw.Files {
+		if f.Type != "file" || !hasFindings(f) {
+			continue
+		}
+		copyrightsJSON, _ := json.Marshal(f.Copyrights)
+		holdersJSON, _ := json.Marshal(f.Holders)
+		licenseDetJSON, _ := json.Marshal(f.LicenseDetections)
+		packageJSON, _ := json.Marshal(f.PackageData)
+		errorsJSON, _ := json.Marshal(f.ScanErrors)
 		dbRows = append(dbRows, &db.ScancodeFileRow{
 			Path:                          f.Path,
 			FileType:                      f.FileType,
@@ -258,31 +112,25 @@ func RunScanCode(ctx context.Context, store *db.PostgresStore, repoID int64, loc
 		})
 	}
 
-	result.FileResults = fileResults
-
-	// Batch insert file results.
 	if err := store.InsertScancodeFileResultBatch(ctx, repoID, dbRows); err != nil {
-		return result, fmt.Errorf("inserting scancode file results: %w", err)
+		return version, fmt.Errorf("inserting scancode file results: %w", err)
 	}
-
-	logger.Info("scancode complete",
-		"repo_id", repoID,
-		"version", result.ScancodeVersion,
-		"files_scanned", result.FilesScanned,
-		"files_with_findings", result.FilesWithFindings,
-		"duration_secs", result.DurationSecs)
-
-	return result, nil
+	return version, nil
 }
 
-// hasFindings returns true if a scancode file entry has any detections.
+// hasFindings returns true if a scancode file entry has any
+// detection worth recording. Pre-v0.21.0 this was conservative
+// (excluded files with only license-text-percentage signals); kept
+// as-is for behavioral parity with existing scancode_file_results
+// rows.
 func hasFindings(f scancodeFile) bool {
 	return f.DetectedLicenseExpression != "" ||
 		len(f.Copyrights) > 0 ||
 		len(f.PackageData) > 0
 }
 
-// scancodeOutput is the top-level JSON structure from `scancode --json`.
+// scancodeOutput is the top-level JSON structure from
+// `scancode --json`.
 type scancodeOutput struct {
 	Headers []scancodeHeader `json:"headers"`
 	Files   []scancodeFile   `json:"files"`

--- a/internal/collector/scancode_test.go
+++ b/internal/collector/scancode_test.go
@@ -74,103 +74,20 @@ func TestScancodeOutputParsing(t *testing.T) {
 	}
 }
 
-// TestScancodeResultStruct verifies ScancodeResult has expected fields.
-func TestScancodeResultStruct(t *testing.T) {
-	r := ScancodeResult{
-		ScancodeVersion:   "32.5.0",
-		FilesScanned:      42,
-		FilesWithFindings: 10,
-		DurationSecs:      12.5,
-		FileResults: []ScancodeFileResult{
-			{
-				Path:                          "main.go",
-				ProgrammingLanguage:           "Go",
-				DetectedLicenseExpressionSPDX: "MIT",
-			},
-		},
-	}
-	if r.ScancodeVersion != "32.5.0" {
-		t.Errorf("ScancodeVersion = %q", r.ScancodeVersion)
-	}
-	if r.FilesScanned != 42 {
-		t.Errorf("FilesScanned = %d", r.FilesScanned)
-	}
-	if r.FilesWithFindings != 10 {
-		t.Errorf("FilesWithFindings = %d", r.FilesWithFindings)
-	}
-	if len(r.FileResults) != 1 {
-		t.Fatalf("FileResults = %d", len(r.FileResults))
-	}
-}
-
-// TestRunScanCodeFunctionExists verifies RunScanCode is defined with expected signature.
-func TestRunScanCodeFunctionExists(t *testing.T) {
-	src, err := os.ReadFile("scancode.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	code := string(src)
-
-	if !strings.Contains(code, "func RunScanCode(") {
-		t.Error("RunScanCode function must exist in scancode.go")
-	}
-	// Must accept a local path to scan.
-	if !strings.Contains(code, "localPath string") {
-		t.Error("RunScanCode must accept a localPath parameter")
-	}
-}
-
-// TestRunScanCodeUsesCorrectFlags verifies the CLI flags used.
-func TestRunScanCodeUsesCorrectFlags(t *testing.T) {
-	src, err := os.ReadFile("scancode.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	code := string(src)
-
-	// Must use license, copyright, package, and info flags.
-	if !strings.Contains(code, "-clpi") {
-		t.Error("RunScanCode must use -clpi flags (copyright, license, package, info)")
-	}
-	// Must use --only-findings to reduce output size.
-	if !strings.Contains(code, "--only-findings") {
-		t.Error("RunScanCode must use --only-findings to reduce output size")
-	}
-	// Must use --json for machine-readable output.
-	if !strings.Contains(code, "--json") {
-		t.Error("RunScanCode must use --json output format")
-	}
-	// Must use --quiet to suppress progress output.
-	if !strings.Contains(code, "--quiet") {
-		t.Error("RunScanCode must use --quiet flag")
-	}
-	// Must limit internal Python process parallelism.
-	if !strings.Contains(code, "--processes") {
-		t.Error("RunScanCode must use --processes to limit Python thread/process count")
-	}
-	// Must limit in-memory file count for large repos.
-	if !strings.Contains(code, "--max-in-memory") {
-		t.Error("RunScanCode must use --max-in-memory to cap memory usage")
-	}
-}
-
-// TestScancodeConcurrencySemaphore verifies that a package-level semaphore
-// limits concurrent ScanCode invocations.
-func TestScancodeConcurrencySemaphore(t *testing.T) {
-	src, err := os.ReadFile("scancode.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	code := string(src)
-
-	if !strings.Contains(code, "scancodeSem") {
-		t.Error("scancode.go must define scancodeSem to limit concurrent invocations")
-	}
-	// The semaphore must be used in RunScanCode to acquire/release slots.
-	if !strings.Contains(code, "scancodeSem <-") || !strings.Contains(code, "<-scancodeSem") {
-		t.Error("RunScanCode must acquire and release scancodeSem")
-	}
-}
+// v0.21.0 — TestScancodeResultStruct / TestRunScanCodeFunctionExists /
+// TestRunScanCodeUsesCorrectFlags / TestScancodeConcurrencySemaphore /
+// TestAnalysisCallsScanCode were retired in this release. They
+// pinned the pre-v0.21.0 architecture: per-job RunScanCode call
+// from AnalysisCollector with a 2-slot package-level semaphore.
+// That architecture was the root cause of the 2026-05-14 incident
+// (177 of 180 workers parked on the semaphore for 7+ hours). The
+// equivalent invariants for the new architecture are pinned by:
+//
+//   - TestAnalyzeRepoNoLongerInvokesScancode      (analysis_no_scancode_test.go)
+//   - TestScancodeSemaphoreNoLongerExists         (analysis_no_scancode_test.go)
+//   - TestScancodeNoLongerHas30DaySkipCheck       (analysis_no_scancode_test.go)
+//   - TestScancodeWorker* family                  (scancode_worker_test.go)
+//   - TestClaim* family                           (scancode_worker_test.go)
 
 // TestAnalysisResultHasScancodeFiles verifies AnalysisResult tracks scancode findings.
 func TestAnalysisResultHasScancodeFiles(t *testing.T) {
@@ -180,19 +97,6 @@ func TestAnalysisResultHasScancodeFiles(t *testing.T) {
 	}
 	if r.ScancodeFiles != 5 {
 		t.Errorf("ScancodeFiles = %d, want 5", r.ScancodeFiles)
-	}
-}
-
-// TestAnalysisCallsScanCode verifies analysis.go includes scancode as a phase.
-func TestAnalysisCallsScanCode(t *testing.T) {
-	src, err := os.ReadFile("analysis.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	code := string(src)
-
-	if !strings.Contains(code, "scanScanCode") || !strings.Contains(code, "RunScanCode") {
-		t.Error("analysis.go must call scancode as a phase (scanScanCode or RunScanCode)")
 	}
 }
 
@@ -288,22 +192,14 @@ func TestScancodeLastRunReturnsTime(t *testing.T) {
 	}
 }
 
-// TestScancode30DaySkipLogic verifies scancode checks last-run date and skips
-// if within 30 days.
-func TestScancode30DaySkipLogic(t *testing.T) {
-	src, err := os.ReadFile("scancode.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	code := string(src)
-
-	if !strings.Contains(code, "ScancodeLastRun") {
-		t.Error("RunScanCode must check ScancodeLastRun to implement 30-day skip")
-	}
-	if !strings.Contains(code, "30") {
-		t.Error("RunScanCode must reference 30-day interval")
-	}
-}
+// v0.21.0 — TestScancode30DaySkipLogic was retired in this release.
+// The 30-day inline skip check in scancode.go was replaced by the
+// configurable cadence (default 180 days) enforced at claim time
+// in db.ClaimNextScancodeRepo. The equivalent invariant is now
+// pinned by TestClaimGatesOnCadenceAndStaleLock in
+// scancode_worker_test.go and the
+// collection.scancode_cadence_days knob in
+// scancode_knobs_test.go.
 
 // TestScancodeStoreHasSBOMMethod verifies the DB has a method to retrieve
 // scancode data for SBOM enrichment.

--- a/internal/collector/scancode_worker.go
+++ b/internal/collector/scancode_worker.go
@@ -1,0 +1,614 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Package collector — scancode_worker.go runs ScanCode Toolkit in a
+// dedicated worker pool, decoupled from the per-repo collection
+// pipeline.
+//
+// # Why a dedicated worker (v0.21.0)
+//
+// Pre-v0.21.0, scancode ran inline in AnalysisCollector.AnalyzeRepo
+// gated by a 2-slot package-level semaphore. The 2026-05-14 production
+// incident on a 180-worker fleet showed 177 worker goroutines parked
+// at the semaphore for 7+ hours — effectively the whole pool stalled
+// behind two slow scancode runs. The fix moves scancode out of the
+// per-job pipeline entirely. The new worker:
+//
+//   - Claims eligible repos via Postgres FOR UPDATE SKIP LOCKED so
+//     multiple aveloxis processes (or future shard splits) can
+//     coordinate without coordination overhead.
+//   - Re-clones each repo shallowly (git clone --depth 1) so it
+//     doesn't depend on the facade's bare clone — the two paths
+//     can run independently without lock-on-bare-clone hazards.
+//   - Persists the OS PID + kernel boot_id immediately after the
+//     scancode subprocess starts, so a crash (kill -9, OOM, host
+//     reboot) leaves recoverable state for the next startup.
+//   - Honors a configurable 6-month default cadence (was 30 days
+//     hardcoded) because per-file license + copyright data
+//     changes rarely on the timescale we care about.
+//
+// See docs/architecture/scancode.md for the full architectural
+// write-up, the four-state recovery table, and the force-rerun
+// cookbook.
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+)
+
+// bootIDPath is the kernel-generated UUID that changes on every
+// boot. Reading this file at lock-record time (paired with the
+// scancode subprocess PID) makes the recovery liveness check
+// unambiguous across kernel reboots — without it a stored PID of
+// 12345 from before a reboot could match an unrelated process that
+// now happens to hold that PID. Linux-only; on macOS dev machines
+// the file is absent and we fall back to a process-stable
+// substitute that still detects "this is a new process".
+const bootIDPath = "/proc/sys/kernel/random/boot_id"
+
+// ScancodeWorker is the v0.21.0 decoupled scancode runner.
+//
+// Lifecycle:
+//
+//  1. Run() probes for the scancode binary on PATH; if absent,
+//     logs once at INFO and returns (no goroutines spawned).
+//  2. recoverOrphans() runs once — examines every row with a
+//     non-null scancode_locked_at and applies the four-state
+//     recovery (reboot survivor / live orphan / recoverable corpse
+//     / lost run).
+//  3. dispatcher() ticks every startInterval seconds, attempts a
+//     claim, and feeds a free runner slot. The ticker (not a tight
+//     loop) is what paces clone-bandwidth bursts on operator
+//     restart.
+//  4. runner() goroutines (workerCount of them) consume jobs and
+//     call runOne(). Each runOne does: shallow clone, scancode
+//     subprocess, parse JSON output, ingest to the existing
+//     scancode_scans + scancode_file_results tables, clear lock.
+//  5. On ctx.Done(), the dispatcher exits immediately. Runners
+//     keep going until shutdownGrace elapses, at which point
+//     pending subprocesses are killed and Run() returns.
+type ScancodeWorker struct {
+	store         *db.PostgresStore
+	logger        *slog.Logger
+	workerCount   int
+	startInterval time.Duration
+	cadence       time.Duration
+	cloneDir      string
+	shutdownGrace time.Duration
+}
+
+// NewScancodeWorker constructs a worker. All time-based fields fall
+// back to documented defaults when zero is passed, so the caller
+// can do `NewScancodeWorker(store, logger, 0, 0, 0, "", 0)` to get
+// an entirely default-configured worker.
+func NewScancodeWorker(store *db.PostgresStore, logger *slog.Logger,
+	workerCount int, startInterval, cadence time.Duration,
+	cloneDir string, shutdownGrace time.Duration) *ScancodeWorker {
+	if workerCount <= 0 {
+		workerCount = 2
+	}
+	if startInterval <= 0 {
+		startInterval = 90 * time.Second
+	}
+	if cadence <= 0 {
+		cadence = 180 * 24 * time.Hour
+	}
+	if cloneDir == "" {
+		cloneDir = "/tmp/aveloxis-scancode"
+	}
+	if shutdownGrace <= 0 {
+		shutdownGrace = 30 * time.Minute
+	}
+	return &ScancodeWorker{
+		store:         store,
+		logger:        logger,
+		workerCount:   workerCount,
+		startInterval: startInterval,
+		cadence:       cadence,
+		cloneDir:      cloneDir,
+		shutdownGrace: shutdownGrace,
+	}
+}
+
+// Run starts the worker pool and blocks until ctx is done. After
+// ctx cancellation, waits up to shutdownGrace for in-flight runners
+// before forcing them to exit and returning.
+//
+// Probes for the scancode binary at startup; if not installed, logs
+// once and returns without spawning goroutines (matches the pre-
+// v0.21.0 silent-skip behavior of the inline analysis-phase scan).
+func (w *ScancodeWorker) Run(ctx context.Context) {
+	if _, err := exec.LookPath("scancode"); err != nil {
+		w.logger.Info("scancode binary not installed; ScancodeWorker disabled",
+			"install_hint", "pipx install scancode-toolkit")
+		return
+	}
+
+	if err := os.MkdirAll(w.cloneDir, 0o755); err != nil {
+		w.logger.Warn("failed to create scancode clone directory; ScancodeWorker disabled",
+			"clone_dir", w.cloneDir, "error", err)
+		return
+	}
+
+	w.logger.Info("scancode worker started",
+		"workers", w.workerCount,
+		"start_interval", w.startInterval.String(),
+		"cadence", w.cadence.String(),
+		"clone_dir", w.cloneDir,
+		"shutdown_grace", w.shutdownGrace.String())
+
+	// One-shot recovery pass before the dispatcher starts claiming
+	// new work. This is what makes graceful shutdown + kill -9
+	// survivable: any orphaned subprocess from a prior run is
+	// either adopted (monitor goroutine spawned) or its lock
+	// cleared, so the dispatcher's claim query sees a clean state.
+	w.recoverOrphans(ctx)
+
+	jobs := make(chan db.ScancodeJob)
+	var wg sync.WaitGroup
+
+	// Runner pool — each runner consumes one job at a time.
+	for i := 0; i < w.workerCount; i++ {
+		wg.Add(1)
+		go w.runner(ctx, jobs, &wg)
+	}
+
+	// Dispatcher claims jobs and feeds the channel. When ctx is
+	// canceled, dispatcher exits, closes the channel, and the
+	// runners drain naturally.
+	dispatcherDone := make(chan struct{})
+	go func() {
+		defer close(dispatcherDone)
+		w.dispatcher(ctx, jobs)
+		close(jobs)
+	}()
+
+	<-dispatcherDone
+
+	// Graceful shutdown: wait up to shutdownGrace for runners to
+	// finish. If they don't, the runners' ctx-derived cmd.Start
+	// will have its subprocess killed via syscall.Kill in the
+	// graceful-shutdown defer chain on each runOne.
+	runnersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(runnersDone)
+	}()
+
+	select {
+	case <-runnersDone:
+		w.logger.Info("scancode worker stopped cleanly — all runners completed within grace window")
+	case <-time.After(w.shutdownGrace):
+		w.logger.Warn("scancode worker shutdown grace expired — outstanding scancode subprocesses will be killed on next syscall",
+			"grace", w.shutdownGrace.String())
+	}
+}
+
+// dispatcher runs the claim ticker. On each tick, attempts a claim;
+// if successful, sends the job to a runner. If the channel is full
+// (no free runner), the dispatcher BLOCKS until one frees up — this
+// is the intended concurrency cap. The dispatcher exits on
+// ctx.Done() OR when sending to the channel returns from
+// ctx.Done() (the latter happens when all runners have exited).
+func (w *ScancodeWorker) dispatcher(ctx context.Context, jobs chan<- db.ScancodeJob) {
+	ticker := time.NewTicker(w.startInterval)
+	defer ticker.Stop()
+
+	// Try one claim immediately on startup so a fresh restart
+	// doesn't sit idle for an entire startInterval before
+	// dispatching the first job. Subsequent claims wait for the
+	// ticker.
+	if !w.tryDispatchOne(ctx, jobs) {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !w.tryDispatchOne(ctx, jobs) {
+				return
+			}
+		}
+	}
+}
+
+// tryDispatchOne attempts one claim. Returns false only if ctx is
+// done (signal to the dispatcher loop to exit). A no-eligible-row
+// result returns true — the next tick will try again.
+func (w *ScancodeWorker) tryDispatchOne(ctx context.Context, jobs chan<- db.ScancodeJob) bool {
+	job, err := w.store.ClaimNextScancodeRepo(ctx, w.cadence)
+	if err != nil {
+		if ctx.Err() != nil {
+			return false
+		}
+		w.logger.Warn("scancode worker claim failed", "error", err)
+		return true
+	}
+	if job == nil {
+		// Queue empty — wait for next tick.
+		return true
+	}
+	select {
+	case jobs <- *job:
+		return true
+	case <-ctx.Done():
+		// We claimed but ctx is canceled. Best-effort: clear the
+		// lock so the next aveloxis startup doesn't have to
+		// adopt this row as a phantom orphan.
+		_ = w.store.ClearScancodeLock(context.Background(), job.RepoID)
+		return false
+	}
+}
+
+// runner consumes jobs and runs them serially. When jobs is closed
+// (dispatcher exit), the loop falls through and the goroutine
+// returns, decrementing the WaitGroup.
+func (w *ScancodeWorker) runner(ctx context.Context, jobs <-chan db.ScancodeJob, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for job := range jobs {
+		w.runOne(ctx, job)
+	}
+}
+
+// runOne is the actual scan pipeline for one repo. Always clears
+// the scancode_locked_* columns on exit (success or failure) so the
+// row becomes eligible for the next claim cycle without waiting for
+// the 12-hour stale-lock fallback.
+//
+// Steps:
+//  1. mkdir <cloneDir>/repo_<id>_<unix_ts>
+//  2. git clone --depth 1 <repo_git> <tempDir>
+//  3. exec.CommandContext(ctx, "scancode", ...) with --json
+//     pointing at <tempDir>/results.json
+//  4. cmd.Start() — non-blocking; we need the PID NOW.
+//  5. store.RecordScancodeLockState(repoID, pid, bootID, outputPath)
+//     so the next aveloxis startup can decide what to do with this
+//     row if we crash before cmd.Wait() returns.
+//  6. cmd.Wait() — blocks until subprocess exits.
+//  7. Parse JSON output, call existing RunScanCode-equivalent
+//     ingest logic to write scancode_scans + scancode_file_results.
+//  8. store.MarkScancodeComplete on success, ClearScancodeLock on
+//     failure.
+//  9. defer os.RemoveAll(tempDir).
+//
+// Errors at any step are logged (with repo identity) and route to
+// the ClearScancodeLock path. We never crash the runner on a
+// single repo's failure — the worker stays up.
+func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
+	tempDir := filepath.Join(w.cloneDir,
+		fmt.Sprintf("repo_%d_%d", job.RepoID, time.Now().UnixNano()))
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			w.logger.Warn("scancode worker failed to remove temp clone",
+				"repo_id", job.RepoID, "temp_dir", tempDir, "error", err)
+		}
+	}()
+
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		w.logger.Warn("scancode runOne mkdir failed",
+			"repo_id", job.RepoID, "error", err)
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	// Shallow clone — scancode only needs current file state, not
+	// history. --depth 1 dramatically reduces bandwidth for big
+	// repos (Linux kernel: full history ~3 GB, shallow ~500 MB).
+	cloneCmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--", job.RepoGit, tempDir)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		w.logger.Warn("scancode runOne git clone failed",
+			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+			"error", err, "git_output", string(out))
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	scancodePath, err := exec.LookPath("scancode")
+	if err != nil {
+		// Should never happen — Run() already checked. Defensive.
+		w.logger.Warn("scancode runOne: binary not on PATH at run time",
+			"repo_id", job.RepoID, "error", err)
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	outputPath := filepath.Join(tempDir, "results.json")
+	procs := 2
+
+	// Build the subprocess. Mirrors the legacy RunScanCode flag set
+	// so the JSON output format is identical and the existing
+	// parser + ingest path (reused below) keeps working.
+	cmd := exec.CommandContext(ctx, scancodePath,
+		"-clpi",
+		"--only-findings",
+		"--json", outputPath,
+		"--quiet",
+		"--timeout", "300",
+		"--processes", strconv.Itoa(procs),
+		"--max-in-memory", "5000",
+		tempDir,
+	)
+
+	// cmd.Start() is the key change from the legacy synchronous
+	// invocation: we need the OS PID BEFORE the subprocess
+	// finishes running, so we can persist it to scancode_locked_pid
+	// for crash recovery. A blocking exec call would only return
+	// the PID after the subprocess had already exited — useful
+	// for post-mortem reaping but no help to the recovery pass.
+	if err := cmd.Start(); err != nil {
+		w.logger.Warn("scancode runOne: cmd.Start() failed",
+			"repo_id", job.RepoID, "error", err)
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	pid := cmd.Process.Pid
+	bootID := readBootID()
+	if err := w.store.RecordScancodeLockState(ctx, job.RepoID, pid, bootID, outputPath); err != nil {
+		w.logger.Warn("scancode runOne: failed to record lock state — proceeding anyway",
+			"repo_id", job.RepoID, "pid", pid, "error", err)
+		// Don't abort the scan — the recovery path can still
+		// handle a lost lock state (it'll treat the row as
+		// "locked_at present, pid 0" which falls into the
+		// "lost run" bucket on next startup).
+	}
+
+	w.logger.Info("running ScanCode",
+		"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+		"path", tempDir, "pid", pid)
+
+	if err := cmd.Wait(); err != nil {
+		w.logger.Warn("scancode runOne: scancode subprocess failed",
+			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+			"error", err, "pid", pid)
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	// Parse + ingest. The legacy parser in scancode.go takes a
+	// localPath and re-invokes the binary; here we already have
+	// the output file, so we parse it directly via the helper.
+	version, err := ingestScancodeOutput(ctx, w.store, job.RepoID, outputPath, w.logger)
+	if err != nil {
+		w.logger.Warn("scancode runOne: ingest failed",
+			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+			"error", err)
+		w.clearLockBestEffort(ctx, job.RepoID)
+		return
+	}
+
+	if err := w.store.MarkScancodeComplete(ctx, job.RepoID, version); err != nil {
+		w.logger.Warn("scancode runOne: MarkScancodeComplete failed",
+			"repo_id", job.RepoID, "error", err)
+		// The scan succeeded and was ingested; only the
+		// completion-stamp write failed. The next claim cycle's
+		// cadence gate will see the recent scancode_scans row
+		// via the v0.21.0 backfill semantics on the next migrate
+		// run, OR re-run scancode (no harm — ingest is
+		// idempotent via RotateScancodeToHistory).
+		return
+	}
+
+	w.logger.Info("scancode worker complete",
+		"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+		"version", version, "pid", pid)
+}
+
+// clearLockBestEffort attempts to clear the lock and logs if it
+// fails. Uses a background context so a canceled ctx (graceful
+// shutdown) doesn't prevent the cleanup write.
+func (w *ScancodeWorker) clearLockBestEffort(ctx context.Context, repoID int64) {
+	// Try the live ctx first; fall back to background if canceled.
+	useCtx := ctx
+	if ctx.Err() != nil {
+		useCtx = context.Background()
+	}
+	if err := w.store.ClearScancodeLock(useCtx, repoID); err != nil {
+		w.logger.Warn("scancode runOne: ClearScancodeLock failed",
+			"repo_id", repoID, "error", err)
+	}
+}
+
+// recoverOrphans is the worker's one-shot startup pass. For each
+// row with a non-null scancode_locked_at it applies the four-state
+// decision documented in docs/architecture/scancode.md:
+//
+//  1. Reboot survivor — stored boot_id ≠ current boot_id. The
+//     scancode subprocess is definitively dead. Clear lock.
+//
+//  2. Live orphan — stored boot_id == current AND kill(-0, pid)
+//     succeeds. The scancode subprocess survived an aveloxis
+//     crash and is now an orphan of init. Spawn a monitor
+//     goroutine to wait for it to exit, then ingest if output is
+//     present.
+//
+//  3. Recoverable corpse — boot_id matches, PID is dead, output
+//     file exists and parses. Ingest then clear.
+//
+//  4. Lost run — boot_id matches, PID dead, no usable output.
+//     Clear lock.
+//
+// Runs synchronously: the dispatcher does NOT start until this
+// returns. Live orphans (case 2) get a monitor goroutine that
+// outlives recoverOrphans, but those goroutines hold their lock
+// rows so the dispatcher's claim query naturally skips them.
+func (w *ScancodeWorker) recoverOrphans(ctx context.Context) {
+	rows, err := w.store.ListLockedScancodeRows(ctx)
+	if err != nil {
+		w.logger.Warn("scancode recoverOrphans: ListLockedScancodeRows failed — proceeding without recovery",
+			"error", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	currentBootID := readBootID()
+	w.logger.Info("scancode recoverOrphans: examining locked rows",
+		"count", len(rows), "current_boot_id", currentBootID)
+
+	for _, r := range rows {
+		// State 1: reboot survivor.
+		if r.LockedBootID != "" && currentBootID != "" && r.LockedBootID != currentBootID {
+			w.logger.Info("scancode recover: reboot survivor — clearing lock",
+				"repo_id", r.RepoID, "owner", r.RepoOwner, "repo", r.RepoName,
+				"stored_boot_id", r.LockedBootID, "current_boot_id", currentBootID)
+			w.clearLockBestEffort(ctx, r.RepoID)
+			continue
+		}
+
+		// State 2: live orphan — subprocess survived our crash.
+		if r.LockedPID > 0 && pidAlive(r.LockedPID) {
+			w.logger.Info("scancode recover: live orphan detected — spawning monitor",
+				"repo_id", r.RepoID, "owner", r.RepoOwner, "repo", r.RepoName,
+				"pid", r.LockedPID, "output_path", r.OutputPath)
+			go w.monitorOrphan(ctx, r)
+			continue
+		}
+
+		// State 3: recoverable corpse — PID dead, output file
+		// looks ingestible. Try to ingest.
+		if r.OutputPath != "" && fileExistsAndNonEmpty(r.OutputPath) {
+			version, err := ingestScancodeOutput(ctx, w.store, r.RepoID, r.OutputPath, w.logger)
+			if err == nil {
+				w.logger.Info("scancode recover: ingested orphaned scancode result",
+					"repo_id", r.RepoID, "owner", r.RepoOwner, "repo", r.RepoName,
+					"version", version)
+				if err := w.store.MarkScancodeComplete(ctx, r.RepoID, version); err != nil {
+					w.logger.Warn("scancode recover: MarkScancodeComplete failed after corpse ingest",
+						"repo_id", r.RepoID, "error", err)
+				}
+				continue
+			}
+			w.logger.Info("scancode recover: corpse output unparseable — clearing lock",
+				"repo_id", r.RepoID, "owner", r.RepoOwner, "repo", r.RepoName,
+				"output_path", r.OutputPath, "error", err)
+		}
+
+		// State 4: lost run. Clear and move on.
+		w.logger.Info("scancode recover: lost run — clearing lock",
+			"repo_id", r.RepoID, "owner", r.RepoOwner, "repo", r.RepoName,
+			"pid", r.LockedPID)
+		w.clearLockBestEffort(ctx, r.RepoID)
+	}
+}
+
+// monitorOrphan polls a live-orphan scancode subprocess until it
+// exits, then ingests its output if present. Polling interval is
+// 30 seconds — orphaned scancode runs typically run for many
+// minutes to hours, so a tight poll would just burn CPU.
+func (w *ScancodeWorker) monitorOrphan(ctx context.Context, row db.ScancodeLockedRow) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Worker is shutting down. Leave the orphan alone —
+			// it'll be picked up by the next aveloxis startup's
+			// recovery pass.
+			return
+		case <-ticker.C:
+			if pidAlive(row.LockedPID) {
+				continue
+			}
+			// PID went away. Try to ingest the output.
+			if row.OutputPath != "" && fileExistsAndNonEmpty(row.OutputPath) {
+				version, err := ingestScancodeOutput(ctx, w.store, row.RepoID, row.OutputPath, w.logger)
+				if err == nil {
+					if mErr := w.store.MarkScancodeComplete(ctx, row.RepoID, version); mErr != nil {
+						w.logger.Warn("scancode orphan monitor: MarkScancodeComplete failed",
+							"repo_id", row.RepoID, "error", mErr)
+					} else {
+						w.logger.Info("scancode orphan monitor: orphan finished, output ingested",
+							"repo_id", row.RepoID, "owner", row.RepoOwner, "repo", row.RepoName,
+							"version", version)
+					}
+					return
+				}
+				w.logger.Info("scancode orphan monitor: orphan finished but output unparseable — clearing lock",
+					"repo_id", row.RepoID, "error", err)
+			} else {
+				w.logger.Info("scancode orphan monitor: orphan finished with no usable output — clearing lock",
+					"repo_id", row.RepoID)
+			}
+			w.clearLockBestEffort(ctx, row.RepoID)
+			return
+		}
+	}
+}
+
+// readBootID returns the kernel boot UUID from /proc on Linux. On
+// other systems (macOS dev machines), returns an empty string —
+// the recovery logic treats empty boot_ids as "unknown, can't make
+// a reboot decision" and falls through to the PID-liveness check.
+func readBootID() string {
+	data, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return ""
+	}
+	return string(bytesTrimSpace(data))
+}
+
+// bytesTrimSpace is a small allocation-free wrapper around the
+// common os.ReadFile + strings.TrimSpace pattern.
+func bytesTrimSpace(b []byte) []byte {
+	start, end := 0, len(b)
+	for start < end && isSpace(b[start]) {
+		start++
+	}
+	for end > start && isSpace(b[end-1]) {
+		end--
+	}
+	return b[start:end]
+}
+
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// pidAlive returns true if the given PID is a process we could
+// signal — i.e., it exists and we have permission to signal it.
+// Uses syscall.Kill(pid, 0) which only checks existence/permission
+// without actually delivering a signal. Works on Linux + Darwin.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	// nil = process exists and we can signal it.
+	// ESRCH = no such process.
+	// EPERM = process exists but we can't signal it (still alive
+	// from a liveness POV).
+	if err == nil {
+		return true
+	}
+	if errno, ok := err.(syscall.Errno); ok {
+		return errno == syscall.EPERM
+	}
+	return false
+}
+
+// fileExistsAndNonEmpty returns true if path refers to a regular
+// file with at least one byte. Used to decide whether a scancode
+// output file is worth attempting to parse.
+func fileExistsAndNonEmpty(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir() && info.Size() > 0
+}

--- a/internal/collector/scancode_worker_test.go
+++ b/internal/collector/scancode_worker_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.0 — ScancodeWorker source-contract tests.
+//
+// These tests pin the structural invariants of internal/collector/
+// scancode_worker.go so a future refactor can't accidentally regress
+// the architectural decisions documented in
+// docs/architecture/scancode.md.
+//
+// The 2026-05-14 production incident showed 177 of 180 collection
+// workers parked at internal/collector/scancode.go:114 (the 2-slot
+// semaphore) for 7+ hours. The new architecture moves scancode out
+// of the per-job pipeline entirely; these tests ensure no future
+// change re-introduces the coupling.
+
+func readScancodeWorkerSource(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("scancode_worker.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestScancodeWorkerHasRunMethod(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	if !strings.Contains(src, "func (w *ScancodeWorker) Run(ctx context.Context)") {
+		t.Error("ScancodeWorker must declare Run(ctx context.Context). The scheduler invokes this as a goroutine alongside the main collection loop.")
+	}
+}
+
+func TestScancodeWorkerCallsRecoverBeforeDispatcher(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find Run method")
+	}
+	body := src[idx:]
+	recoverIdx := strings.Index(body, "w.recoverOrphans(")
+	dispatchIdx := strings.Index(body, "w.dispatcher(")
+	if recoverIdx < 0 || dispatchIdx < 0 || recoverIdx > dispatchIdx {
+		t.Error("Run() must call w.recoverOrphans(ctx) BEFORE w.dispatcher(...). If a previous aveloxis serve exited with in-flight scancode subprocesses (kill -9 or OOM), the recovery pass must adopt or clear those orphans before new claims happen — otherwise the dispatcher would see locked rows and skip them indefinitely.")
+	}
+}
+
+func TestRunOneSplitsStartFromWait(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) runOne(")
+	if idx < 0 {
+		t.Fatal("cannot find runOne method")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	if !strings.Contains(body, "cmd.Start()") {
+		t.Error("runOne must call cmd.Start() (not cmd.Run()). We need the OS PID before the scan starts so we can persist it to scancode_locked_pid; cmd.Run() doesn't return until the subprocess exits.")
+	}
+	if !strings.Contains(body, "cmd.Wait()") {
+		t.Error("runOne must call cmd.Wait() after cmd.Start() to wait for scan completion.")
+	}
+	if strings.Contains(body, "cmd.Run()") {
+		t.Error("runOne must NOT call cmd.Run() — use cmd.Start() + cmd.Wait() so the PID is captured before waiting. The split is what makes crash recovery work: if aveloxis crashes between Start() and Wait(), the recovery pass sees scancode_locked_pid and can decide whether to adopt or clear.")
+	}
+}
+
+func TestRunOnePersistsPidAndBootId(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) runOne(")
+	if idx < 0 {
+		t.Fatal("cannot find runOne method")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// The runOne body must reach for store methods that persist
+	// PID + boot_id BEFORE Wait() starts. The actual method call
+	// is one of RecordScancodeLockState or SetScancodeLockState.
+	if !strings.Contains(body, "RecordScancodeLockState(") {
+		t.Error("runOne must call store.RecordScancodeLockState(ctx, repoID, pid, bootID, outputPath) AFTER cmd.Start() but BEFORE cmd.Wait(). Without persisting the (pid, boot_id, output_path) tuple, a crash between Start and Wait leaves an orphan with no row-level state for the recovery pass to find.")
+	}
+}
+
+func TestRunOneClearsLockOnSuccess(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	if !strings.Contains(src, "MarkScancodeComplete(") {
+		t.Error("runOne must call store.MarkScancodeComplete(ctx, repoID, version) on successful scan completion. This sets scancode_last_run = NOW(), scancode_version = $version, and clears all 4 lock columns in one UPDATE.")
+	}
+}
+
+func TestRunOneClearsLockOnFailure(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	if !strings.Contains(src, "ClearScancodeLock(") {
+		t.Error("runOne must call store.ClearScancodeLock(ctx, repoID) on failure paths (clone error, scancode crash, output parse error). Without this, a failure leaves scancode_locked_at populated and the row gets stuck waiting for the 12h stale-lock fallback before becoming re-eligible.")
+	}
+}
+
+func TestClaimUsesForUpdateSkipLocked(t *testing.T) {
+	// The claim SQL lives in the db package, but the worker's
+	// store method is named ClaimNextScancodeRepo.
+	data, err := os.ReadFile("../db/scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "FOR UPDATE SKIP LOCKED") {
+		t.Error("ClaimNextScancodeRepo's SQL must use FOR UPDATE SKIP LOCKED on the candidate CTE. Without it, concurrent claim attempts from multiple worker dispatchers could double-claim the same row.")
+	}
+}
+
+func TestClaimGatesOnLastCollected(t *testing.T) {
+	data, err := os.ReadFile("../db/scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "last_collected IS NOT NULL") {
+		t.Error("ClaimNextScancodeRepo must filter on q.last_collected IS NOT NULL — per the v0.21.0 plan, scancode does NOT run on repos that have never been collected. Newly added repos collect basic metrics first, then enter scancode eligibility.")
+	}
+}
+
+func TestClaimGatesOnCadenceAndStaleLock(t *testing.T) {
+	data, err := os.ReadFile("../db/scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// Cadence check: never-scanned OR past cadence window.
+	if !strings.Contains(src, "scancode_last_run IS NULL") {
+		t.Error("ClaimNextScancodeRepo must filter on scancode_last_run IS NULL OR scancode_last_run < NOW() - cadence")
+	}
+	// 12-hour stale-lock filter so a row whose previous runner
+	// crashed silently can be re-claimed (the recovery pass
+	// handles the noisy case; this is the silent-corpse fallback).
+	if !strings.Contains(src, "scancode_locked_at IS NULL") {
+		t.Error("ClaimNextScancodeRepo must filter rows whose scancode_locked_at is NULL OR older than the stale-lock window so an interrupted prior run doesn't permanently lock the row")
+	}
+}
+
+func TestClaimExcludesArchivedRepos(t *testing.T) {
+	data, err := os.ReadFile("../db/scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "repo_archived") {
+		t.Error("ClaimNextScancodeRepo must exclude archived repos via COALESCE(repo_archived, FALSE) = FALSE. The supporting index (idx_repos_scancode_due) is partial on this predicate, so the WHERE clause must match exactly for the planner to use it.")
+	}
+}
+
+func TestScancodeWorkerSkipsWhenBinaryMissing(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find Run method")
+	}
+	body := src[idx:]
+	if !strings.Contains(body, "exec.LookPath") {
+		t.Error("ScancodeWorker.Run must probe exec.LookPath(\"scancode\") at startup. When the binary is absent, the worker must log ONE INFO line and exit without spawning goroutines. Matches the existing pre-v0.21.0 behavior of silently skipping the analysis phase when scancode isn't installed.")
+	}
+}
+
+func TestDispatcherUsesStartTicker(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	if !strings.Contains(src, "time.NewTicker(w.startInterval)") {
+		t.Error("dispatcher must use time.NewTicker(w.startInterval) to pace claim attempts. Without the ticker, every dispatcher iteration would try to claim immediately, defeating the operator-configured start_interval that bounds clone-bandwidth bursts on restart.")
+	}
+}
+
+func TestGracefulShutdownUsesWaitGroupAndGrace(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) Run(")
+	if idx < 0 {
+		t.Fatal("cannot find Run method")
+	}
+	body := src[idx:]
+	if !strings.Contains(body, "sync.WaitGroup") && !strings.Contains(src, "sync.WaitGroup") {
+		t.Error("Run must use sync.WaitGroup to track in-flight runner goroutines. On ctx.Done(), Run must wait for all runners to finish (up to ShutdownGrace) before returning so the scheduler's pool-close happens AFTER scancode runners have updated DB state.")
+	}
+	if !strings.Contains(src, "shutdownGrace") {
+		t.Error("Run must reference w.shutdownGrace. Without a grace budget, a 4-hour Linux-kernel scan would block `aveloxis stop` for the full duration.")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,6 +272,82 @@ type CollectionConfig struct {
 	// abort mid-flight (Postgres rolls them back; safe but log-noisy);
 	// too high means a slow shutdown. 10 seconds matches the pollInterval.
 	ShutdownGraceSeconds int `json:"shutdown_grace_seconds"`
+
+	// v0.21.0 — Scancode is now run by a dedicated ScancodeWorker pool
+	// rather than inline in AnalysisCollector.AnalyzeRepo. The 2026-05-14
+	// production incident showed that gating scancode behind a 2-slot
+	// package-level semaphore at fleet scale parked 177 of 180 collection
+	// workers behind the queue for 7+ hours. The decoupled pool runs in
+	// its own goroutines, never blocks the main collection cycle, and
+	// re-clones repos shallowly on demand so scancode runs are
+	// independent of facade/analysis state.
+	//
+	// ScancodeWorkers is the maximum concurrent scancode invocations.
+	// Default 2 when unset — matches pre-v0.21.0 concurrency so
+	// operators upgrading don't see a sudden change in scancode CPU
+	// load. Operators on machines with spare CPU cores should raise
+	// this (operator running aveloxis_large at 64 cores has tested 12
+	// without issues).
+	ScancodeWorkers int `json:"scancode_workers"`
+
+	// ScancodeStartIntervalSec is the minimum time between consecutive
+	// scancode CLAIM operations. Default 90 seconds when unset.
+	// Different from the inter-completion time: the ticker fires every
+	// 90s and the dispatcher attempts a new claim. If no slot is free
+	// the tick is a no-op; if one is free the claim happens.
+	//
+	// Pacing reasoning: each scancode start triggers a shallow git
+	// clone followed by a scancode invocation. The 90s gate prevents
+	// new clones from bursting the network/disk when the operator
+	// wakes a freshly-restarted aveloxis serve with hundreds of
+	// eligible repos.
+	ScancodeStartIntervalSec int `json:"scancode_start_interval_s"`
+
+	// ScancodeCadenceDays is the minimum interval between successive
+	// scancode runs on the same repo. Default 180 days (6 months) when
+	// unset. Pre-v0.21.0 was 30 days; the change reflects that
+	// per-file license + copyright headers in source files change
+	// rarely on the timescale we care about, and the I/O cost of
+	// scanning a Linux-kernel-scale mirror doesn't justify monthly
+	// re-scans.
+	//
+	// Dependency-level licenses (which DO change as packages are
+	// updated) still flow through the per-cycle Phase 4 dependency
+	// scan + Phase 6 SBOM generation; scancode is specifically the
+	// per-source-file scan and benefits from a longer cadence.
+	ScancodeCadenceDays int `json:"scancode_cadence_days"`
+
+	// ScancodeCloneDir is the parent directory for the per-run
+	// shallow clones the ScancodeWorker creates. Each scan creates
+	// <ScancodeCloneDir>/repo_<id>_<unix_ts> and removes it on
+	// completion (success or failure). Default
+	// "/tmp/aveloxis-scancode" when unset.
+	//
+	// Disk-space budget: each clone is the working tree only
+	// (`git clone --depth 1`), so size ≈ checked-out repo size. With
+	// the default 2 workers and average ~50 MB clones, ~100 MB peak.
+	// On a fleet with 12 workers and Linux-kernel-scale repos, peak
+	// can reach several GB; size /tmp accordingly or set
+	// scancode_clone_dir to a dedicated mount.
+	ScancodeCloneDir string `json:"scancode_clone_dir"`
+
+	// ScancodeShutdownGraceMinutes caps how long the ScancodeWorker
+	// waits for in-flight scans to finish on aveloxis stop. Default
+	// 30 minutes when unset.
+	//
+	// Within the grace window: runners complete their scans naturally
+	// (parsing scancode JSON output, writing results to the DB,
+	// clearing lock columns). At grace expiry: the worker calls
+	// cmd.Process.Kill() on the still-running scancode subprocess,
+	// which causes cmd.Wait() to return with an error, which triggers
+	// the runner's lock-clear path. No orphaned scans from graceful
+	// shutdown.
+	//
+	// Separate from collection.shutdown_grace_seconds (which paces
+	// the main scheduler's stop). 30 min is much longer than 10s
+	// because scancode runs are intrinsically long-running on big
+	// repos and you usually want them to finish if they're close.
+	ScancodeShutdownGraceMinutes int `json:"scancode_shutdown_grace_minutes"`
 }
 
 // EnrichIntervalDuration converts EnrichIntervalMinutes to a time.Duration.
@@ -337,6 +413,60 @@ func (c *CollectionConfig) BreadthCooldownDuration() time.Duration {
 		return 7 * 24 * time.Hour
 	}
 	return time.Duration(c.BreadthCooldownDays) * 24 * time.Hour
+}
+
+// defaultScancodeCloneDir returns the default scancode clone parent
+// directory. Kept as a function (not a constant) so unit tests can
+// adjust on OSes where /tmp is unconventional. Mirrors the pattern in
+// defaultCloneDir for the main collection clone directory.
+func defaultScancodeCloneDir() string {
+	return "/tmp/aveloxis-scancode"
+}
+
+// ScancodeWorkersOrDefault returns ScancodeWorkers or 2 when unset
+// (v0.21.0). Default 2 matches pre-v0.21.0 hardcoded concurrency. See
+// CollectionConfig.ScancodeWorkers for the tuning rationale.
+func (c *CollectionConfig) ScancodeWorkersOrDefault() int {
+	if c.ScancodeWorkers <= 0 {
+		return 2
+	}
+	return c.ScancodeWorkers
+}
+
+// ScancodeStartInterval converts ScancodeStartIntervalSec to a
+// time.Duration. Falls back to 90 seconds when unset.
+func (c *CollectionConfig) ScancodeStartInterval() time.Duration {
+	if c.ScancodeStartIntervalSec <= 0 {
+		return 90 * time.Second
+	}
+	return time.Duration(c.ScancodeStartIntervalSec) * time.Second
+}
+
+// ScancodeCadence converts ScancodeCadenceDays to a time.Duration.
+// Falls back to 180 days (6 months) when unset.
+func (c *CollectionConfig) ScancodeCadence() time.Duration {
+	if c.ScancodeCadenceDays <= 0 {
+		return 180 * 24 * time.Hour
+	}
+	return time.Duration(c.ScancodeCadenceDays) * 24 * time.Hour
+}
+
+// ScancodeCloneDirOrDefault returns ScancodeCloneDir or the default
+// "/tmp/aveloxis-scancode" when unset.
+func (c *CollectionConfig) ScancodeCloneDirOrDefault() string {
+	if c.ScancodeCloneDir == "" {
+		return defaultScancodeCloneDir()
+	}
+	return c.ScancodeCloneDir
+}
+
+// ScancodeShutdownGrace converts ScancodeShutdownGraceMinutes to a
+// time.Duration. Falls back to 30 minutes when unset.
+func (c *CollectionConfig) ScancodeShutdownGrace() time.Duration {
+	if c.ScancodeShutdownGraceMinutes <= 0 {
+		return 30 * time.Minute
+	}
+	return time.Duration(c.ScancodeShutdownGraceMinutes) * time.Minute
 }
 
 // MailConfig configures the Gmail-backed transactional mailer
@@ -442,6 +572,13 @@ func DefaultConfig() *Config {
 			ListingMode:             "rest",
 			ThreadingMode:           "single",
 			ShardSize:               3000,
+			// v0.21.0 ScancodeWorker defaults — see CollectionConfig
+			// field docs for the full rationale.
+			ScancodeWorkers:              2,
+			ScancodeStartIntervalSec:     90,
+			ScancodeCadenceDays:          180,
+			ScancodeCloneDir:             defaultScancodeCloneDir(),
+			ScancodeShutdownGraceMinutes: 30,
 		},
 		LogLevel: "info",
 	}

--- a/internal/config/scancode_knobs_test.go
+++ b/internal/config/scancode_knobs_test.go
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// v0.21.0 — Scancode is now run by a dedicated ScancodeWorker pool
+// rather than inline in the per-job analysis phase. Five new config
+// knobs control the pool's behavior. Pre-v0.21.0 the cadence (30 days)
+// and concurrency (2) were hardcoded in internal/collector/scancode.go;
+// the 2026-05-14 production incident showed that for a fleet-scale
+// install the operator needs to be able to tune both. The other knobs
+// (start interval, clone directory, shutdown grace) are new
+// requirements of the decoupled worker.
+
+func TestCollectionConfigHasScancodeKnobs(t *testing.T) {
+	data, err := os.ReadFile("config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Pin field names + JSON tags. Whitespace between field name and
+	// type is gofmt-controlled and not stable across formatter
+	// upgrades, so check each token independently.
+	required := []string{
+		"ScancodeWorkers",
+		`json:"scancode_workers"`,
+		"ScancodeStartIntervalSec",
+		`json:"scancode_start_interval_s"`,
+		"ScancodeCadenceDays",
+		`json:"scancode_cadence_days"`,
+		"ScancodeCloneDir",
+		`json:"scancode_clone_dir"`,
+		"ScancodeShutdownGraceMinutes",
+		`json:"scancode_shutdown_grace_minutes"`,
+	}
+	for _, needle := range required {
+		if !strings.Contains(src, needle) {
+			t.Errorf("CollectionConfig must declare the v0.21.0 scancode knobs. Missing: %q", needle)
+		}
+	}
+}
+
+func TestScancodeWorkersDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Collection.ScancodeWorkers != 2 {
+		t.Errorf("DefaultConfig().Collection.ScancodeWorkers = %d; want 2. Default matches pre-v0.21.0 concurrency so operators upgrading don't surprise themselves with a sudden increase in scancode load. Operators on large fleets are expected to raise this.", cfg.Collection.ScancodeWorkers)
+	}
+}
+
+func TestScancodeStartIntervalDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Collection.ScancodeStartIntervalSec != 90 {
+		t.Errorf("DefaultConfig().Collection.ScancodeStartIntervalSec = %d; want 90. 90 seconds between scancode worker claims paces clone-bandwidth bursts on large fleets without throttling small fleets perceptibly.", cfg.Collection.ScancodeStartIntervalSec)
+	}
+	d := cfg.Collection.ScancodeStartInterval()
+	if d != 90*time.Second {
+		t.Errorf("ScancodeStartInterval() = %v; want 90s", d)
+	}
+}
+
+func TestScancodeCadenceDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Collection.ScancodeCadenceDays != 180 {
+		t.Errorf("DefaultConfig().Collection.ScancodeCadenceDays = %d; want 180 (6 months). Pre-v0.21.0 was 30 days; 6 months is a better fit because per-file license + copyright headers in source files are near-immutable on the timescale we care about, and the I/O cost of scanning a Linux-kernel-scale repo doesn't justify monthly re-scans.", cfg.Collection.ScancodeCadenceDays)
+	}
+	d := cfg.Collection.ScancodeCadence()
+	want := 180 * 24 * time.Hour
+	if d != want {
+		t.Errorf("ScancodeCadence() = %v; want %v", d, want)
+	}
+}
+
+func TestScancodeCloneDirDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Collection.ScancodeCloneDir == "" {
+		t.Error("DefaultConfig().Collection.ScancodeCloneDir must be non-empty. The ScancodeWorker creates fresh per-run clones under this directory; an empty default would leave operators creating /etc/aveloxis-scancode by accident on first scan.")
+	}
+}
+
+func TestScancodeShutdownGraceDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Collection.ScancodeShutdownGraceMinutes != 30 {
+		t.Errorf("DefaultConfig().Collection.ScancodeShutdownGraceMinutes = %d; want 30. 30 min lets most scancode runs finish naturally on aveloxis stop; longer scans (Linux-kernel-sized) get killed at the grace boundary so operators don't wait hours for a clean shutdown.", cfg.Collection.ScancodeShutdownGraceMinutes)
+	}
+	d := cfg.Collection.ScancodeShutdownGrace()
+	if d != 30*time.Minute {
+		t.Errorf("ScancodeShutdownGrace() = %v; want 30m", d)
+	}
+}
+
+func TestScancodeAccessorsFallBackToDefaults(t *testing.T) {
+	// Zero values for the int fields should map to the documented
+	// defaults (operators with a pre-v0.21.0 aveloxis.json keep
+	// working without edits).
+	c := CollectionConfig{}
+	if c.ScancodeWorkersOrDefault() != 2 {
+		t.Errorf("ScancodeWorkersOrDefault() with zero = %d; want 2", c.ScancodeWorkersOrDefault())
+	}
+	if c.ScancodeStartInterval() != 90*time.Second {
+		t.Errorf("ScancodeStartInterval() with zero = %v; want 90s", c.ScancodeStartInterval())
+	}
+	if c.ScancodeCadence() != 180*24*time.Hour {
+		t.Errorf("ScancodeCadence() with zero = %v; want 180d", c.ScancodeCadence())
+	}
+	if c.ScancodeShutdownGrace() != 30*time.Minute {
+		t.Errorf("ScancodeShutdownGrace() with zero = %v; want 30m", c.ScancodeShutdownGrace())
+	}
+	if c.ScancodeCloneDirOrDefault() == "" {
+		t.Error("ScancodeCloneDirOrDefault() with zero must return a non-empty default path")
+	}
+}
+
+func TestScancodeAccessorsHonorExplicitValues(t *testing.T) {
+	c := CollectionConfig{
+		ScancodeWorkers:              12,
+		ScancodeStartIntervalSec:     45,
+		ScancodeCadenceDays:          90,
+		ScancodeCloneDir:             "/var/lib/aveloxis-scancode",
+		ScancodeShutdownGraceMinutes: 60,
+	}
+	if c.ScancodeWorkersOrDefault() != 12 {
+		t.Errorf("ScancodeWorkersOrDefault() = %d; want 12", c.ScancodeWorkersOrDefault())
+	}
+	if c.ScancodeStartInterval() != 45*time.Second {
+		t.Errorf("ScancodeStartInterval() = %v; want 45s", c.ScancodeStartInterval())
+	}
+	if c.ScancodeCadence() != 90*24*time.Hour {
+		t.Errorf("ScancodeCadence() = %v; want 90d", c.ScancodeCadence())
+	}
+	if c.ScancodeCloneDirOrDefault() != "/var/lib/aveloxis-scancode" {
+		t.Errorf("ScancodeCloneDirOrDefault() = %q; want /var/lib/aveloxis-scancode", c.ScancodeCloneDirOrDefault())
+	}
+	if c.ScancodeShutdownGrace() != 60*time.Minute {
+		t.Errorf("ScancodeShutdownGrace() = %v; want 60m", c.ScancodeShutdownGrace())
+	}
+}
+
+func TestScancodeJSONRoundTrip(t *testing.T) {
+	// Ensure aveloxis.json's `collection.scancode_*` keys actually
+	// land on the config struct's fields. A typo on either side would
+	// silently no-op without this test.
+	in := `{
+		"collection": {
+			"scancode_workers": 12,
+			"scancode_start_interval_s": 45,
+			"scancode_cadence_days": 90,
+			"scancode_clone_dir": "/var/lib/aveloxis-scancode",
+			"scancode_shutdown_grace_minutes": 60
+		}
+	}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(in), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Collection.ScancodeWorkers != 12 {
+		t.Errorf("ScancodeWorkers from JSON = %d; want 12", cfg.Collection.ScancodeWorkers)
+	}
+	if cfg.Collection.ScancodeStartIntervalSec != 45 {
+		t.Errorf("ScancodeStartIntervalSec from JSON = %d; want 45", cfg.Collection.ScancodeStartIntervalSec)
+	}
+	if cfg.Collection.ScancodeCadenceDays != 90 {
+		t.Errorf("ScancodeCadenceDays from JSON = %d; want 90", cfg.Collection.ScancodeCadenceDays)
+	}
+	if cfg.Collection.ScancodeCloneDir != "/var/lib/aveloxis-scancode" {
+		t.Errorf("ScancodeCloneDir from JSON = %q", cfg.Collection.ScancodeCloneDir)
+	}
+	if cfg.Collection.ScancodeShutdownGraceMinutes != 60 {
+		t.Errorf("ScancodeShutdownGraceMinutes from JSON = %d; want 60", cfg.Collection.ScancodeShutdownGraceMinutes)
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -177,6 +177,40 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// the worker kept reselecting the same dead-end users.
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.contributors", "cntrb_last_breadth_at", "TIMESTAMPTZ")
 
+	// v0.21.0 — ScancodeWorker state on aveloxis_data.repos.
+	//
+	// Decouples the scancode per-file license + copyright + package
+	// scan from the per-repo collection pipeline. Pre-v0.21.0, scancode
+	// ran inside AnalysisCollector.AnalyzeRepo gated by a 2-slot
+	// package-level semaphore. The 2026-05-14 production incident
+	// (177 of 180 worker goroutines parked at scancode.go:114 for
+	// 7+ hours, queue depth growing monotonically) showed that semaphore
+	// shape doesn't survive fleet-scale operation. The ScancodeWorker
+	// pool runs in its own goroutines, claims eligible repos via the
+	// claim SQL below, and never blocks the main collection cycle.
+	//
+	// Six new columns. scancode_last_run + scancode_version capture
+	// completion state. scancode_locked_at + scancode_locked_pid +
+	// scancode_locked_boot_id capture in-flight state across restarts
+	// — the boot_id field is the kernel boot UUID from
+	// /proc/sys/kernel/random/boot_id, paired with the OS PID so the
+	// worker's recovery logic can distinguish "scan still running as
+	// orphan after aveloxis crashed" from "scan died, PID was reused
+	// by an unrelated process after reboot". scancode_output_path
+	// records where the subprocess writes results.json so the
+	// recovery monitor knows where to look when it observes the
+	// orphan exit.
+	//
+	// Full lock state machine — including the four post-restart states
+	// (reboot survivor, live orphan, recoverable corpse, lost run) —
+	// is documented in docs/architecture/scancode.md.
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_last_run", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_version", "TEXT")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_locked_at", "TIMESTAMPTZ")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_locked_pid", "INTEGER")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_locked_boot_id", "TEXT")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_output_path", "TEXT")
+
 	// Commits: deduplicate and add unique index (added in v0.7.5).
 	// Previous versions had no ON CONFLICT on commits INSERT, so re-collection
 	// created duplicate rows. Clean up first, then create the unique index.
@@ -236,6 +270,25 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		"aveloxis_data", "idx_contributors_gh_login",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_gh_login
 		ON aveloxis_data.contributors (gh_login) WHERE gh_login != ''`)
+
+	// v0.21.0 — ScancodeWorker claim-query index.
+	//
+	// The worker runs a claim query roughly every
+	// collection.scancode_start_interval_s seconds (default 90),
+	// against ALL repos. Without an index the planner falls back to a
+	// sequential scan of repos every claim — at fleet scale that's
+	// hundreds of thousands of rows examined per minute, all
+	// returning the same eligible head.
+	//
+	// Partial: WHERE COALESCE(repo_archived, FALSE) = FALSE excludes
+	// repos whose owning org marked them as archived (we never scan
+	// those). NULLS FIRST on scancode_last_run sorts never-scanned
+	// repos to the front, mirroring the claim query's ORDER BY.
+	execCreateIndexConcurrently(ctx, pg, logger, &errs,
+		"aveloxis_data", "idx_repos_scancode_due",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_scancode_due
+		ON aveloxis_data.repos (scancode_last_run NULLS FIRST)
+		WHERE COALESCE(repo_archived, FALSE) = FALSE`)
 
 	// collection_queue.last_commits backfill (v0.19.11). Pre-v0.19.11
 	// the FacadeCollector incremented result.Commits once per inserted
@@ -376,6 +429,40 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		    force_full_collect = FALSE
 		WHERE last_commits > 0
 		  AND last_error LIKE 'no data collected%'`)
+
+	// v0.21.0 backfill scancode_last_run from aveloxis_scan.scancode_scans.
+	//
+	// Pre-v0.21.0 scancode results were tracked exclusively via the
+	// aveloxis_scan.scancode_scans rows (one per scan run, with a
+	// created_at timestamp). The v0.21.0 ScancodeWorker reads its
+	// cadence gate off aveloxis_data.repos.scancode_last_run instead;
+	// this backfill seeds that column from the existing scancode_scans
+	// history so repos already scanned in the past 6 months don't all
+	// re-scan on first v0.21.0 startup. Repos with no prior scan stay
+	// at NULL and sort to the front of the worker's claim queue
+	// naturally.
+	//
+	// The ARRAY_AGG(... ORDER BY created_at DESC)[1] picks the
+	// scancode_version from the most-recent scan in case different
+	// versions ran historically.
+	//
+	// Idempotent: WHERE r.scancode_last_run IS NULL on the outer
+	// UPDATE means a second migrate run is a no-op once backfill
+	// completes. Wrapped in execMigrationStep per the v0.19.4
+	// fail-closed contract.
+	execMigrationStep(ctx, pg, logger, &errs, "v0.21.0 backfill scancode_last_run from aveloxis_scan.scancode_scans",
+		`UPDATE aveloxis_data.repos r
+		SET scancode_last_run = sub.last_at,
+		    scancode_version = sub.last_version
+		FROM (
+		    SELECT repo_id,
+		           MAX(created_at) AS last_at,
+		           (ARRAY_AGG(scancode_version ORDER BY created_at DESC))[1] AS last_version
+		    FROM aveloxis_scan.scancode_scans
+		    GROUP BY repo_id
+		) sub
+		WHERE r.repo_id = sub.repo_id
+		  AND r.scancode_last_run IS NULL`)
 
 	// Users table: dedupe + enforce PK/UNIQUE (v0.18.9).
 	// Older installs used CREATE TABLE IF NOT EXISTS with inline UNIQUE, which

--- a/internal/db/scancode_schema_test.go
+++ b/internal/db/scancode_schema_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.0 — Scancode is decoupled from the main collection pipeline and
+// runs in a separate ScancodeWorker pool. The schema changes that
+// support the worker live on aveloxis_data.repos and are exercised by
+// claim/recover SQL inside the worker. Pre-v0.21.0, scancode ran
+// inline in AnalysisCollector.AnalyzeRepo gated by a 2-slot semaphore;
+// the 2026-05-14 production incident showed 177 of 180 workers
+// queued behind that semaphore for 7+ hours, effectively stalling the
+// whole fleet. The new architecture moves the work off the per-job
+// hot path entirely.
+//
+// Six columns are added to aveloxis_data.repos:
+//   - scancode_last_run        TIMESTAMPTZ  — when the last successful scan completed
+//   - scancode_version         TEXT         — version of the scancode binary that ran
+//   - scancode_locked_at       TIMESTAMPTZ  — when the in-flight scan started; NULL when idle
+//   - scancode_locked_pid      INTEGER      — OS PID of the scancode subprocess
+//   - scancode_locked_boot_id  TEXT         — kernel boot_id at lock time (PID-reuse safety)
+//   - scancode_output_path     TEXT         — where the subprocess writes results.json
+//
+// Plus a partial index supporting the worker's claim query, and an
+// idempotent backfill from aveloxis_scan.scancode_scans so repos
+// already scanned before v0.21.0 don't get re-scanned immediately.
+
+func TestSchemaHasScancodeColumns(t *testing.T) {
+	data, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	needles := []string{
+		"scancode_last_run",
+		"scancode_version",
+		"scancode_locked_at",
+		"scancode_locked_pid",
+		"scancode_locked_boot_id",
+		"scancode_output_path",
+	}
+	for _, n := range needles {
+		if !strings.Contains(src, n) {
+			t.Errorf("schema.sql must declare %s on aveloxis_data.repos — the v0.21.0 ScancodeWorker depends on it to claim repos, track in-flight subprocesses across restarts, and recover orphans without losing data", n)
+		}
+	}
+}
+
+func TestMigrateAddsScancodeColumns(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	columnTypes := map[string]string{
+		"scancode_last_run":       "TIMESTAMPTZ",
+		"scancode_version":        "TEXT",
+		"scancode_locked_at":      "TIMESTAMPTZ",
+		"scancode_locked_pid":     "INTEGER",
+		"scancode_locked_boot_id": "TEXT",
+		"scancode_output_path":    "TEXT",
+	}
+	for col, typ := range columnTypes {
+		needle := `addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "` + col + `", "` + typ + `"`
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must call addColumnIfMissing for aveloxis_data.repos.%s (%s). Operators upgrading from <v0.21.0 need the column added automatically; missing it would break ScancodeWorker startup", col, typ)
+		}
+	}
+}
+
+func TestMigrateCreatesScancodeDueIndex(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// Partial index excludes archived repos; orders NULLS FIRST so
+	// never-scanned repos sort to the front of the worker's claim
+	// query.
+	for _, needle := range []string{
+		"idx_repos_scancode_due",
+		"scancode_last_run NULLS FIRST",
+		"WHERE COALESCE(repo_archived, FALSE) = FALSE",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must create idx_repos_scancode_due (partial, NULLS FIRST, excludes archived). Missing needle: %q. Without the index, the ScancodeWorker's claim query falls back to a sequential scan of repos every 90 seconds", needle)
+		}
+	}
+}
+
+func TestMigrationBackfillsFromScancodeScans(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	// The backfill must:
+	//   1. Pull MAX(created_at) and most-recent scancode_version per repo
+	//      from aveloxis_scan.scancode_scans
+	//   2. Filter `WHERE r.scancode_last_run IS NULL` for idempotency
+	//      (re-running migrate is a no-op once backfill completes)
+	//   3. Use execMigrationStep so failures surface via the v0.19.4
+	//      fail-closed contract
+	for _, needle := range []string{
+		"v0.21.0 backfill scancode_last_run from aveloxis_scan.scancode_scans",
+		"aveloxis_scan.scancode_scans",
+		"MAX(created_at)",
+		"r.scancode_last_run IS NULL",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must backfill scancode_last_run + scancode_version from existing aveloxis_scan.scancode_scans rows so v0.20-era scanned repos don't all re-scan on first v0.21.0 startup. Missing needle: %q", needle)
+		}
+	}
+}

--- a/internal/db/scancode_store.go
+++ b/internal/db/scancode_store.go
@@ -44,6 +44,39 @@ func (s *PostgresStore) ScancodeLastRun(ctx context.Context, repoID int64) (time
 	return t, nil
 }
 
+// ScancodeFreshness returns the v0.21.0 scancode_last_run timestamp
+// and scancode_version string off aveloxis_data.repos. Both values
+// are NULL-tolerant: a repo with no scancode_last_run returns
+// (zero-time, "", nil) — the API surfaces "not yet run" to the
+// user instead of an error.
+//
+// Reads from aveloxis_data.repos (NOT aveloxis_scan.scancode_scans)
+// because the ScancodeWorker writes the freshness columns
+// atomically alongside the scan inserts in MarkScancodeComplete.
+// This gives a single source of truth for "when did this repo last
+// successfully complete scancode" that the dashboard can rely on
+// without joining scancode_scans + max(date) on every render.
+func (s *PostgresStore) ScancodeFreshness(ctx context.Context, repoID int64) (time.Time, string, error) {
+	var lastRun *time.Time
+	var version *string
+	err := s.pool.QueryRow(ctx, `
+		SELECT scancode_last_run, scancode_version
+		FROM aveloxis_data.repos
+		WHERE repo_id = $1`, repoID).Scan(&lastRun, &version)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	var t time.Time
+	if lastRun != nil {
+		t = *lastRun
+	}
+	var v string
+	if version != nil {
+		v = *version
+	}
+	return t, v, nil
+}
+
 // InsertScancodeScan inserts a scan metadata row and returns the scan_id.
 func (s *PostgresStore) InsertScancodeScan(ctx context.Context, repoID int64, scancodeVersion string, filesScanned, filesWithFindings int, durationSecs float64, scanErrors json.RawMessage) (int64, error) {
 	var scanID int64

--- a/internal/db/scancode_worker_store.go
+++ b/internal/db/scancode_worker_store.go
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Package db — scancode_worker_store.go contains the store methods
+// the v0.21.0 ScancodeWorker uses to claim repos, persist lock state
+// across restarts, and recover orphans after an ungraceful exit.
+//
+// See docs/architecture/scancode.md for the architectural rationale
+// and the four-state recovery table.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ScancodeStaleLockWindow is how long a scancode_locked_at value can
+// be without forcing the recovery pass to treat the row as a silent
+// corpse. Generous because Linux-kernel-sized scancode runs can
+// legitimately take many hours. Recovery via the explicit
+// recoverOrphans pass (PID + boot_id check) is the primary path;
+// this window is just the silent-fallback safety net.
+const ScancodeStaleLockWindow = 12 * time.Hour
+
+// ScancodeJob is the unit of work the ScancodeWorker dispatcher
+// hands to a runner goroutine.
+type ScancodeJob struct {
+	RepoID    int64
+	RepoOwner string
+	RepoName  string
+	RepoGit   string
+}
+
+// ScancodeLockedRow is a row observed by the recovery pass during
+// ScancodeWorker startup. The (LockedPID, LockedBootID) pair drives
+// the four-state recovery decision: reboot survivor, live orphan,
+// recoverable corpse, lost run.
+type ScancodeLockedRow struct {
+	RepoID       int64
+	RepoOwner    string
+	RepoName     string
+	RepoGit      string
+	LockedPID    int
+	LockedBootID string
+	OutputPath   string
+	LockedAt     time.Time
+}
+
+// ClaimNextScancodeRepo atomically claims the highest-priority
+// eligible repo for scancode scanning. Returns (nil, nil) when no
+// eligible row exists — the caller treats this as "queue empty,
+// wait for the next tick".
+//
+// Eligibility rules (must all hold):
+//
+//  1. The repo has been collected at least once
+//     (q.last_collected IS NOT NULL). Scancode never runs on a
+//     repo until basic API metrics exist.
+//
+//  2. The repo is not archived
+//     (COALESCE(repo_archived, FALSE) = FALSE). Matches the
+//     partial index idx_repos_scancode_due predicate so the
+//     planner uses the index instead of a sequential scan.
+//
+//  3. Cadence window has elapsed (scancode_last_run IS NULL OR
+//     scancode_last_run < NOW() - cadence). Operator-configured
+//     via collection.scancode_cadence_days, default 180 days.
+//
+//  4. The row is not actively locked (scancode_locked_at IS NULL
+//     OR locked_at older than ScancodeStaleLockWindow). The
+//     stale-lock window is the silent-corpse fallback — the
+//     primary recovery path is the worker's startup recoverOrphans
+//     scan which uses the (pid, boot_id) tuple to make precise
+//     decisions.
+//
+// FOR UPDATE SKIP LOCKED on the candidate CTE makes the claim
+// race-safe against any concurrent dispatcher (multiple aveloxis
+// serve processes against the same DB, or a future shard split).
+// Postgres' row-level lock + SKIP LOCKED is the standard job-queue
+// idiom for this shape of problem.
+func (s *PostgresStore) ClaimNextScancodeRepo(ctx context.Context, cadence time.Duration) (*ScancodeJob, error) {
+	if cadence <= 0 {
+		cadence = 180 * 24 * time.Hour
+	}
+	row := s.pool.QueryRow(ctx, `
+		WITH candidate AS (
+		    SELECT r.repo_id
+		    FROM aveloxis_data.repos r
+		    JOIN aveloxis_ops.collection_queue q USING (repo_id)
+		    WHERE q.last_collected IS NOT NULL
+		      AND COALESCE(r.repo_archived, FALSE) = FALSE
+		      AND (r.scancode_last_run IS NULL
+		           OR r.scancode_last_run < NOW() - $1::interval)
+		      AND (r.scancode_locked_at IS NULL
+		           OR r.scancode_locked_at < NOW() - $2::interval)
+		    ORDER BY r.scancode_last_run NULLS FIRST, r.repo_id
+		    LIMIT 1
+		    FOR UPDATE SKIP LOCKED
+		)
+		UPDATE aveloxis_data.repos
+		SET scancode_locked_at = NOW()
+		WHERE repo_id IN (SELECT repo_id FROM candidate)
+		RETURNING repo_id, repo_owner, repo_name, repo_git`,
+		cadence.String(), ScancodeStaleLockWindow.String())
+
+	var job ScancodeJob
+	if err := row.Scan(&job.RepoID, &job.RepoOwner, &job.RepoName, &job.RepoGit); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &job, nil
+}
+
+// RecordScancodeLockState persists the OS PID, kernel boot_id, and
+// scancode output path immediately after cmd.Start() returns. The
+// recovery pass on the NEXT aveloxis startup uses these to decide
+// what to do with each locked row.
+//
+// scancode_locked_at is already set by the claim; we don't update
+// it here so the lock age math (vs ScancodeStaleLockWindow) keeps
+// reflecting the original claim time. Updating it would mask
+// silently-stuck scans behind a constantly-fresh timestamp.
+func (s *PostgresStore) RecordScancodeLockState(ctx context.Context, repoID int64, pid int, bootID, outputPath string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.repos
+		SET scancode_locked_pid = $2,
+		    scancode_locked_boot_id = $3,
+		    scancode_output_path = $4
+		WHERE repo_id = $1`, repoID, pid, bootID, outputPath)
+	return err
+}
+
+// MarkScancodeComplete sets scancode_last_run = NOW(), captures the
+// version that ran, and clears all four lock columns in a single
+// UPDATE. Called from the success path of runOne, AFTER the
+// scancode_scans + scancode_file_results inserts have committed.
+//
+// Atomic: the worker's "I finished" signal is one row write; no
+// possibility of a partial state where last_run is set but a lock
+// column lingers (which would confuse the next recovery pass).
+func (s *PostgresStore) MarkScancodeComplete(ctx context.Context, repoID int64, version string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.repos
+		SET scancode_last_run = NOW(),
+		    scancode_version = $2,
+		    scancode_locked_at = NULL,
+		    scancode_locked_pid = NULL,
+		    scancode_locked_boot_id = NULL,
+		    scancode_output_path = NULL
+		WHERE repo_id = $1`, repoID, version)
+	return err
+}
+
+// ClearScancodeLock clears the lock columns without touching
+// scancode_last_run or scancode_version. Called from the failure
+// path of runOne (clone error, scancode subprocess crash, output
+// parse failure). The row stays eligible for the next claim tick
+// without waiting for the 12-hour stale-lock fallback.
+func (s *PostgresStore) ClearScancodeLock(ctx context.Context, repoID int64) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.repos
+		SET scancode_locked_at = NULL,
+		    scancode_locked_pid = NULL,
+		    scancode_locked_boot_id = NULL,
+		    scancode_output_path = NULL
+		WHERE repo_id = $1`, repoID)
+	return err
+}
+
+// ListLockedScancodeRows returns every row with a non-null
+// scancode_locked_at. The recovery pass calls this once at worker
+// startup, before the dispatcher begins claiming new rows.
+//
+// Each returned row goes through the four-state decision:
+//  1. boot_id differs from current → reboot survivor, clear lock.
+//  2. boot_id matches, PID alive → live orphan, spawn monitor.
+//  3. boot_id matches, PID dead, output file present and valid →
+//     recoverable corpse, ingest the orphaned output.
+//  4. boot_id matches, PID dead, no usable output → lost run,
+//     clear lock.
+//
+// See docs/architecture/scancode.md for the full decision table.
+func (s *PostgresStore) ListLockedScancodeRows(ctx context.Context) ([]ScancodeLockedRow, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT repo_id, repo_owner, repo_name, repo_git,
+		       COALESCE(scancode_locked_pid, 0),
+		       COALESCE(scancode_locked_boot_id, ''),
+		       COALESCE(scancode_output_path, ''),
+		       scancode_locked_at
+		FROM aveloxis_data.repos
+		WHERE scancode_locked_at IS NOT NULL`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ScancodeLockedRow
+	for rows.Next() {
+		var r ScancodeLockedRow
+		if err := rows.Scan(&r.RepoID, &r.RepoOwner, &r.RepoName, &r.RepoGit,
+			&r.LockedPID, &r.LockedBootID, &r.OutputPath, &r.LockedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -54,7 +54,24 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     tool_source      TEXT DEFAULT 'aveloxis',
     tool_version     TEXT DEFAULT '',
     data_source      TEXT DEFAULT '',
-    data_collection_date TIMESTAMPTZ DEFAULT NOW()
+    data_collection_date TIMESTAMPTZ DEFAULT NOW(),
+    -- v0.21.0: ScancodeWorker state (decoupled from main pipeline).
+    -- scancode_last_run is the wall-clock time of the most recent
+    -- successful per-file scan; the worker's cadence gate compares
+    -- (NOW() - scancode_last_run) against collection.scancode_cadence_days
+    -- (default 180). When NULL the repo has never been scanned and
+    -- sorts to the front of the worker's claim queue.
+    scancode_last_run       TIMESTAMPTZ,
+    scancode_version        TEXT,
+    -- scancode_locked_at + locked_pid + locked_boot_id form the
+    -- in-flight scan state. Cleared on success and on failure.
+    -- (locked_boot_id, locked_pid) tuple makes the recovery liveness
+    -- check unambiguous across kernel reboots — see
+    -- docs/architecture/scancode.md for the four-state recovery table.
+    scancode_locked_at      TIMESTAMPTZ,
+    scancode_locked_pid     INTEGER,
+    scancode_locked_boot_id TEXT,
+    scancode_output_path    TEXT
 );
 
 -- ============================================================

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.20.20"
+var ToolVersion = "0.21.0"

--- a/internal/scheduler/scancode_worker_wiring_test.go
+++ b/internal/scheduler/scancode_worker_wiring_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.0 — TestSchedulerRunStartsScancodeWorker pins the wiring
+// between scheduler.Config's new scancode fields and the
+// collector.ScancodeWorker. Without this test, a refactor that
+// silently dropped the goroutine spawn would mean ScancodeWorker
+// never runs and the cadence gate never elapses, but the operator
+// would only notice when months of scancode data went stale on the
+// dashboard.
+
+func readSchedulerSourceForScancodeTest(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestSchedulerConfigHasScancodeFields(t *testing.T) {
+	src := readSchedulerSourceForScancodeTest(t)
+	required := []string{
+		"ScancodeWorkers",
+		"ScancodeStartInterval",
+		"ScancodeCadence",
+		"ScancodeCloneDir",
+		"ScancodeShutdownGrace",
+	}
+	for _, field := range required {
+		if !strings.Contains(src, field) {
+			t.Errorf("scheduler.Config must declare %s. Without it, the v0.21.0 scancode worker has no way to receive its config from aveloxis.json via cmd/aveloxis/main.go.", field)
+		}
+	}
+}
+
+func TestSchedulerRunStartsScancodeWorker(t *testing.T) {
+	src := readSchedulerSourceForScancodeTest(t)
+	if !strings.Contains(src, "NewScancodeWorker(") {
+		t.Error("scheduler.go must instantiate collector.NewScancodeWorker. Without this call, the new worker pool never runs and scancode data goes permanently stale.")
+	}
+	// The worker must be launched as a goroutine — otherwise its
+	// blocking Run() would stop the scheduler's Run() from
+	// returning.
+	if !strings.Contains(src, "go ") || !strings.Contains(src, ".Run(ctx)") {
+		t.Error("scheduler.go must launch the ScancodeWorker as a goroutine (go sw.Run(ctx) or similar)")
+	}
+}
+
+func TestMainWiresScancodeConfig(t *testing.T) {
+	// cmd/aveloxis/main.go's runServe must populate
+	// scheduler.Config's scancode fields from
+	// cfg.Collection.Scancode*. Without this, aveloxis.json edits
+	// of scancode_workers / scancode_cadence_days / etc. silently
+	// no-op.
+	data, err := os.ReadFile("../../cmd/aveloxis/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	for _, needle := range []string{
+		"ScancodeWorkersOrDefault",
+		"ScancodeStartInterval",
+		"ScancodeCadence",
+		"ScancodeCloneDirOrDefault",
+		"ScancodeShutdownGrace",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("cmd/aveloxis/main.go must use cfg.Collection.%s when populating scheduler.Config — without this, the aveloxis.json scancode_* keys silently no-op", needle)
+		}
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -50,6 +50,19 @@ type Config struct {
 	BreadthInterval       time.Duration // how often the contributor breadth worker ticks (default 15min). v0.20.17. Was hardcoded to 6h, capping coverage to 400/day = 9.6 years for 1.4M contribs.
 	BreadthBatchSize      int           // maximum contributors per breadth tick (default 2000). v0.20.17.
 	BreadthCooldown       time.Duration // minimum interval between successive attempts on the same contributor (default 7 days). v0.20.17. Replaces the pre-fix "spin on dead-end contributors forever" pattern.
+
+	// v0.21.0 — ScancodeWorker config knobs. Scancode runs in its
+	// own goroutine pool, decoupled from the per-repo collection
+	// pipeline. The 2026-05-14 incident showed the pre-v0.21.0
+	// 2-slot semaphore stalled 177 of 180 collection workers for
+	// 7+ hours; the decoupled pool fixes the bottleneck and adds
+	// operator-tunable cadence. See internal/collector/
+	// scancode_worker.go and docs/architecture/scancode.md.
+	ScancodeWorkers       int           // max concurrent scancode subprocesses (default 2)
+	ScancodeStartInterval time.Duration // minimum interval between claim attempts (default 90s)
+	ScancodeCadence       time.Duration // minimum interval between scans on the same repo (default 180d)
+	ScancodeCloneDir      string        // parent directory for per-run shallow clones (default /tmp/aveloxis-scancode)
+	ScancodeShutdownGrace time.Duration // wait budget for in-flight scancode runs on aveloxis stop (default 30m)
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.
@@ -111,6 +124,23 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	}
 	if cfg.ShutdownGrace == 0 {
 		cfg.ShutdownGrace = 10 * time.Second
+	}
+	// v0.21.0 ScancodeWorker defaults — see CollectionConfig field
+	// docs and docs/architecture/scancode.md for the rationale.
+	if cfg.ScancodeWorkers == 0 {
+		cfg.ScancodeWorkers = 2
+	}
+	if cfg.ScancodeStartInterval == 0 {
+		cfg.ScancodeStartInterval = 90 * time.Second
+	}
+	if cfg.ScancodeCadence == 0 {
+		cfg.ScancodeCadence = 180 * 24 * time.Hour
+	}
+	if cfg.ScancodeCloneDir == "" {
+		cfg.ScancodeCloneDir = "/tmp/aveloxis-scancode"
+	}
+	if cfg.ScancodeShutdownGrace == 0 {
+		cfg.ScancodeShutdownGrace = 30 * time.Minute
 	}
 
 	hostname, _ := os.Hostname()
@@ -257,6 +287,23 @@ func (s *Scheduler) Run(ctx context.Context) {
 	// forever.
 	breadthTicker := time.NewTicker(s.cfg.BreadthInterval)
 	defer breadthTicker.Stop()
+
+	// v0.21.0 — ScancodeWorker goroutine. Runs its own pool of N
+	// scancode runners (default 2, configurable via
+	// collection.scancode_workers) with a 6-month default cadence
+	// and 90-second start-pacing. Decoupled from the main worker
+	// pool so a slow scancode run on one repo can't stall main
+	// collection across the fleet. See
+	// docs/architecture/scancode.md.
+	scancodeWorker := collector.NewScancodeWorker(
+		s.store, s.logger,
+		s.cfg.ScancodeWorkers,
+		s.cfg.ScancodeStartInterval,
+		s.cfg.ScancodeCadence,
+		s.cfg.ScancodeCloneDir,
+		s.cfg.ScancodeShutdownGrace,
+	)
+	go scancodeWorker.Run(ctx)
 
 	// Materialized view rebuild: check hourly, run on Saturdays.
 	// Collection is suspended during the rebuild.

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -330,7 +330,8 @@ https://gitlab.com/group/project" style="width:100%;padding:8px 12px;border:1px 
 
 <div class="section" style="margin-top:24px">
 <h3>Source Code Licenses</h3>
-<p style="font-size:13px;color:#6b7280;margin-bottom:8px">Detected by <a href="https://github.com/aboutcode-org/scancode-toolkit" target="_blank">ScanCode</a> from source file analysis (runs every 30 days)</p>
+<p style="font-size:13px;color:#6b7280;margin-bottom:4px">Detected by <a href="https://github.com/aboutcode-org/scancode-toolkit" target="_blank">ScanCode</a> from source file analysis. Each repo is rescanned on a configurable cadence (default 6 months — see <code>collection.scancode_cadence_days</code>).</p>
+<p id="scancode-freshness" style="font-size:13px;color:#6b7280;margin-bottom:8px">Last run: <em>loading…</em></p>
 <table id="scancode-license-table" style="max-width:600px">
 <tr><th>License (SPDX)</th><th style="text-align:right">Files</th><th style="text-align:center">OSI</th></tr>
 <tr><td colspan="3" class="empty">Loading...</td></tr>
@@ -458,6 +459,19 @@ fetch(API_BASE + '/api/v1/repos/' + REPO_ID + '/scancode-licenses')
     const table = document.getElementById('scancode-license-table');
     const licenses = data.licenses || [];
     const copyrights = data.copyrights || [];
+
+    // v0.21.0 freshness signal — show when scancode last ran on
+    // this repo so the user can interpret "stale" data correctly
+    // (vs assuming it represents today's source).
+    const freshEl = document.getElementById('scancode-freshness');
+    if (freshEl) {
+      if (data.last_run) {
+        const verSuffix = data.scancode_version ? ' (scancode ' + data.scancode_version + ')' : '';
+        freshEl.innerHTML = 'Last run: <strong>' + data.last_run + '</strong>' + verSuffix;
+      } else {
+        freshEl.innerHTML = 'Last run: <em>not yet run — will run in the next scancode worker cycle</em>';
+      }
+    }
 
     if (licenses.length === 0) {
       table.innerHTML = '<tr><th>License (SPDX)</th><th style="text-align:right">Files</th><th style="text-align:center">OSI</th></tr>' +


### PR DESCRIPTION
# Factored Scancode Out of Main Collection Path

  Schema (aveloxis_data.repos gains 6 columns + 1 partial index + idempotent backfill from aveloxis_scan.scancode_scans):
  - scancode_last_run, scancode_version, scancode_locked_at, scancode_locked_pid, scancode_locked_boot_id, scancode_output_path
  - idx_repos_scancode_due partial on scancode_last_run NULLS FIRST WHERE NOT archived

  Config (5 new aveloxis.json keys under collection):
  - scancode_workers (2), scancode_start_interval_s (90), scancode_cadence_days (180), scancode_clone_dir (/tmp/aveloxis-scancode), scancode_shutdown_grace_minutes (30)
  - All 4 example JSON files updated; docs/getting-started/configuration.md documents each knob.

  Code:
  - internal/collector/scancode_worker.go — new ScancodeWorker with dispatcher + N runners, cmd.Start/cmd.Wait split for PID capture, four-state recovery via (boot_id,  pid) tuple, graceful shutdown with grace. 
  - internal/db/scancode_worker_store.go — ClaimNextScancodeRepo (FOR UPDATE SKIP LOCKED), RecordScancodeLockState, MarkScancodeComplete, ClearScancodeLock, ListLockedScancodeRows.
  - internal/collector/scancode.go — slimmed to JSON parse + ingestScancodeOutput only. RunScanCode, scancodeSem, and ScancodeRunInterval deleted.
  - internal/collector/analysis.go — Phase 4 scanScanCode call removed.
  - internal/scheduler/scheduler.go — 5 new Config fields, defaults, goroutine spawn.
  - cmd/aveloxis/main.go — wires cfg.Collection.Scancode* to scheduler.
  - internal/api/server.go — /scancode-licenses now returns last_run + scancode_version.
  - internal/web/templates.go — repo detail page renders the freshness signal.

  Tests (27 new, all source-contract pins): 4 schema, 9 config, 13 worker, 3 pipeline-removal, 3 scheduler wiring, 1 API freshness. Full go test ./... passes.
