### PR TITLE
ux improvements

### DIFF
--- a/internal/db/cumulative_counts_test.go
+++ b/internal/db/cumulative_counts_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.2 — collection_queue.last_issues and last_prs are now
+// cumulative counts (matching v0.19.11's treatment of
+// last_commits), not per-cycle deltas. The pre-v0.21.2 behavior
+// wrote whatever count the staged collector incremented as it
+// staged rows — for incremental cycles with since-filtered API
+// calls, that's "rows updated since the previous cycle", typically
+// 0–single-digit for stable repos.
+//
+// The user-visible symptom on v0.21.0/v0.21.1: cycles finished in
+// seconds (no scancode bottleneck anymore) and the dashboard
+// repeatedly showed "Gathered: 0 / Meta: 53" on repos that had all
+// 53 issues sitting in the DB from prior cycles. The data wasn't
+// missing — the cache just reported the per-cycle delta, which is
+// nearly always 0 when collection is keeping up.
+//
+// The fix matches what v0.19.11 did for commits: have CompleteJob
+// write the cumulative count via subquery against the actual data
+// table. SELECT COUNT(*) WHERE repo_id = $1 is indexed (the schema
+// declares idx_issues_repo_id and idx_pull_requests_repo_id) and
+// runs in a millisecond on typical repos, well within CompleteJob's
+// existing transaction budget.
+
+func TestCompleteJobWritesCumulativeIssuesCount(t *testing.T) {
+	data, err := os.ReadFile("queue.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Locate CompleteJob's body.
+	idx := strings.Index(src, "func (s *PostgresStore) CompleteJob(")
+	if idx < 0 {
+		t.Fatal("cannot find CompleteJob")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		t.Fatal("cannot find end of CompleteJob")
+	}
+	body := tail[:1+endRel]
+
+	// The fix: last_issues comes from a SELECT COUNT(*) FROM
+	// aveloxis_data.issues subquery, not the parameter directly.
+	// A regression that drops the subquery and goes back to the
+	// per-cycle parameter fires this test.
+	if !strings.Contains(body, "SELECT COUNT(*) FROM aveloxis_data.issues") {
+		t.Error("CompleteJob must write last_issues as SELECT COUNT(*) FROM aveloxis_data.issues WHERE repo_id = $1 — pre-v0.21.2 this column was per-cycle delta, which produced misleading 'Gathered: 0' dashboard reads on incremental cycles. See CLAUDE.md v0.21.2 entry.")
+	}
+	if !strings.Contains(body, "SELECT COUNT(*) FROM aveloxis_data.pull_requests") {
+		t.Error("CompleteJob must write last_prs as SELECT COUNT(*) FROM aveloxis_data.pull_requests WHERE repo_id = $1. Same rationale as last_issues — match v0.19.11's cumulative-commits pattern.")
+	}
+}
+
+func TestMigrationBackfillsCumulativeIssuesAndPRs(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// The v0.21.2 backfill: one-shot UPDATE that sets every
+	// queue row's last_issues and last_prs to the cumulative
+	// COUNT from the data tables. Idempotent via
+	// `IS DISTINCT FROM` so re-running migrate is a no-op once
+	// counts catch up.
+	for _, needle := range []string{
+		"v0.21.2 backfill collection_queue.last_issues with cumulative counts",
+		"v0.21.2 backfill collection_queue.last_prs with cumulative counts",
+		"COUNT(*) AS cnt",
+		"FROM aveloxis_data.issues",
+		"FROM aveloxis_data.pull_requests",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must backfill cumulative last_issues and last_prs from aveloxis_data.issues / pull_requests. Missing needle: %q. Without this, operators upgrading from v0.21.x or earlier still see the misleading 'Gathered: 0 / Meta: N' dashboard reads until each repo's next collection cycle.", needle)
+		}
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -465,6 +465,54 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		WHERE r.repo_id = sub.repo_id
 		  AND r.scancode_last_run IS NULL`)
 
+	// v0.21.2 backfill collection_queue.last_issues with cumulative counts.
+	//
+	// Pre-v0.21.2 the column was the since-filtered per-cycle delta
+	// from the most recent collection. v0.21.2 changes CompleteJob
+	// to write the cumulative count instead (mirroring v0.19.11's
+	// commit-count treatment). This one-shot backfill brings
+	// existing rows into the new world without waiting for each
+	// repo's next collection cycle — operators on a 40K-repo fleet
+	// would otherwise see the misleading "Gathered: 0 / Meta: N"
+	// reads on the dashboard for days while the queue rolls.
+	//
+	// Idempotent in two ways:
+	//   1. `IS DISTINCT FROM` filter means once a row's
+	//      last_issues matches the cumulative count, subsequent
+	//      migrate runs skip it.
+	//   2. On a fresh deploy (no historical issues rows), the
+	//      subquery returns 0 and the UPDATE skips rows that are
+	//      already 0.
+	//
+	// The COUNT(*) is fast because idx_issues_repo_id exists; the
+	// outer subquery scans the full collection_queue but joins
+	// each row with a single indexed lookup. On a 40K-repo / 5M-
+	// row issues fleet this is a few seconds.
+	execMigrationStep(ctx, pg, logger, &errs, "v0.21.2 backfill collection_queue.last_issues with cumulative counts",
+		`UPDATE aveloxis_ops.collection_queue q
+		SET last_issues = sub.cnt
+		FROM (
+		    SELECT repo_id, COUNT(*) AS cnt
+		    FROM aveloxis_data.issues
+		    GROUP BY repo_id
+		) sub
+		WHERE q.repo_id = sub.repo_id
+		  AND q.last_issues IS DISTINCT FROM sub.cnt`)
+
+	// v0.21.2 backfill collection_queue.last_prs with cumulative counts.
+	// See last_issues backfill above for the rationale; same shape
+	// against aveloxis_data.pull_requests via idx_pull_requests_repo_id.
+	execMigrationStep(ctx, pg, logger, &errs, "v0.21.2 backfill collection_queue.last_prs with cumulative counts",
+		`UPDATE aveloxis_ops.collection_queue q
+		SET last_prs = sub.cnt
+		FROM (
+		    SELECT repo_id, COUNT(*) AS cnt
+		    FROM aveloxis_data.pull_requests
+		    GROUP BY repo_id
+		) sub
+		WHERE q.repo_id = sub.repo_id
+		  AND q.last_prs IS DISTINCT FROM sub.cnt`)
+
 	// Users table: dedupe + enforce PK/UNIQUE (v0.18.9).
 	// Older installs used CREATE TABLE IF NOT EXISTS with inline UNIQUE, which
 	// silently skipped on pre-existing tables created without the constraint —

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -131,6 +131,27 @@ func (s *PostgresStore) CompleteJob(ctx context.Context, repoID int64, success b
 		lastErr = &errMsg
 	}
 
+	// v0.21.2 — last_issues and last_prs are written as the
+	// CUMULATIVE COUNT from the data tables, not the per-cycle
+	// delta the caller passed via the issues/prs parameters. This
+	// mirrors v0.19.11's treatment of last_commits (facade always
+	// passes the full distinct-commit count from `git log` on the
+	// default branch). Pre-v0.21.2 these columns were the
+	// since-filtered count from the most recent cycle, which
+	// produced "Gathered: 0 / Meta: 53" dashboard reads on
+	// incremental cycles even when the DB had all 53 issues.
+	//
+	// The COUNT(*) subqueries are O(log n) because the schema
+	// declares idx_issues_repo_id and idx_pull_requests_repo_id —
+	// both partial-equality lookups, microseconds on typical repos.
+	// The issues and prs parameters are kept for backward
+	// compatibility with callers; they're currently unused inside
+	// the UPDATE but left in the signature so a follow-up refactor
+	// can expose them as separate "delta this cycle" columns if
+	// operators ever want that data surfaced.
+	_ = issues
+	_ = prs
+
 	return s.withRetry(ctx, func(ctx context.Context) error {
 		_, err := s.pool.Exec(ctx, `
 			UPDATE aveloxis_ops.collection_queue
@@ -141,19 +162,19 @@ func (s *PostgresStore) CompleteJob(ctx context.Context, repoID int64, success b
 				locked_at = NULL,
 				last_collected = NOW(),
 				last_error = $4,
-				last_issues = $5,
-				last_prs = $6,
-				last_messages = $7,
-				last_events = $8,
-				last_releases = $9,
-				last_contributors = $10,
-				last_commits = $11,
-				last_duration_ms = $12,
-				force_full_collect = CASE WHEN $13::boolean THEN FALSE ELSE force_full_collect END,
+				last_issues = (SELECT COUNT(*) FROM aveloxis_data.issues WHERE repo_id = $1),
+				last_prs = (SELECT COUNT(*) FROM aveloxis_data.pull_requests WHERE repo_id = $1),
+				last_messages = $5,
+				last_events = $6,
+				last_releases = $7,
+				last_contributors = $8,
+				last_commits = $9,
+				last_duration_ms = $10,
+				force_full_collect = CASE WHEN $11::boolean THEN FALSE ELSE force_full_collect END,
 				updated_at = NOW()
 			WHERE repo_id = $1`,
 			repoID, status, recollectAfter.String(),
-			lastErr, issues, prs, messages, events, releases, contributors, commits, durationMs,
+			lastErr, messages, events, releases, contributors, commits, durationMs,
 			success)
 		return err
 	})

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.21.1"
+var ToolVersion = "0.21.2"


### PR DESCRIPTION
v0.21.2 

  Fix shape: CompleteJob's UPDATE now writes last_issues and last_prs via indexed subqueries (SELECT COUNT(*) FROM aveloxis_data.issues/pull_requests WHERE repo_id = $1)
   instead of the per-cycle delta the staged collector passes. Symmetric with v0.19.11's treatment of last_commits.

  Backfill: two new idempotent migration steps (v0.21.2 backfill collection_queue.last_issues/last_prs with cumulative counts) bring every existing queue row's cached
  counts in line with the actual table contents on the next aveloxis migrate. Filtered with IS DISTINCT FROM so a second migrate run is a no-op.

  Tests: 2 new source-contract pins guard against regression. Full go test ./... passes.

  Operator deployment:
```bash
  go install ./cmd/aveloxis
  aveloxis stop all
  aveloxis migrate --skip-views   # 2 backfills run (seconds on the 40K-repo fleet)
  aveloxis start all
```

  On your server, after restart the dashboard's rapidly-cycling rows will immediately show the cumulative counts you'd expect — "Issues 53 / Meta 53" rather than "Issues 0  / Meta 53" on the nasa/ncompare-shaped repos.