### PR TITLE
updated scancode to handle LFS better.

### DIFF
--- a/internal/collector/scancode_failure_backoff_test.go
+++ b/internal/collector/scancode_failure_backoff_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"strings"
+	"testing"
+)
+
+// v0.21.4 — pin that the runOne failure paths route through
+// RecordScancodeFailure (the new failure-tracking helper) instead of
+// ClearScancodeLock. The 2026-05-14 production loop bug was that
+// ClearScancodeLock left scancode_last_run = NULL and never tracked
+// the failure, so failed repos were always at the head of the claim
+// queue. v0.21.4 routes ALL repo-specific failure paths through a
+// counter-incrementing path; only the dispatcher's "ctx canceled
+// after claim, never dispatched" cleanup keeps using ClearScancodeLock
+// (that's a clean release, not a failure).
+
+func TestRunOneRoutesFailuresThroughRecordFailure(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) runOne(")
+	if idx < 0 {
+		t.Fatal("cannot find runOne method")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// runOne must call recordFailureBestEffort on its failure paths.
+	// We pin the helper name rather than counting occurrences so a
+	// future refactor (e.g. consolidating defers) doesn't trip the
+	// test for a stylistic reason.
+	if !strings.Contains(body, "recordFailureBestEffort") {
+		t.Error("runOne must call w.recordFailureBestEffort on failure paths (clone error, scancode subprocess crash, ingest error). The pre-v0.21.4 clearLockBestEffort path discarded the failure event entirely — losing the failure history, so the next claim cycle saw the row as healthy and immediately re-dispatched it. recordFailureBestEffort wraps RecordScancodeFailure which increments the counter and stamps last_failed_at for the backoff gate.")
+	}
+
+	// runOne must NOT call clearLockBestEffort on its failure
+	// paths (it's allowed at one location — the dispatcher's
+	// ctx-canceled-after-claim cleanup — but that lives in
+	// `dispatcher`, not `runOne`). Pin the actual call-site
+	// shape `w.clearLockBestEffort(` rather than the bare token,
+	// because the body slice may extend into the next function's
+	// docstring which legitimately mentions the helper name.
+	if strings.Contains(body, "w.clearLockBestEffort(") {
+		t.Error("runOne must not call w.clearLockBestEffort(...) — failure paths must route through w.recordFailureBestEffort(...) so the failure is tracked and backed off, not just silently cleared. (clearLockBestEffort is still allowed in dispatcher's ctx-canceled-after-claim cleanup, which is a clean release rather than a failure.)")
+	}
+}
+
+func TestRecordFailureBestEffortHelperExists(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	if !strings.Contains(src, "func (w *ScancodeWorker) recordFailureBestEffort(") {
+		t.Error("scancode_worker.go must declare recordFailureBestEffort(ctx, repoID) wrapping store.RecordScancodeFailure with the same canceled-ctx fallback as clearLockBestEffort. Pre-v0.21.4 only had clearLockBestEffort; the new helper is what runOne calls on failure paths.")
+	}
+}
+
+func TestDispatcherStillUsesClearLockForCleanRelease(t *testing.T) {
+	// Carve-out test: pre-v0.21.4 dispatcher had a `case
+	// <-ctx.Done()` arm that called ClearScancodeLock to release a
+	// row we'd claimed but never dispatched to a runner. That's a
+	// clean release (no actual scan attempt happened), so it
+	// should NOT increment the failure counter — verify that
+	// dispatcher still uses ClearScancodeLock, not the new failure
+	// helper.
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) dispatcher(")
+	if idx < 0 {
+		t.Fatal("cannot find dispatcher")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	if !strings.Contains(body, "ClearScancodeLock") {
+		t.Error("dispatcher must keep calling ClearScancodeLock on its ctx-canceled-after-claim cleanup path. That's a clean release (no scan attempt happened), and routing it through RecordScancodeFailure would falsely accumulate failure counts on every graceful shutdown.")
+	}
+	if strings.Contains(body, "recordFailureBestEffort") || strings.Contains(body, "RecordScancodeFailure") {
+		t.Error("dispatcher must NOT call recordFailureBestEffort / RecordScancodeFailure — the ctx-canceled cleanup is a clean release, not a failure event.")
+	}
+}

--- a/internal/collector/scancode_runone_diagnostics_test.go
+++ b/internal/collector/scancode_runone_diagnostics_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"strings"
+	"testing"
+)
+
+// v0.21.4 — diagnostic + reliability fixes for repeatedly-failing
+// scancode runs.
+//
+// 2026-05-14 production diagnostic of /Users/sean/github/aveloxis/
+// aveloxis/aveloxis.log: of 731 scancode starts in the log, 301 were
+// failures concentrated in 10 repos. Two distinct failure modes:
+//
+//   - 214 git clone failures, all "This repository exceeded its LFS
+//     budget" (nasa/RtRetrievalFramework, nasa/Mixed-Reality-
+//     Exploration-Toolkit). Both repos use Git LFS for binary assets
+//     scancode doesn't need to scan.
+//
+//   - 87 subprocess exits with status 1, ZERO diagnostic information
+//     because cmd.Stdout / cmd.Stderr were nil — the subprocess
+//     output was discarded.
+//
+// These tests pin the v0.21.4 fixes:
+//
+//  1. runOne captures stderr (bounded buffer) and logs the tail on
+//     failure so future "exit status 1" failures are diagnosable.
+//
+//  2. The git clone command runs with GIT_LFS_SKIP_SMUDGE=1 in its
+//     environment so LFS-pointer files come down as 130-byte text
+//     blobs instead of triggering the smudge filter. Scancode scans
+//     source-license + copyright headers — LFS payloads (tarballs,
+//     compiled assets, binary unity packages) aren't useful for that
+//     work and skipping them turns the LFS-budget-failure cohort
+//     into "scans successfully without LFS payloads."
+
+func TestRunOneCapturesScancodeStderr(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) runOne(")
+	if idx < 0 {
+		t.Fatal("cannot find runOne method")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// The runOne body must assign something to cmd.Stderr before
+	// cmd.Start(). Without this, scancode subprocess output is
+	// discarded by Go's exec default and "exit status 1" failures
+	// are undiagnosable. Pin the literal `cmd.Stderr =` so a
+	// refactor that drops the capture fails the test.
+	if !strings.Contains(body, "cmd.Stderr =") {
+		t.Error("runOne must assign cmd.Stderr to a buffer before cmd.Start() so the subprocess's error output is captured. Without it, a scancode 'exit status 1' produces a log line with no information about WHY it failed — exactly the v0.21.4 diagnostic gap this fix closes.")
+	}
+
+	// Stdout capture is also needed because scancode --quiet still
+	// writes some progress to stdout, and some non-quiet error
+	// paths route to stdout instead of stderr.
+	if !strings.Contains(body, "cmd.Stdout =") {
+		t.Error("runOne must assign cmd.Stdout to a buffer alongside cmd.Stderr. Scancode's failure messages don't reliably route to one stream.")
+	}
+
+	// The failure log must include the captured tail. Pin a stable
+	// keyword in the structured log call.
+	if !strings.Contains(body, "stderr_tail") && !strings.Contains(body, "stderr") {
+		t.Error("the cmd.Wait() failure log line must include a 'stderr_tail' (or at least 'stderr') key carrying the captured tail of subprocess output. Otherwise the capture is dead code.")
+	}
+}
+
+func TestRunOneCloneSkipsLFSSmudge(t *testing.T) {
+	src := readScancodeWorkerSource(t)
+	idx := strings.Index(src, "func (w *ScancodeWorker) runOne(")
+	if idx < 0 {
+		t.Fatal("cannot find runOne method")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// The git clone command must set GIT_LFS_SKIP_SMUDGE=1 in its
+	// environment. Otherwise repos whose LFS quota is exhausted
+	// fail at the smudge filter (~1 min wasted per clone attempt
+	// because git checks out thousands of files before hitting the
+	// LFS step). Skipping the smudge means LFS pointer files come
+	// down as text — scancode reads them as 130-byte license-free
+	// blobs and moves on. The same change makes clones faster on
+	// every LFS-using repo, not just the broken ones.
+	if !strings.Contains(body, "GIT_LFS_SKIP_SMUDGE=1") {
+		t.Error("the clone command in runOne must set GIT_LFS_SKIP_SMUDGE=1 in its environment. Without it, repos that have exhausted their LFS budget loop forever (2026-05-14 diagnostic: 214 of 301 scancode failures were LFS-budget exhausted on 2 repos). Scancode doesn't need LFS payloads — it scans license + copyright headers in source files.")
+	}
+
+	// Must be set via cloneCmd.Env (or equivalent). A bare
+	// `os.Setenv` in runOne would pollute every other subprocess
+	// in the worker. Pin the per-command shape.
+	if !strings.Contains(body, "cloneCmd.Env") {
+		t.Error("GIT_LFS_SKIP_SMUDGE=1 must be set on cloneCmd.Env (the per-process environment), NOT via os.Setenv (which would leak to every other subprocess this worker spawns).")
+	}
+}

--- a/internal/collector/scancode_worker.go
+++ b/internal/collector/scancode_worker.go
@@ -47,6 +47,12 @@ import (
 	"github.com/aveloxis/aveloxis/internal/db"
 )
 
+// scancodeStderrTailBytes is the cap on how much subprocess output
+// we keep in memory and log on failure. Big enough to surface a
+// meaningful traceback or error message, small enough that 100+
+// concurrent failures don't pressure the heap.
+const scancodeStderrTailBytes = 4096
+
 // bootIDPath is the kernel-generated UUID that changes on every
 // boot. Reading this file at lock-record time (paired with the
 // scancode subprocess PID) makes the recovery liveness check
@@ -342,19 +348,33 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 	if err := os.MkdirAll(tempDir, 0o755); err != nil {
 		w.logger.Warn("scancode runOne mkdir failed",
 			"repo_id", job.RepoID, "error", err)
-		w.clearLockBestEffort(ctx, job.RepoID)
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
 	// Shallow clone — scancode only needs current file state, not
 	// history. --depth 1 dramatically reduces bandwidth for big
 	// repos (Linux kernel: full history ~3 GB, shallow ~500 MB).
+	//
+	// GIT_LFS_SKIP_SMUDGE=1 (v0.21.4): suppresses the LFS smudge
+	// filter so pointer files come down as ~130-byte text blobs
+	// instead of triggering a fetch from the LFS endpoint. Scancode
+	// scans source-license + copyright headers — LFS payloads
+	// (tarballs, binary assets, compiled artifacts) aren't useful
+	// for that work. Critical for repos whose LFS budget is
+	// exhausted (2026-05-14 diagnostic: 214 clone failures on the
+	// chaoss.tv fleet, all "exceeded its LFS budget"); the LFS
+	// fetch fails, which fails the smudge filter, which fails the
+	// checkout, which fails the whole clone. Skipping smudge bypasses
+	// the entire chain. Also speeds up clones on every LFS-using
+	// repo (no payload fetch).
 	cloneCmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--", job.RepoGit, tempDir)
+	cloneCmd.Env = append(os.Environ(), "GIT_LFS_SKIP_SMUDGE=1")
 	if out, err := cloneCmd.CombinedOutput(); err != nil {
 		w.logger.Warn("scancode runOne git clone failed",
 			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
 			"error", err, "git_output", string(out))
-		w.clearLockBestEffort(ctx, job.RepoID)
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
@@ -363,7 +383,7 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 		// Should never happen — Run() already checked. Defensive.
 		w.logger.Warn("scancode runOne: binary not on PATH at run time",
 			"repo_id", job.RepoID, "error", err)
-		w.clearLockBestEffort(ctx, job.RepoID)
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
@@ -384,6 +404,21 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 		tempDir,
 	)
 
+	// Capture stdout + stderr to bounded ring buffers so we can
+	// log the tail on failure. Pre-v0.21.4, both streams were nil
+	// and Go's exec default discarded the subprocess output —
+	// producing log lines that said only "exit status 1" with no
+	// diagnostic information whatsoever. The 2026-05-14 production
+	// log had 87 such failures across 8 repos and we had no idea
+	// why scancode was crashing. The buffers are capped via
+	// tailBuffer so concurrent large failures can't pressure the
+	// heap (worst case: workerCount × 2 × scancodeStderrTailBytes
+	// ≈ a few hundred KB on a 7-worker pool).
+	stderrBuf := &tailBuffer{cap: scancodeStderrTailBytes}
+	stdoutBuf := &tailBuffer{cap: scancodeStderrTailBytes}
+	cmd.Stderr = stderrBuf
+	cmd.Stdout = stdoutBuf
+
 	// cmd.Start() is the key change from the legacy synchronous
 	// invocation: we need the OS PID BEFORE the subprocess
 	// finishes running, so we can persist it to scancode_locked_pid
@@ -393,7 +428,7 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 	if err := cmd.Start(); err != nil {
 		w.logger.Warn("scancode runOne: cmd.Start() failed",
 			"repo_id", job.RepoID, "error", err)
-		w.clearLockBestEffort(ctx, job.RepoID)
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
@@ -415,8 +450,10 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 	if err := cmd.Wait(); err != nil {
 		w.logger.Warn("scancode runOne: scancode subprocess failed",
 			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
-			"error", err, "pid", pid)
-		w.clearLockBestEffort(ctx, job.RepoID)
+			"error", err, "pid", pid,
+			"stderr_tail", stderrBuf.String(),
+			"stdout_tail", stdoutBuf.String())
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
@@ -428,7 +465,7 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 		w.logger.Warn("scancode runOne: ingest failed",
 			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
 			"error", err)
-		w.clearLockBestEffort(ctx, job.RepoID)
+		w.recordFailureBestEffort(ctx, job.RepoID)
 		return
 	}
 
@@ -452,6 +489,13 @@ func (w *ScancodeWorker) runOne(ctx context.Context, job db.ScancodeJob) {
 // clearLockBestEffort attempts to clear the lock and logs if it
 // fails. Uses a background context so a canceled ctx (graceful
 // shutdown) doesn't prevent the cleanup write.
+//
+// As of v0.21.4 this is used ONLY by the dispatcher's
+// ctx-canceled-after-claim cleanup — that's a clean release of a
+// row we claimed but never dispatched to a runner, not a failure
+// event. All repo-specific failure paths in runOne use
+// recordFailureBestEffort instead so the failure-counter +
+// last_failed_at columns get updated and the backoff gate applies.
 func (w *ScancodeWorker) clearLockBestEffort(ctx context.Context, repoID int64) {
 	// Try the live ctx first; fall back to background if canceled.
 	useCtx := ctx
@@ -460,6 +504,26 @@ func (w *ScancodeWorker) clearLockBestEffort(ctx context.Context, repoID int64) 
 	}
 	if err := w.store.ClearScancodeLock(useCtx, repoID); err != nil {
 		w.logger.Warn("scancode runOne: ClearScancodeLock failed",
+			"repo_id", repoID, "error", err)
+	}
+}
+
+// recordFailureBestEffort (v0.21.4) is the failure-path counterpart
+// to clearLockBestEffort. It calls store.RecordScancodeFailure which
+// increments scancode_failed_attempts, stamps scancode_last_failed_at,
+// and conditionally stamps scancode_last_run when the failure count
+// reaches ScancodeMaxFailures.
+//
+// Falls back to a background context if the live ctx is canceled,
+// matching clearLockBestEffort's contract so graceful shutdown
+// doesn't lose the failure record.
+func (w *ScancodeWorker) recordFailureBestEffort(ctx context.Context, repoID int64) {
+	useCtx := ctx
+	if ctx.Err() != nil {
+		useCtx = context.Background()
+	}
+	if err := w.store.RecordScancodeFailure(useCtx, repoID); err != nil {
+		w.logger.Warn("scancode runOne: RecordScancodeFailure failed",
 			"repo_id", repoID, "error", err)
 	}
 }

--- a/internal/collector/tail_buffer.go
+++ b/internal/collector/tail_buffer.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"bytes"
+)
+
+// tailBuffer is a bounded io.Writer that retains only the last `cap`
+// bytes written. Used to capture the tail of scancode subprocess
+// output for failure diagnostics without unbounded memory growth on
+// chatty failures.
+//
+// Not safe for concurrent writes — the caller (exec.Cmd's IO
+// goroutines) writes serially per stream.
+type tailBuffer struct {
+	cap int
+	buf bytes.Buffer
+}
+
+// Write implements io.Writer. Appends to the underlying buffer, then
+// trims from the front if the buffer exceeds cap. Trimming is done
+// in-place by copying the tail into a fresh buffer — bytes.Buffer
+// doesn't expose a "discard front N bytes" method.
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	if t.cap <= 0 {
+		return len(p), nil
+	}
+	n, _ := t.buf.Write(p)
+	if t.buf.Len() > t.cap {
+		// Keep only the last cap bytes.
+		tail := t.buf.Bytes()
+		t.buf.Reset()
+		t.buf.Write(tail[len(tail)-t.cap:])
+	}
+	return n, nil
+}
+
+// String returns the captured tail.
+func (t *tailBuffer) String() string {
+	return t.buf.String()
+}

--- a/internal/collector/tail_buffer_test.go
+++ b/internal/collector/tail_buffer_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTailBufferRetainsOnlyTail(t *testing.T) {
+	tb := &tailBuffer{cap: 10}
+	n, err := tb.Write([]byte("0123456789ABCDEF"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 16 {
+		t.Errorf("Write must report bytes-written = full input length (Go io.Writer contract), got %d, want 16", n)
+	}
+	got := tb.String()
+	if got != "6789ABCDEF" {
+		t.Errorf("tailBuffer with cap=10 must retain only last 10 bytes after writing 16; got %q want %q", got, "6789ABCDEF")
+	}
+}
+
+func TestTailBufferAccumulatesAcrossWrites(t *testing.T) {
+	tb := &tailBuffer{cap: 8}
+	tb.Write([]byte("hello "))
+	tb.Write([]byte("world!"))
+	got := tb.String()
+	// Total 12 bytes written; cap=8 → keep last 8: "o world!"
+	want := "o world!"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestTailBufferZeroCapDiscardsEverything(t *testing.T) {
+	tb := &tailBuffer{cap: 0}
+	tb.Write([]byte("anything"))
+	if tb.String() != "" {
+		t.Errorf("cap=0 must discard all input; got %q", tb.String())
+	}
+}
+
+func TestTailBufferShorterInputThanCap(t *testing.T) {
+	tb := &tailBuffer{cap: 100}
+	tb.Write([]byte("short"))
+	if !strings.HasPrefix(tb.String(), "short") {
+		t.Errorf("input shorter than cap should be preserved verbatim; got %q", tb.String())
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -211,6 +211,26 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_locked_boot_id", "TEXT")
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_output_path", "TEXT")
 
+	// v0.21.4: failure tracking + exponential backoff.
+	//
+	// 2026-05-14 production diagnostic: the v0.21.0 ScancodeWorker
+	// cleared the lock columns on failure but kept scancode_last_run
+	// NULL. The claim query orders NULLS FIRST on scancode_last_run,
+	// so failed repos became the highest-priority candidates for the
+	// next dispatcher tick. With ~45s failure scans and ~3-min
+	// healthy scans, 10 doomed repos dominated visible activity on
+	// a 7-worker pool.
+	//
+	// v0.21.4 adds a counter + last-failure-time column so the claim
+	// query can apply per-row exponential backoff (1h, 4h, 9h, ...,
+	// 7d cap). After ScancodeMaxFailures consecutive failures the
+	// RecordScancodeFailure helper also stamps scancode_last_run =
+	// NOW(), letting the cadence gate (default 180 days) shoulder
+	// the long-tail "this repo will never scan" cases out of the
+	// queue.
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_failed_attempts", "INTEGER DEFAULT 0")
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "scancode_last_failed_at", "TIMESTAMPTZ")
+
 	// Commits: deduplicate and add unique index (added in v0.7.5).
 	// Previous versions had no ON CONFLICT on commits INSERT, so re-collection
 	// created duplicate rows. Clean up first, then create the unique index.

--- a/internal/db/scancode_failure_backoff_test.go
+++ b/internal/db/scancode_failure_backoff_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.21.4 — scancode failure tracking + exponential backoff.
+//
+// 2026-05-14 production diagnostic showed 10 repos in a tight failure
+// loop: each scan failed in ~45s (clone fail or scancode exit 1),
+// ClearScancodeLock cleared scancode_locked_at but LEFT
+// scancode_last_run = NULL. The claim query orders NULLS FIRST on
+// scancode_last_run, so failed repos became the highest-priority
+// candidates for the very next dispatcher tick. With ~3-min legitimate
+// scans and ~45s failing scans, failing repos cycled through the
+// worker pool 4× faster than productive ones, dominating visible
+// activity (a small failing cohort can starve a healthy fleet).
+//
+// Fix shape (this file pins the source contract):
+//
+//  1. Two new columns on aveloxis_data.repos:
+//       scancode_failed_attempts INTEGER DEFAULT 0
+//       scancode_last_failed_at  TIMESTAMPTZ
+//
+//  2. New store method RecordScancodeFailure(ctx, repoID) replaces
+//     ClearScancodeLock on failure paths. It clears the lock columns,
+//     increments failed_attempts, stamps last_failed_at = NOW(), AND
+//     when attempts >= ScancodeMaxFailures (default 10) also stamps
+//     scancode_last_run = NOW() so the cadence gate (default 180
+//     days) pushes the row out of the queue.
+//
+//  3. ClaimNextScancodeRepo gains a backoff gate:
+//       scancode_last_failed_at IS NULL
+//         OR scancode_last_failed_at < NOW() - backoff(attempts)
+//     where backoff = LEAST(attempts*attempts, 168) hours.
+//     attempts=1 → 1h, 2 → 4h, 3 → 9h, ..., 13+ → 7d cap.
+//
+//  4. MarkScancodeComplete resets failed_attempts to 0 on success.
+//
+//  5. Schema + migrate.go declare the new columns so a fresh DB or
+//     an upgrade both end up with the same shape.
+
+func TestSchemaHasScancodeFailureColumns(t *testing.T) {
+	data, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	for _, needle := range []string{
+		"scancode_failed_attempts",
+		"scancode_last_failed_at",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("schema.sql must declare %s on aveloxis_data.repos so a fresh DB has the column at table-create time, not retrofitted via migrate", needle)
+		}
+	}
+}
+
+func TestMigrateAddsScancodeFailureColumns(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	columnTypes := map[string]string{
+		"scancode_failed_attempts": "INTEGER DEFAULT 0",
+		"scancode_last_failed_at":  "TIMESTAMPTZ",
+	}
+	for col, typ := range columnTypes {
+		needle := `addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "` + col + `", "` + typ + `"`
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must call addColumnIfMissing for aveloxis_data.repos.%s (%s). Without this, upgrading instances would crash the v0.21.4 ScancodeWorker when it tries to update the column", col, typ)
+		}
+	}
+}
+
+func TestRecordScancodeFailureExists(t *testing.T) {
+	data, err := os.ReadFile("scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	if !strings.Contains(src, "func (s *PostgresStore) RecordScancodeFailure(") {
+		t.Error("scancode_worker_store.go must declare RecordScancodeFailure(ctx, repoID). This replaces the v0.21.0 ClearScancodeLock call on failure paths so failures get tracked and backed off instead of looping immediately.")
+	}
+
+	idx := strings.Index(src, "func (s *PostgresStore) RecordScancodeFailure(")
+	if idx < 0 {
+		return
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// The UPDATE must increment scancode_failed_attempts.
+	if !strings.Contains(body, "scancode_failed_attempts") {
+		t.Error("RecordScancodeFailure must UPDATE scancode_failed_attempts = COALESCE(scancode_failed_attempts, 0) + 1 (or equivalent). Without this counter, backoff has no input.")
+	}
+	// Must stamp scancode_last_failed_at = NOW().
+	if !strings.Contains(body, "scancode_last_failed_at") {
+		t.Error("RecordScancodeFailure must stamp scancode_last_failed_at = NOW() so the claim-query backoff gate can compute time-since-failure.")
+	}
+	// Must clear the lock columns (was the whole job of the
+	// pre-v0.21.4 ClearScancodeLock).
+	if !strings.Contains(body, "scancode_locked_at = NULL") {
+		t.Error("RecordScancodeFailure must clear scancode_locked_at = NULL so the row becomes eligible again after backoff (the claim query's lock-age gate would otherwise hold it for 12 hours).")
+	}
+	// Must eventually push the row out of the queue when failures
+	// are unrecoverable: at attempts >= ScancodeMaxFailures, stamp
+	// scancode_last_run = NOW() so the cadence gate excludes it.
+	if !strings.Contains(body, "scancode_last_run") {
+		t.Error("RecordScancodeFailure must reference scancode_last_run — when failed_attempts >= ScancodeMaxFailures, stamp it to NOW() so the cadence gate (default 180 days) pushes the unrecoverable row out of the queue. Otherwise a permanently-failing repo loops forever after exhausting the exponential backoff schedule.")
+	}
+}
+
+func TestMarkScancodeCompleteResetsFailureCounter(t *testing.T) {
+	data, err := os.ReadFile("scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	idx := strings.Index(src, "func (s *PostgresStore) MarkScancodeComplete(")
+	if idx < 0 {
+		t.Fatal("cannot find MarkScancodeComplete")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	if !strings.Contains(body, "scancode_failed_attempts = 0") {
+		t.Error("MarkScancodeComplete must reset scancode_failed_attempts = 0 on success. Without this, a repo that fails 5 times then succeeds carries the high failed_attempts forever — future failures would skip the lower backoff tiers and jump to maximum delay immediately.")
+	}
+	if !strings.Contains(body, "scancode_last_failed_at = NULL") {
+		t.Error("MarkScancodeComplete must clear scancode_last_failed_at = NULL on success so the backoff gate doesn't consult a stale timestamp on the next failure.")
+	}
+}
+
+func TestClaimNextScancodeRepoBackoffGate(t *testing.T) {
+	data, err := os.ReadFile("scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	idx := strings.Index(src, "func (s *PostgresStore) ClaimNextScancodeRepo(")
+	if idx < 0 {
+		t.Fatal("cannot find ClaimNextScancodeRepo")
+	}
+	tail := src[idx:]
+	endRel := strings.Index(tail[1:], "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail) - 1
+	}
+	body := tail[:1+endRel]
+
+	// Pin both halves of the backoff gate.
+	if !strings.Contains(body, "scancode_last_failed_at IS NULL") {
+		t.Error("ClaimNextScancodeRepo's WHERE clause must include scancode_last_failed_at IS NULL OR <backoff window past>. Without this gate, a freshly-failed repo is re-eligible on the very next dispatcher tick (the v0.21.4 loop bug).")
+	}
+	if !strings.Contains(body, "scancode_failed_attempts") {
+		t.Error("ClaimNextScancodeRepo must reference scancode_failed_attempts when computing the backoff window — exponential backoff requires the attempt count as input.")
+	}
+	// The SQL must reference an interval expression that depends on
+	// failed_attempts. Pin the simplest readable form
+	// (make_interval(hours => ...)) so a future refactor that drops
+	// the expression fails the test.
+	if !strings.Contains(body, "make_interval") {
+		t.Error("ClaimNextScancodeRepo's backoff gate must use make_interval(hours => ...) to compute the per-row backoff window from scancode_failed_attempts. Plain `NOW() - $N::interval` won't work because the interval is row-dependent.")
+	}
+}
+
+func TestScancodeMaxFailuresConstant(t *testing.T) {
+	// The threshold for "push the row out of the queue" lives as a
+	// named constant so operators can grep for it and engineers
+	// can see the policy in one place.
+	data, err := os.ReadFile("scancode_worker_store.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+	if !strings.Contains(src, "ScancodeMaxFailures") {
+		t.Error("scancode_worker_store.go must declare a named constant ScancodeMaxFailures (default 10) controlling when RecordScancodeFailure stamps scancode_last_run = NOW() to push the unrecoverable repo out of the active queue.")
+	}
+}

--- a/internal/db/scancode_worker_store.go
+++ b/internal/db/scancode_worker_store.go
@@ -26,6 +26,25 @@ import (
 // this window is just the silent-fallback safety net.
 const ScancodeStaleLockWindow = 12 * time.Hour
 
+// ScancodeMaxFailures (v0.21.4) is the consecutive-failure count
+// after which RecordScancodeFailure stamps scancode_last_run = NOW()
+// so the cadence gate excludes the row for the full cadence window
+// (default 180 days). The exponential backoff schedule (quadratic,
+// capped at 7 days) handles attempts 1 through ScancodeMaxFailures-1;
+// once a repo has failed ScancodeMaxFailures times in a row it's
+// presumed permanently broken (LFS-budget exhausted, malformed
+// source tree, scancode-incompatible content) and shouldn't burn
+// further worker time until the cadence gate naturally expires.
+//
+// 10 means an operator who fixes the underlying problem (top-ups
+// the LFS budget, removes the broken file) gets up to ~10×7d = 70
+// days × the natural Sunday-cron cadence to see the repo retry on
+// its own. For faster retry, operators clear scancode_failed_attempts
+// directly: `UPDATE aveloxis_data.repos SET scancode_failed_attempts
+// = 0, scancode_last_failed_at = NULL, scancode_last_run = NULL
+// WHERE repo_id = X`.
+const ScancodeMaxFailures = 10
+
 // ScancodeJob is the unit of work the ScancodeWorker dispatcher
 // hands to a runner goroutine.
 type ScancodeJob struct {
@@ -86,6 +105,16 @@ func (s *PostgresStore) ClaimNextScancodeRepo(ctx context.Context, cadence time.
 	if cadence <= 0 {
 		cadence = 180 * 24 * time.Hour
 	}
+	// v0.21.4 backoff gate: rows that recently failed are gated by
+	// a per-row exponential window. The window is quadratic in
+	// scancode_failed_attempts (1h → 4h → 9h → 16h → 25h → 36h →
+	// 49h → 64h → 81h → 100h → 121h → 144h → 168h cap). Cap at
+	// 168 hours (7 days) so even pathological cases retry weekly
+	// rather than monthly. Implemented as
+	// `NOW() - make_interval(hours => LEAST(attempts*attempts,168))`
+	// — make_interval is the only built-in way to express a
+	// row-dependent interval; concatenating into ::interval works
+	// but is ugly and slower.
 	row := s.pool.QueryRow(ctx, `
 		WITH candidate AS (
 		    SELECT r.repo_id
@@ -97,6 +126,12 @@ func (s *PostgresStore) ClaimNextScancodeRepo(ctx context.Context, cadence time.
 		           OR r.scancode_last_run < NOW() - $1::interval)
 		      AND (r.scancode_locked_at IS NULL
 		           OR r.scancode_locked_at < NOW() - $2::interval)
+		      AND (r.scancode_last_failed_at IS NULL
+		           OR r.scancode_last_failed_at < NOW() - make_interval(
+		               hours => LEAST(
+		                   GREATEST(COALESCE(r.scancode_failed_attempts, 0), 1)
+		                   * GREATEST(COALESCE(r.scancode_failed_attempts, 0), 1),
+		                   168)))
 		    ORDER BY r.scancode_last_run NULLS FIRST, r.repo_id
 		    LIMIT 1
 		    FOR UPDATE SKIP LOCKED
@@ -144,6 +179,11 @@ func (s *PostgresStore) RecordScancodeLockState(ctx context.Context, repoID int6
 // Atomic: the worker's "I finished" signal is one row write; no
 // possibility of a partial state where last_run is set but a lock
 // column lingers (which would confuse the next recovery pass).
+//
+// v0.21.4: also resets the failure counter (scancode_failed_attempts
+// = 0, scancode_last_failed_at = NULL) so a repo that previously
+// failed several times then succeeds doesn't carry the old attempt
+// count into the next failure cycle.
 func (s *PostgresStore) MarkScancodeComplete(ctx context.Context, repoID int64, version string) error {
 	_, err := s.pool.Exec(ctx, `
 		UPDATE aveloxis_data.repos
@@ -152,8 +192,50 @@ func (s *PostgresStore) MarkScancodeComplete(ctx context.Context, repoID int64, 
 		    scancode_locked_at = NULL,
 		    scancode_locked_pid = NULL,
 		    scancode_locked_boot_id = NULL,
-		    scancode_output_path = NULL
+		    scancode_output_path = NULL,
+		    scancode_failed_attempts = 0,
+		    scancode_last_failed_at = NULL
 		WHERE repo_id = $1`, repoID, version)
+	return err
+}
+
+// RecordScancodeFailure (v0.21.4) is the failure-path counterpart
+// to MarkScancodeComplete. It clears the lock columns AND increments
+// scancode_failed_attempts AND stamps scancode_last_failed_at = NOW()
+// so the claim query's backoff gate can compute time-since-failure.
+//
+// When the resulting failed_attempts reaches ScancodeMaxFailures the
+// UPDATE also stamps scancode_last_run = NOW(), which lets the
+// cadence gate (default 180 days) push the unrecoverable row out of
+// the active queue. Without that escape valve, a permanently-failing
+// repo would never stop consuming worker time — even the 7-day
+// backoff cap would let it retry weekly forever.
+//
+// Replaces ClearScancodeLock on every repo-specific failure path
+// in scancode_worker.runOne. ClearScancodeLock still exists for the
+// dispatcher's ctx-canceled-after-claim cleanup (which is a clean
+// release, not a failure).
+func (s *PostgresStore) RecordScancodeFailure(ctx context.Context, repoID int64) error {
+	// One UPDATE that:
+	//   - clears the four lock columns,
+	//   - increments scancode_failed_attempts (COALESCE for legacy NULL),
+	//   - stamps scancode_last_failed_at = NOW(),
+	//   - if the post-increment count >= ScancodeMaxFailures, also
+	//     stamps scancode_last_run = NOW() so the cadence gate
+	//     excludes the row.
+	_, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.repos
+		SET scancode_locked_at = NULL,
+		    scancode_locked_pid = NULL,
+		    scancode_locked_boot_id = NULL,
+		    scancode_output_path = NULL,
+		    scancode_failed_attempts = COALESCE(scancode_failed_attempts, 0) + 1,
+		    scancode_last_failed_at = NOW(),
+		    scancode_last_run = CASE
+		        WHEN COALESCE(scancode_failed_attempts, 0) + 1 >= $2 THEN NOW()
+		        ELSE scancode_last_run
+		    END
+		WHERE repo_id = $1`, repoID, ScancodeMaxFailures)
 	return err
 }
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -71,7 +71,19 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     scancode_locked_at      TIMESTAMPTZ,
     scancode_locked_pid     INTEGER,
     scancode_locked_boot_id TEXT,
-    scancode_output_path    TEXT
+    scancode_output_path    TEXT,
+    -- v0.21.4: per-repo failure tracking for the ScancodeWorker
+    -- backoff schedule. scancode_failed_attempts counts consecutive
+    -- failures (reset to 0 on success). scancode_last_failed_at is
+    -- the most recent failure time. The claim query consults both
+    -- to compute a per-row backoff window (quadratic, capped at
+    -- 7 days). After ScancodeMaxFailures consecutive failures the
+    -- failure-recording helper also stamps scancode_last_run = NOW()
+    -- so the cadence gate pushes the unrecoverable row out of the
+    -- queue for the full cadence window. See
+    -- internal/db/scancode_worker_store.go for the policy.
+    scancode_failed_attempts INTEGER DEFAULT 0,
+    scancode_last_failed_at  TIMESTAMPTZ
 );
 
 -- ============================================================

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.21.3"
+var ToolVersion = "0.21.4"


### PR DESCRIPTION
Fixes LFS issues with Scancode. 

v0.21.4 ships three fixes for the scancode failure loop diagnosed from aveloxis.log (731 starts → 301 failures concentrated in 10 looping repos):

  Fix 1 — Capture scancode stderr (internal/collector/tail_buffer.go, scancode_worker.go:417-420,453-454)
  Subprocess output is now captured into a bounded tailBuffer (4 KB cap) and logged as stderr_tail / stdout_tail on failure. Future exit status 1 failures are diagnosable in one log read.

  Fix 2 — GIT_LFS_SKIP_SMUDGE=1 on clone (scancode_worker.go:371-372)
  The 214 LFS-budget-exhausted clone failures (nasa/RtRetrievalFramework, nasa/Mixed-Reality-Exploration-Toolkit) now succeed — scancode only needs source-license + copyright headers, not LFS binary payloads.

  Fix 3 — Failure tracking + exponential backoff
  - New schema columns: scancode_failed_attempts, scancode_last_failed_at (added in schema.sql + migrate.go).
  - New store method RecordScancodeFailure replaces ClearScancodeLock on every repo-specific failure path. It clears the lock, increments the counter, stamps the failure
   time, AND at ≥10 consecutive failures also stamps scancode_last_run = NOW() to push the row out for the full cadence window.
  - ClaimNextScancodeRepo gains a quadratic backoff gate (1h → 4h → 9h → ... → 168h cap) via make_interval(hours => LEAST(attempts*attempts, 168)).
  - MarkScancodeComplete resets the counter on success.

  15 new tests, all packages green, version bumped to 0.21.4