### PR TITLE
hardening test suite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,86 @@
+# Integration tests against a live Postgres service container.
+#
+# Runs alongside test.yml (the unit-tier workflow) on every push and
+# pull request. The unit job in test.yml stays fast — no DB, no
+# service spin-up — and gives PR contributors quick feedback. This
+# workflow trades a few seconds of service-container boot for the
+# ability to catch the v0.21.0 bug shape (migration SQL that
+# references a non-existent column / wrong schema / wrong table)
+# before the change merges.
+#
+# Why a separate workflow rather than extending test.yml: separation
+# of concerns. A green "Tests" status means the unit tier passed; a
+# green "Integration" status means the migration ran end-to-end
+# against a real Postgres. If only one is green, the failure mode
+# is obvious from the badge.
+
+name: Integration
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+
+    # Postgres 16 service container. Empty DB on every job
+    # invocation — the test (TestRunMigrationsOnFreshDB) owns the
+    # full schema and is destructive. health-cmd + retries ensure
+    # the steps below don't try to connect before Postgres is
+    # accepting connections; ports binding to 5432:5432 makes the
+    # service reachable on localhost from the test binary.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aveloxis_test
+          POSTGRES_PASSWORD: aveloxis_test
+          POSTGRES_DB: aveloxis_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # The integration test (and any future AVELOXIS_TEST_DB-gated
+      # tests) read this and connect. sslmode=disable matches the
+      # default postgres:16 image configuration. The DSN points at
+      # localhost because GitHub Actions exposes service container
+      # ports via the runner's loopback interface.
+      AVELOXIS_TEST_DB: postgres://aveloxis_test:aveloxis_test@localhost:5432/aveloxis_test?sslmode=disable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Run only the integration-tier tests. Filtering by name keeps
+      # this job focused — the unit tests already ran in test.yml.
+      # If a future integration test is added with a different
+      # naming pattern, update the -run regex here.
+      - name: Run migration integration tests
+        run: |
+          go test ./internal/db/ \
+            -run "TestRunMigrationsOnFreshDB|TestRunMigrationsIsIdempotent|TestRealign" \
+            -count=1 -v
+
+      # Final sanity check: run the entire test suite with the env
+      # var still set. Any other AVELOXIS_TEST_DB-gated tests that
+      # exist now or get added later will run here too, against the
+      # same Postgres service container.
+      - name: Run full suite with integration tier enabled
+        run: go test -count=1 ./...

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -4,39 +4,65 @@ Aveloxis uses GitHub Actions for continuous integration and deployment. All work
 
 ## Workflows
 
-### Tests (`test.yml`)
+### Tests (`test.yml`) — unit tier
 
 **Trigger:** Every push to any branch, every PR to main.
 
-Runs `go test -race ./...` with race detection enabled. Uploads coverage artifact on main branch pushes.
+Runs `go test -race ./...` with race detection enabled. Uploads coverage artifact on main branch pushes. No database service; tests gated on `AVELOXIS_TEST_DB` self-skip.
 
-Tests split into two tiers:
+### Integration (`integration.yml`) — integration tier (v0.21.1)
 
-* **Unit tier (default, always runs).** Pure Go, no database, covers source-contract tests and logic that can be exercised in-process.
-* **Integration tier (gated by `AVELOXIS_TEST_DB`).** Runs SQL against a live Postgres. Tests skip with a clear message when the env var is unset, so local `go test ./...` stays fast. To run locally:
+**Trigger:** Every push to any branch, every PR to main. Runs in parallel with the unit-tier `test.yml` job.
 
-  ```bash
-  # Create a scratch DB on your existing Postgres instance.
-  psql -h localhost -U aveloxis -d postgres -c "CREATE DATABASE aveloxis_test;"
+Provisions a `postgres:16` service container, sets `AVELOXIS_TEST_DB=postgres://aveloxis_test:aveloxis_test@localhost:5432/aveloxis_test?sslmode=disable`, runs the migration-integration tests, then re-runs the entire test suite with the env var still set so any `AVELOXIS_TEST_DB`-gated tests added later (e.g. additional `*_integration_test.go` files) get exercised automatically.
 
-  # Apply the schema.
-  AVELOXIS_DBNAME=aveloxis_test aveloxis migrate --config /path/to/test.json
+**Why split from `test.yml`:** separation of green-badge semantics. A green **Tests** status means unit-tier passed; a green **Integration** status means migrations + cross-table backfills actually ran against a real Postgres. If only one is green, the failure mode is obvious from the workflow badge.
 
-  # Run only the integration suite.
-  AVELOXIS_TEST_DB="host=localhost port=5432 user=aveloxis password=... dbname=aveloxis_test sslmode=prefer" \
-    go test ./... -run 'Integration|RealignDueDates_|CompleteJob_' -v
+**Why this matters operationally:** the v0.21.0 ship contained a backfill SQL referencing `aveloxis_scan.scancode_scans.created_at` — a column that doesn't exist (the table uses `data_collection_date`). The source-contract test pinned `MAX(created_at)` and silently passed because both sides of the contract agreed on the wrong answer. Production migrate failed with SQLSTATE 42703. `TestRunMigrationsOnFreshDB` (added in v0.21.1) catches this class of bug end-to-end by actually running RunMigrations against a Postgres service container and observing whether each statement parses + executes cleanly.
 
-  # Drop when done.
-  psql -h localhost -U aveloxis -d postgres -c "DROP DATABASE aveloxis_test;"
-  ```
+### Local dev — running the integration tier
 
-  **Never** run the integration suite against the production `aveloxis` database. `RealignDueDates` is unscoped — it updates every `status='queued'` row in the queue, and an integration test that passes `7*24h` would silently realign the entire fleet.
+The simplest path uses a throwaway Postgres container:
 
-  Conventions for adding integration tests:
+```bash
+# Start an empty Postgres container.
+docker run --rm -d --name aveloxis-test-pg -p 5433:5432 \
+  -e POSTGRES_PASSWORD=test -e POSTGRES_DB=aveloxis_test postgres:16
 
-  * Name the test `TestX_YIntegration` or put it in a file ending in `_integration_test.go`.
-  * Seed rows with nanosecond-suffixed synthetic slugs (see `seedRealignRepo` in `internal/db/queue_realign_integration_test.go`) so parallel or repeated runs do not collide on `ON CONFLICT` constraints.
-  * Prefer strict-equality assertions (`approxEqual(..., time.Millisecond)`) where the SQL does not involve `NOW()`, since source-text tests cannot catch interval-arithmetic drift and this is where runtime regressions hide.
+# Run the integration tests against it.
+AVELOXIS_TEST_DB="postgres://postgres:test@localhost:5433/aveloxis_test?sslmode=disable" \
+  go test ./internal/db/ -run "TestRunMigrations" -v
+
+# Run any other AVELOXIS_TEST_DB-gated tests in the codebase.
+AVELOXIS_TEST_DB="postgres://postgres:test@localhost:5433/aveloxis_test?sslmode=disable" \
+  go test ./... -v
+
+# Tear down when done.
+docker stop aveloxis-test-pg
+```
+
+Or, if you have an existing Postgres you want to use:
+
+```bash
+# Create a scratch DB on your existing Postgres instance.
+psql -h localhost -U aveloxis -d postgres -c "CREATE DATABASE aveloxis_test;"
+
+# Run with the test DB.
+AVELOXIS_TEST_DB="host=localhost port=5432 user=aveloxis password=... dbname=aveloxis_test sslmode=prefer" \
+  go test ./... -v
+
+# Drop when done.
+psql -h localhost -U aveloxis -d postgres -c "DROP DATABASE aveloxis_test;"
+```
+
+**Never** run the integration suite against the production `aveloxis` database. `TestRunMigrationsOnFreshDB` is destructive (it owns the schema), and `RealignDueDates`-style integration tests are unscoped — they update every matching row in the queue and would silently realign the entire fleet.
+
+Conventions for adding integration tests:
+
+* Name the test `TestX_YIntegration` or put it in a file ending in `_integration_test.go`.
+* Always gate on `os.Getenv("AVELOXIS_TEST_DB")` with `t.Skip` when empty, so `go test ./...` without the env var stays fast.
+* For non-migration tests, seed rows with nanosecond-suffixed synthetic slugs (see `seedRealignRepo` in `internal/db/queue_realign_integration_test.go`) so parallel or repeated runs do not collide on `ON CONFLICT` constraints.
+* Prefer strict-equality assertions (`approxEqual(..., time.Millisecond)`) where the SQL does not involve `NOW()`, since source-text tests cannot catch interval-arithmetic drift and this is where runtime regressions hide.
 
 ### Lint (`lint.yml`)
 

--- a/internal/db/migrate_integration_test.go
+++ b/internal/db/migrate_integration_test.go
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// Integration tests for RunMigrations against a live Postgres.
+//
+// # Why this exists (v0.21.1)
+//
+// v0.21.0 shipped a migration step whose SQL referenced
+// aveloxis_scan.scancode_scans.created_at — but that table uses the
+// aveloxis-wide convention data_collection_date. The source-contract
+// test for that migration pinned MAX(created_at) as a needle in
+// migrate.go, which silently passed because both sides of the
+// contract agreed on the wrong answer. Production migrate failed
+// with SQLSTATE 42703 (undefined_column).
+//
+// The failure mode is general: any source-contract test that
+// references a column or table NOT also pinned in schema.sql is
+// vulnerable to the same shape of bug — typo, wrong schema prefix,
+// stale column rename, etc. The only sufficient safety net is
+// actually running the migration against a Postgres that knows the
+// real schema and observing whether each statement parses + executes
+// cleanly.
+//
+// This test does exactly that. It runs once per CI invocation
+// against the Postgres service container provisioned by GitHub
+// Actions (or any env-pointed Postgres for local dev). Every
+// addColumnIfMissing call, every execMigrationStep, every
+// execCreateIndexConcurrently is exercised end-to-end. A wrong
+// column name surfaces as a test failure with the exact SQLSTATE
+// and offending statement in the error message.
+//
+// # Local dev
+//
+// To run locally:
+//
+//   docker run --rm -d --name aveloxis-test-pg -p 5433:5432 \
+//     -e POSTGRES_PASSWORD=test -e POSTGRES_DB=aveloxis_test postgres:16
+//   AVELOXIS_TEST_DB="postgres://postgres:test@localhost:5433/aveloxis_test?sslmode=disable" \
+//     go test ./internal/db/ -run TestRunMigrationsOnFreshDB -v
+//
+// The Docker container is empty Postgres; the test owns the entire
+// DB and is destructive (it CREATEs the aveloxis_* schemas and all
+// tables). Don't point AVELOXIS_TEST_DB at a DB you care about.
+//
+// # CI
+//
+// .github/workflows/integration.yml provisions a postgres:16
+// service container and sets AVELOXIS_TEST_DB to point at it. The
+// integration job runs in parallel with the existing unit job.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRunMigrationsOnFreshDB is the v0.21.1 safety net. It runs the
+// schema + RunMigrations against an empty Postgres and asserts no
+// errors. Any column-name typo / wrong-schema-prefix / SQL syntax
+// error in any migration step fails here.
+//
+// Pre-test state: DB must exist and be reachable, but the
+// aveloxis_data / aveloxis_ops / aveloxis_scan / aveloxis_augur_data
+// schemas can be either absent (fresh DB) or pre-migrated (rerun on
+// the same DB). Both states are handled — schema.sql uses
+// CREATE SCHEMA IF NOT EXISTS / CREATE TABLE IF NOT EXISTS
+// throughout, and every migration step is idempotent.
+//
+// Post-test state: the DB has the full aveloxis schema applied.
+// This is intentionally NOT cleaned up because (a) the CI container
+// is ephemeral and gets discarded after the job, and (b) on local
+// dev, leaving the schema in place lets a subsequent unit-tier
+// integration test (e.g. queue_realign_integration_test.go) reuse
+// the same DB without re-migrating.
+func TestRunMigrationsOnFreshDB(t *testing.T) {
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test. See test docstring for setup.")
+	}
+
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	store, err := NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	defer store.Close()
+
+	// Run migrations. Any non-nil return means at least one
+	// schema-changing step failed. The error message includes
+	// errors.Join of every collected failure, so the test failure
+	// surfaces the full list — operators don't have to fix
+	// failures one at a time.
+	if err := RunMigrations(ctx, store, logger); err != nil {
+		t.Fatalf("RunMigrations on fresh DB failed — this is exactly the v0.21.0 bug shape (wrong column / table / schema name) that source-contract tests can't catch. Error:\n%v", err)
+	}
+
+	// Sanity-check: a representative sample of the new v0.21.0
+	// columns exists. This isn't strictly necessary (a successful
+	// RunMigrations call already proves the column-adds ran without
+	// SQLSTATE error) but it's a fast confirmation that the
+	// integration test is actually exercising the schema and not
+	// silently no-op-ing.
+	var exists bool
+	err = store.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'aveloxis_data'
+			  AND table_name = 'repos'
+			  AND column_name = 'scancode_last_run'
+		)`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("information_schema query: %v", err)
+	}
+	if !exists {
+		t.Error("aveloxis_data.repos.scancode_last_run does not exist after RunMigrations — the v0.21.0 column adds either silently no-op'd or the migration ran against a different DB than the test verifies.")
+	}
+}
+
+// TestRunMigrationsIsIdempotent runs RunMigrations twice on the
+// same DB and asserts both runs succeed. Migrations are documented
+// as idempotent (every column add uses IF NOT EXISTS, every
+// execMigrationStep filters on the not-yet-applied state, etc.).
+// A regression that breaks idempotency would manifest as the second
+// run returning an error. Specific bugs this catches:
+//   - addColumnIfMissing accidentally dropping the IF NOT EXISTS.
+//   - A backfill UPDATE missing its "WHERE state = unbackfilled"
+//     filter and re-touching already-backfilled rows (with side
+//     effects beyond the no-op contract).
+//   - A CREATE INDEX CONCURRENTLY missing its IF NOT EXISTS and
+//     failing the second run with "relation already exists."
+func TestRunMigrationsIsIdempotent(t *testing.T) {
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+	}
+
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	store, err := NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := RunMigrations(ctx, store, logger); err != nil {
+		t.Fatalf("first RunMigrations: %v", err)
+	}
+	if err := RunMigrations(ctx, store, logger); err != nil {
+		t.Fatalf("second RunMigrations (idempotency check): %v", err)
+	}
+}
+
+// TestScancodeBackfillReferencesCorrectColumn is the regression
+// guard SPECIFICALLY for the v0.21.0 created_at/data_collection_date
+// typo. The pin is in addition to the broader
+// TestRunMigrationsOnFreshDB safety net so a future refactor that
+// breaks the column reference fails this test with a precise
+// message naming the affected column.
+//
+// This is a hybrid: source-contract pin AGAINST the existence of
+// the wrong column in scancode_scans. Reads both migrate.go and
+// schema.sql, asserts that any column referenced by the backfill
+// against scancode_scans is one that actually exists in the
+// scancode_scans table definition.
+func TestScancodeBackfillReferencesCorrectColumn(t *testing.T) {
+	migrateData, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemaData, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Locate the scancode backfill SQL inside migrate.go. It's
+	// inside the execMigrationStep call with the canonical label.
+	migrateSrc := string(migrateData)
+	labelIdx := strings.Index(migrateSrc, "v0.21.0 backfill scancode_last_run from aveloxis_scan.scancode_scans")
+	if labelIdx < 0 {
+		t.Fatal("cannot locate v0.21.0 scancode backfill step")
+	}
+	// Grab a generous slice around the label — the SQL body
+	// follows on subsequent lines.
+	tail := migrateSrc[labelIdx:]
+	endRel := strings.Index(tail, "\n\t// ")
+	if endRel < 0 {
+		endRel = len(tail)
+	}
+	backfillBlock := tail[:endRel]
+
+	// Find which timestamp column the backfill SQL is using.
+	// Pre-fix this was created_at (wrong). Post-fix this is
+	// data_collection_date (correct, matches the table definition).
+	if strings.Contains(backfillBlock, "created_at") {
+		t.Error("v0.21.0 scancode backfill SQL references created_at — but aveloxis_scan.scancode_scans uses data_collection_date. This is the exact bug shape that shipped in v0.21.0 and failed migrate on 2026-05-14 with SQLSTATE 42703.")
+	}
+
+	// Now verify the column the backfill DOES use actually exists
+	// in the scancode_scans table definition.
+	schemaSrc := string(schemaData)
+	tableIdx := strings.Index(schemaSrc, "CREATE TABLE IF NOT EXISTS aveloxis_scan.scancode_scans")
+	if tableIdx < 0 {
+		t.Fatal("cannot locate aveloxis_scan.scancode_scans in schema.sql")
+	}
+	tableEnd := strings.Index(schemaSrc[tableIdx:], ");")
+	if tableEnd < 0 {
+		t.Fatal("cannot find end of scancode_scans CREATE TABLE")
+	}
+	tableBlock := schemaSrc[tableIdx : tableIdx+tableEnd]
+
+	if strings.Contains(backfillBlock, "data_collection_date") &&
+		!strings.Contains(tableBlock, "data_collection_date") {
+		t.Error("backfill SQL uses data_collection_date, but the scancode_scans table definition no longer declares that column. Schema and backfill have drifted.")
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.21.0"
+var ToolVersion = "0.21.1"


### PR DESCRIPTION
What shipped in v0.21.1

  Bug fix: backfill SQL now uses data_collection_date (was created_at). The buggy migrate is recoverable — re-running aveloxis migrate --skip-views now succeeds because every prior step was already idempotently applied.

  Tests added (3):
  - TestRunMigrationsOnFreshDB — runs RunMigrations end-to-end against a real Postgres. Catches every column/table/schema typo / SQL syntax error in any migration step.
  The durable safety net.
  - TestRunMigrationsIsIdempotent — runs migrate twice, asserts both pass. Catches regressions that break idempotency.
  - TestScancodeBackfillReferencesCorrectColumn — precise pin against the exact v0.21.0 bug shape: scans the backfill SQL AND the table definition, asserts they agree.

  CI workflow added: .github/workflows/integration.yml provisions postgres:16 as a service container with health checks, sets AVELOXIS_TEST_DB, runs the integration tier
   + the full suite-with-env-var. Separate from test.yml so green-badge semantics are clear.

  Audit result: of the 4 cross-table backfill steps currently in migrate.go, only v0.21.0's was bugged. The other 3 reference real columns (verified via grep against
  schema.sql). No outstanding instances of the same bug shape.

  Docs: docs/guide/ci-cd.md rewritten to cover the new integration workflow, local Docker-based test recipe, and explicit guidance on the test-tier split. CLAUDE.md

  v0.21.1 changelog entry documents the bug + lesson + fix.