### PR TITLE
Feat/issue accelerate

### DIFF
--- a/aveloxis-shadow-rest.json
+++ b/aveloxis-shadow-rest.json
@@ -4,7 +4,7 @@
     "port": 5432,
     "user": "aveloxis",
     "password": "fuckoffdawn",
-    "dbname": "aveloxis_shadow_graphql",
+    "dbname": "aveloxis_shadow_rest",
     "sslmode": "prefer"
   },
   "github": {
@@ -20,24 +20,24 @@
     "days_until_recollect": 6,
     "workers": 40,
     "force_full": false,
-    "repo_clone_dir": "~/aveloxis-repos-shadow-graphql/",
+    "repo_clone_dir": "~/aveloxis-repos-shadow-rest/",
     "matview_rebuild_day": "friday",
     "matview_rebuild_on_startup": false,
-    "pr_child_mode": "graphql",
-    "listing_mode": "graphql",
-    "threading_mode": "sharded",
-    "shard_size": 500,
-    "issue_child_mode": "graphql",
+    "pr_child_mode": "rest",
+    "listing_mode": "rest",
+    "threading_mode": "single",
+    "shard_size": 3000,
+    "issue_child_mode": "rest",
     "scancode_workers": 2,
     "scancode_start_interval_s": 90,
     "scancode_cadence_days": 180,
-    "scancode_clone_dir": "/tmp/aveloxis-scancode-shadow",
+    "scancode_clone_dir": "/tmp/aveloxis-scancode-shadow-rest",
     "scancode_shutdown_grace_minutes": 30
   },
   "web": {
-    "addr": ":9082",
+    "addr": ":9081",
     "dev_mode": true,
-    "base_url": "http://localhost:9082"
+    "base_url": "http://localhost:9081"
   },
   "log_level": "info"
 }

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -33,6 +33,7 @@
     "listing_mode": "rest",
     "threading_mode": "single",
     "shard_size": 3000,
+    "issue_child_mode": "rest",
     "enrich_interval_minutes": 30,
     "search_resolve_interval_minutes": 60,
     "affiliation_interval_minutes": 60,

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -163,6 +163,7 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		ListingMode:           cfg.Collection.ListingMode,
 		ThreadingMode:         cfg.Collection.ThreadingMode,
 		ShardSize:             cfg.Collection.ShardSize,
+		IssueChildMode:        cfg.Collection.IssueChildMode,
 		EnrichInterval:        cfg.Collection.EnrichIntervalDuration(),
 		SearchResolveInterval: cfg.Collection.SearchResolveIntervalDuration(),
 		AffiliationInterval:   cfg.Collection.AffiliationIntervalDuration(),

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -65,6 +65,7 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "listing_mode": "graphql",
     "threading_mode": "sharded",
     "shard_size": 3000,
+    "issue_child_mode": "graphql",
     "enrich_interval_minutes": 30,
     "search_resolve_interval_minutes": 60,
     "affiliation_interval_minutes": 60,
@@ -156,6 +157,7 @@ These four settings control the staged collector's request shape. The default fo
 | `collection.listing_mode` | string | `"rest"` | `"rest"` uses separate iterators for `/issues` and `/pulls`. `"graphql"` (v0.18.2+) calls `ListIssuesAndPRs` once per repo — a pair of paginated GraphQL queries instead of two REST scans. Setting both this AND `pr_child_mode` to `"graphql"` activates v0.18.5's `fullGraphQLMode` gate: conversation comments are delivered inline, eliminating one repo-wide REST call. |
 | `collection.threading_mode` | string | `"single"` | `"single"` fetches PR batches sequentially. `"sharded"` (v0.18.3+) partitions the enumerated PR list and runs each shard in its own goroutine when the PR count exceeds `shard_size`. Only activates when `pr_child_mode=graphql`. |
 | `collection.shard_size` | integer | `3000` | Item-count threshold for `threading_mode=sharded`. Number of shards = `ceil(prs / shard_size)`. Smaller values fan out earlier on medium repos. Ignored when `threading_mode != "sharded"`. |
+| `collection.issue_child_mode` | string | `"rest"` | `"rest"` fetches each issue's labels and assignees via two per-issue REST calls (the legacy waterfall — ~0.5s per issue on a 73-key fleet). `"graphql"` (v0.22.0+, phase 5) drains labels and assignees from the inline maps delivered by `ListIssuesAndPRs`, eliminating both REST calls per issue. ~100× speedup on the issue phase on repos with thousands of issues. Requires `listing_mode=graphql` to have effect (the inline maps come from that path). GitLab path is REST composition in both modes (column parity preserved). Trade-off: `platform_label_id` in `issue_labels` stays 0 on the GraphQL path because GitHub's GraphQL `Label` type has no `databaseId` — same gap as `pull_request_labels.platform_label_id`. The column has no downstream consumers (no SELECT/JOIN/WHERE) so this is a known parity gap, not a regression. Detection of label renames within a project becomes impossible (renamed labels look like distinct rows). |
 
 **Background tasks**
 

--- a/internal/collector/phase4_comments_gate_test.go
+++ b/internal/collector/phase4_comments_gate_test.go
@@ -5,6 +5,7 @@ package collector
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -78,11 +79,17 @@ func TestPhase4StagedPRCarriesInlineComments(t *testing.T) {
 	}
 	code := string(src)
 
-	if !strings.Contains(code, "Comments []MessageWithRef") {
+	// Use whitespace-tolerant regex: gofmt aligns struct fields in
+	// columns, so adding a longer-named field later shifts the spacing
+	// on every existing field. The contract is "name + type", not
+	// "exact spacing".
+	commentsRE := regexp.MustCompile(`\bComments\s+\[\]MessageWithRef\b`)
+	if !commentsRE.MatchString(code) {
 		t.Error("platform.StagedPR must declare Comments []MessageWithRef for inline " +
 			"PR conversation comments delivered by phase 4's GraphQL PR batch")
 	}
-	if !strings.Contains(code, "IssueComments []MessageWithRef") {
+	issueCommentsRE := regexp.MustCompile(`\bIssueComments\s+\[\]MessageWithRef\b`)
+	if !issueCommentsRE.MatchString(code) {
 		t.Error("platform.IssueAndPRBatch must declare IssueComments []MessageWithRef for " +
 			"inline issue conversation comments delivered by phase 4's unified listing")
 	}

--- a/internal/collector/phase5_issue_children_test.go
+++ b/internal/collector/phase5_issue_children_test.go
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestPhase5IssueAndPRBatchCarriesLabelsAndAssignees — source-contract
+// test pinning that the platform.IssueAndPRBatch envelope carries the
+// inline issue labels and assignees delivered by phase 5's GraphQL
+// listing.
+//
+// Without these map fields, the mappers have nowhere to put label /
+// assignee data and the staged collector has nothing to drain, so
+// phase 5 would silently fall back to the REST per-issue iterators in
+// every mode — making the config flag a no-op.
+func TestPhase5IssueAndPRBatchCarriesLabelsAndAssignees(t *testing.T) {
+	src, err := os.ReadFile("../platform/platform.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Whitespace-tolerant regex: gofmt aligns struct fields in columns,
+	// so a longer-named sibling field shifts spacing here.
+	labelsRE := regexp.MustCompile(`\bIssueLabels\s+map\[int\]\[\]model\.IssueLabel\b`)
+	if !labelsRE.MatchString(code) {
+		t.Error("platform.IssueAndPRBatch must declare " +
+			"IssueLabels map[int][]model.IssueLabel for inline issue labels " +
+			"delivered by phase 5's GraphQL listing — keyed by issue number")
+	}
+	assigneesRE := regexp.MustCompile(`\bIssueAssignees\s+map\[int\]\[\]model\.IssueAssignee\b`)
+	if !assigneesRE.MatchString(code) {
+		t.Error("platform.IssueAndPRBatch must declare " +
+			"IssueAssignees map[int][]model.IssueAssignee for inline issue " +
+			"assignees delivered by phase 5's GraphQL listing — keyed by issue number")
+	}
+}
+
+// TestPhase5ListIssuesGraphQLSelectsLabelsAndAssignees — source-contract
+// test pinning that the GraphQL issues listing query selects labels and
+// assignees connections inline.
+//
+// If a refactor drops these selections from the query but leaves the
+// surrounding map plumbing in place, every map would silently be empty
+// and the staged collector would fall back to REST without telling
+// anyone — collapsing the phase 5 speedup to zero.
+func TestPhase5ListIssuesGraphQLSelectsLabelsAndAssignees(t *testing.T) {
+	src, err := os.ReadFile("../platform/github/graphql_listing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// The two connection selections must appear in listIssuesGraphQL's
+	// embedded query string.
+	if !strings.Contains(code, "labels(first: 100)") {
+		t.Error("listIssuesGraphQL must select labels(first: 100) on each " +
+			"issue node — phase 5 of the REST → GraphQL refactor")
+	}
+	if !strings.Contains(code, "assignees(first: 100)") {
+		t.Error("listIssuesGraphQL must select assignees(first: 100) on each " +
+			"issue node — phase 5 of the REST → GraphQL refactor")
+	}
+}
+
+// TestPhase5PaginateIssueLabelsAndAssigneesHelpersExist — source-contract
+// test pinning the two pagination follow-up helpers for issues with
+// >100 labels or >100 assignees. Without them, pathological issues
+// silently lose data past the first 100 entries.
+func TestPhase5PaginateIssueLabelsAndAssigneesHelpersExist(t *testing.T) {
+	src, err := os.ReadFile("../platform/github/graphql_listing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "func (c *Client) paginateIssueLabels(") {
+		t.Error("graphql_listing.go must define paginateIssueLabels — issues " +
+			"with more than 100 labels lose data past the first page without it")
+	}
+	if !strings.Contains(code, "func (c *Client) paginateIssueAssignees(") {
+		t.Error("graphql_listing.go must define paginateIssueAssignees — issues " +
+			"with more than 100 assignees lose data past the first page without it")
+	}
+	// Both helpers must actually be CALLED from listIssuesGraphQL on the
+	// HasNextPage branch, not just defined. A refactor that drops the call
+	// site reintroduces the truncation bug.
+	if !strings.Contains(code, "c.paginateIssueLabels(") {
+		t.Error("listIssuesGraphQL must call paginateIssueLabels when " +
+			"Labels.PageInfo.HasNextPage is true on an issue node")
+	}
+	if !strings.Contains(code, "c.paginateIssueAssignees(") {
+		t.Error("listIssuesGraphQL must call paginateIssueAssignees when " +
+			"Assignees.PageInfo.HasNextPage is true on an issue node")
+	}
+}
+
+// TestPhase5CollectIssuesSkipsRESTChildrenInGraphQLMode — source-
+// contract test pinning that collectIssues skips the per-issue
+// ListIssueLabels and ListIssueAssignees REST iterators when the
+// staged collector is configured with issueChildMode=graphql AND the
+// inline maps from ListIssuesAndPRs are non-nil.
+//
+// Without this gate, phase 5 buys us the inline GraphQL fetch but then
+// the REST iterators still run alongside it — double the work, no
+// speedup. With the gate, the REST loop only runs in rest mode or
+// when the inline maps are nil (e.g., GitLab REST composition path).
+func TestPhase5CollectIssuesSkipsRESTChildrenInGraphQLMode(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "issueChildMode") {
+		t.Error("staged.go must define an issueChildMode field on " +
+			"StagedCollector — phase 5 config gate for inline issue label / " +
+			"assignee fetching via GraphQL")
+	}
+	// The gate must appear in collectIssues and be paired with a map-non-nil
+	// check so the REST fallback still fires when the inline maps are absent
+	// (GitLab path, or graphql listing failed and fell back).
+	if !strings.Contains(code, "preLabels") {
+		t.Error("collectIssues must accept a preLabels map parameter — " +
+			"phase 5 drains inline labels by issue number into the stagedIssue " +
+			"envelope without touching ListIssueLabels")
+	}
+	if !strings.Contains(code, "preAssignees") {
+		t.Error("collectIssues must accept a preAssignees map parameter — " +
+			"phase 5 drains inline assignees by issue number into the " +
+			"stagedIssue envelope without touching ListIssueAssignees")
+	}
+}
+
+// TestPhase5StagedCollectorConstructorAcceptsIssueChildMode —
+// source-contract test pinning the explicit constructor accepts an
+// issueChildMode parameter and threads it through to the struct.
+// Without this wiring the config field set in aveloxis.json never
+// reaches the StagedCollector and the gate stays at its default.
+func TestPhase5StagedCollectorConstructorAcceptsIssueChildMode(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// One of the constructor signatures must accept the new mode. The
+	// established pattern (phases 1, 2, 3) added a new "WithAll…" variant
+	// per phase. Phase 5 may extend NewStagedCollectorWithAllModes or
+	// introduce a phase-5-named constructor — either is acceptable as
+	// long as the field is threaded through.
+	if !strings.Contains(code, "issueChildMode") {
+		t.Error("StagedCollector must thread issueChildMode through a " +
+			"constructor — phase 5 wiring from CollectionConfig.IssueChildMode")
+	}
+	if !strings.Contains(code, "sc.issueChildMode") &&
+		!strings.Contains(code, "issueChildMode: issueChildMode") &&
+		!strings.Contains(code, "issueChildMode:   issueChildMode") {
+		t.Error("StagedCollector constructor must set the struct's " +
+			"issueChildMode field from a parameter (literal assignment in " +
+			"struct literal or via a sc.issueChildMode = … line)")
+	}
+}
+
+// TestPhase5ConfigHasIssueChildMode — source-contract test pinning
+// the CollectionConfig field + JSON tag for operator-facing config.
+//
+// Without the field, the JSON parser silently ignores any
+// "issue_child_mode" key in aveloxis.json and the config flag does
+// nothing — exactly the failure mode v0.20.18 ripped out for
+// `batch_size`.
+func TestPhase5ConfigHasIssueChildMode(t *testing.T) {
+	src, err := os.ReadFile("../config/config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "IssueChildMode") {
+		t.Error("CollectionConfig must declare an IssueChildMode field — " +
+			"phase 5 operator-facing config flag for inline GraphQL issue children")
+	}
+	if !strings.Contains(code, `json:"issue_child_mode"`) {
+		t.Error("CollectionConfig.IssueChildMode must carry " +
+			`json:"issue_child_mode"` + " — operators set this in aveloxis.json")
+	}
+	if !strings.Contains(code, `IssueChildMode:`) ||
+		!strings.Contains(code, `"rest"`) {
+		t.Error("DefaultConfig must set IssueChildMode: \"rest\" — phase 5 " +
+			"ships opt-in; default flip to graphql is reserved for phase 5.2")
+	}
+}
+
+// TestPhase5SchedulerConfigHasIssueChildMode — source-contract test
+// pinning scheduler.Config carries the field. Without it, main.go's
+// wiring from cfg.Collection.IssueChildMode to the scheduler has
+// nowhere to land.
+func TestPhase5SchedulerConfigHasIssueChildMode(t *testing.T) {
+	src, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "IssueChildMode") {
+		t.Error("scheduler.Config must declare an IssueChildMode field — " +
+			"phase 5 wiring from CollectionConfig through to NewStagedCollector…")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -100,15 +100,16 @@ type stagedPR struct {
 // StagedCollector writes raw API data to the staging table instead of directly
 // into the relational schema. This is the fast path for high-throughput collection.
 type StagedCollector struct {
-	client        platform.Client
-	store         *db.PostgresStore
-	logger        *slog.Logger
-	platID        int16
-	prChildMode   string // "rest" (default) or "graphql" — see CollectionConfig.PRChildMode
-	listingMode   string // "rest" (default) or "graphql" — see CollectionConfig.ListingMode
-	threadingMode string // "single" (default) or "sharded" — see CollectionConfig.ThreadingMode
-	shardSize     int    // item-count threshold for sharded fan-out (default 3000)
-	workers       int    // scheduler worker pool size — feeds parallelSlotsForWorkers
+	client         platform.Client
+	store          *db.PostgresStore
+	logger         *slog.Logger
+	platID         int16
+	prChildMode    string // "rest" (default) or "graphql" — see CollectionConfig.PRChildMode
+	listingMode    string // "rest" (default) or "graphql" — see CollectionConfig.ListingMode
+	threadingMode  string // "single" (default) or "sharded" — see CollectionConfig.ThreadingMode
+	shardSize      int    // item-count threshold for sharded fan-out (default 3000)
+	issueChildMode string // "rest" (default) or "graphql" — phase 5: inline issue label+assignee fetch via the GraphQL listing
+	workers        int    // scheduler worker pool size — feeds parallelSlotsForWorkers
 }
 
 // WithWorkers records the scheduler's worker-pool size on a
@@ -121,6 +122,21 @@ func (sc *StagedCollector) WithWorkers(n int) *StagedCollector {
 		n = 0
 	}
 	sc.workers = n
+	return sc
+}
+
+// WithIssueChildMode sets the phase 5 mode controlling whether issue
+// labels + assignees are fetched via per-issue REST iterators (the
+// legacy path) or drained from the inline maps delivered by the
+// GraphQL listing. Unknown values collapse to "rest". Returns the
+// same collector for chaining. Kept as a chainable setter (rather
+// than a new constructor) because the phase 1/2/3 constructor
+// signature is already at 7 parameters.
+func (sc *StagedCollector) WithIssueChildMode(mode string) *StagedCollector {
+	if mode != "graphql" {
+		mode = "rest"
+	}
+	sc.issueChildMode = mode
 	return sc
 }
 
@@ -166,14 +182,15 @@ func NewStagedCollectorWithAllModes(client platform.Client, store *db.PostgresSt
 		shardSize = defaultShardSize
 	}
 	return &StagedCollector{
-		client:        client,
-		store:         store,
-		logger:        logger,
-		platID:        int16(client.Platform()),
-		prChildMode:   prChildMode,
-		listingMode:   listingMode,
-		threadingMode: threadingMode,
-		shardSize:     shardSize,
+		client:         client,
+		store:          store,
+		logger:         logger,
+		platID:         int16(client.Platform()),
+		prChildMode:    prChildMode,
+		listingMode:    listingMode,
+		threadingMode:  threadingMode,
+		shardSize:      shardSize,
+		issueChildMode: "rest", // phase 5 — opt in via WithIssueChildMode
 	}
 }
 
@@ -312,48 +329,77 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 // collectSequential runs issues, PRs, events, and messages one after another.
 // Used for repos with fewer than LargeRepoCommitThreshold commits.
 func (sc *StagedCollector) collectSequential(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
-	preIssues, prePRs, preIssueComments := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
-	sc.collectIssues(ctx, sw, owner, repo, since, result, preIssues)
-	sc.stageInlineIssueComments(ctx, sw, preIssueComments, result)
-	sc.collectPRs(ctx, sw, owner, repo, since, result, prePRs)
+	pre := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
+	sc.collectIssues(ctx, sw, owner, repo, since, result, pre.issues, pre.issueLabels, pre.issueAssignees)
+	sc.stageInlineIssueComments(ctx, sw, pre.issueComments, result)
+	sc.collectPRs(ctx, sw, owner, repo, since, result, pre.prs)
 	sc.collectEvents(ctx, sw, owner, repo, since, result)
 	sc.collectMessages(ctx, sw, owner, repo, since, result)
 }
 
+// preEnumerateBatch carries the result of the unified GraphQL
+// issue+PR listing. issues and prs are non-nil empty slices when the
+// listing succeeded with zero items, so the caller can distinguish
+// "pre-fetched, found none" from "not pre-fetched, use iterator".
+// issueLabels and issueAssignees are nil unless phase 5's
+// IssueChildMode is "graphql" (kept nil otherwise so collectIssues
+// can short-circuit cheaply).
+type preEnumerateBatch struct {
+	issues         []model.Issue
+	prs            []model.PullRequest
+	issueComments  []platform.MessageWithRef
+	issueLabels    map[int][]model.IssueLabel
+	issueAssignees map[int][]model.IssueAssignee
+}
+
 // preEnumerateIfGraphQL does the unified GraphQL issue+PR listing once
 // when listingMode=graphql, returning the issue and PR slices plus the
-// inline issue comments delivered with the listing (phase 4). In
-// listingMode=rest it returns (nil, nil, nil) — the legacy per-path
-// iterators in collectIssues and collectPRs remain in charge, and the
-// repo-wide collectMessages call keeps its job.
+// inline issue comments (phase 4) and the inline issue labels +
+// assignees (phase 5) delivered with the listing. In listingMode=rest
+// it returns an empty batch — the legacy per-path iterators in
+// collectIssues and collectPRs remain in charge.
 //
 // Non-fatal errors from the unified listing are logged and the function
-// returns (nil, nil, nil) so collection falls through to the legacy
+// returns an empty batch so collection falls through to the legacy
 // iterators. This way a transient GraphQL problem doesn't take down the
 // entire repo's collection — we just lose the speedup for this cycle.
-func (sc *StagedCollector) preEnumerateIfGraphQL(ctx context.Context, owner, repo string, since time.Time, _ *CollectResult) ([]model.Issue, []model.PullRequest, []platform.MessageWithRef) {
+func (sc *StagedCollector) preEnumerateIfGraphQL(ctx context.Context, owner, repo string, since time.Time, _ *CollectResult) preEnumerateBatch {
 	if sc.listingMode != "graphql" {
-		return nil, nil, nil
+		return preEnumerateBatch{}
 	}
 	batch, err := sc.client.ListIssuesAndPRs(ctx, owner, repo, since)
 	if err != nil {
+		// Surface partial results even on error: ListIssuesAndPRs (phase 5)
+		// returns the batch with whatever issues/labels/assignees made it
+		// before the error, so we still stage them rather than discarding
+		// all the work done so far.
+		if batch != nil && (len(batch.Issues) > 0 || len(batch.PullRequests) > 0) {
+			sc.logger.Warn("unified GraphQL listing errored after partial results — staging what we got, then falling back to REST iterators for the rest",
+				"owner", owner, "repo", repo, "error", err,
+				"partial_issues", len(batch.Issues), "partial_prs", len(batch.PullRequests))
+			return preEnumerateBatch{
+				issues:         batch.Issues,
+				prs:            batch.PullRequests,
+				issueComments:  batch.IssueComments,
+				issueLabels:    batch.IssueLabels,
+				issueAssignees: batch.IssueAssignees,
+			}
+		}
 		if isOptionalEndpointSkip(err) {
 			sc.logger.Info("unified listing skipped — falling back to REST iterators",
 				"owner", owner, "repo", repo, "reason", err)
-			return nil, nil, nil
+			return preEnumerateBatch{}
 		}
 		sc.logger.Warn("unified GraphQL listing failed — falling back to REST iterators",
 			"owner", owner, "repo", repo, "error", err)
-		return nil, nil, nil
+		return preEnumerateBatch{}
 	}
 	sc.logger.Info("unified listing complete",
 		"owner", owner, "repo", repo,
 		"issues", len(batch.Issues), "prs", len(batch.PullRequests),
-		"inline_issue_comments", len(batch.IssueComments))
-	// Initialize to non-nil empty slices when the batch had zero items
-	// so the caller can distinguish "pre-fetched, found none" from
-	// "not pre-fetched, use iterator". Legacy rest-mode callers still
-	// see (nil, nil, nil).
+		"inline_issue_comments", len(batch.IssueComments),
+		"inline_issue_labels_buckets", len(batch.IssueLabels),
+		"inline_issue_assignees_buckets", len(batch.IssueAssignees))
 	issues := batch.Issues
 	if issues == nil {
 		issues = []model.Issue{}
@@ -362,7 +408,13 @@ func (sc *StagedCollector) preEnumerateIfGraphQL(ctx context.Context, owner, rep
 	if prs == nil {
 		prs = []model.PullRequest{}
 	}
-	return issues, prs, batch.IssueComments
+	return preEnumerateBatch{
+		issues:         issues,
+		prs:            prs,
+		issueComments:  batch.IssueComments,
+		issueLabels:    batch.IssueLabels,
+		issueAssignees: batch.IssueAssignees,
+	}
 }
 
 // stageInlineIssueComments stages the issue comments that came inline
@@ -414,7 +466,7 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 	// Pre-enumerate once before forking goroutines when listingMode is
 	// graphql. Calling ListIssuesAndPRs in each child goroutine would
 	// double-fetch the entire data set.
-	preIssues, prePRs, preIssueComments := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
+	pre := sc.preEnumerateIfGraphQL(ctx, owner, repo, since, result)
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex // protects result.Errors and counts
@@ -428,8 +480,8 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 		defer wg.Done()
 		issueSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
 		localResult := &CollectResult{}
-		sc.collectIssues(ctx, issueSW, owner, repo, since, localResult, preIssues)
-		sc.stageInlineIssueComments(ctx, issueSW, preIssueComments, localResult)
+		sc.collectIssues(ctx, issueSW, owner, repo, since, localResult, pre.issues, pre.issueLabels, pre.issueAssignees)
+		sc.stageInlineIssueComments(ctx, issueSW, pre.issueComments, localResult)
 		if err := issueSW.Flush(ctx); err != nil {
 			localResult.Errors = append(localResult.Errors, fmt.Errorf("issue flush: %w", err))
 		}
@@ -445,7 +497,7 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 		defer wg.Done()
 		prSW := db.NewStagingWriter(sc.store, repoID, sc.platID, sc.logger)
 		localResult := &CollectResult{}
-		sc.collectPRs(ctx, prSW, owner, repo, since, localResult, prePRs)
+		sc.collectPRs(ctx, prSW, owner, repo, since, localResult, pre.prs)
 		if err := prSW.Flush(ctx); err != nil {
 			localResult.Errors = append(localResult.Errors, fmt.Errorf("pr flush: %w", err))
 		}
@@ -490,13 +542,30 @@ func (sc *StagedCollector) collectParallel(ctx context.Context, repoID int64, ow
 // unified ListIssuesAndPRs call (phase 2, listingMode=graphql); the
 // iterator path is bypassed. When nil, the legacy ListIssues iterator
 // drives enumeration (listingMode=rest, the default).
-func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult, preEnumerated []model.Issue) {
+//
+// Phase 5: when issueChildMode=="graphql" AND the preLabels /
+// preAssignees maps are non-nil (delivered by ListIssuesAndPRs on
+// GitHub), labels and assignees are drained from the maps by issue
+// number — the per-issue ListIssueLabels and ListIssueAssignees REST
+// calls are skipped. In every other configuration (rest mode, GitLab
+// REST composition, GraphQL listing fell back) the legacy per-issue
+// REST iterators run as before.
+func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult, preEnumerated []model.Issue, preLabels map[int][]model.IssueLabel, preAssignees map[int][]model.IssueAssignee) {
 	mode := sc.listingMode
 	if preEnumerated == nil && mode == "graphql" {
 		// Pre-enumeration failed or wasn't done. Fall back to REST.
 		mode = "rest"
 	}
-	sc.logger.Info("collecting issues", "owner", owner, "repo", repo, "listing_mode", mode)
+	// Phase 5 inline-child mode fires only when explicitly enabled AND
+	// the inline maps are present (GitHub graphql path). On GitLab
+	// FetchPRBatch-style REST composition the maps stay nil and we
+	// fall through to the legacy REST iterators below.
+	inlineChildren := sc.issueChildMode == "graphql" && (preLabels != nil || preAssignees != nil)
+	sc.logger.Info("collecting issues",
+		"owner", owner, "repo", repo,
+		"listing_mode", mode,
+		"issue_child_mode", sc.issueChildMode,
+		"inline_children", inlineChildren)
 
 	issues := preEnumerated
 	if preEnumerated == nil {
@@ -517,17 +586,26 @@ func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWrit
 
 	for _, issue := range issues {
 		envelope := stagedIssue{Issue: issue}
-		for label, err := range sc.client.ListIssueLabels(ctx, owner, repo, issue.Number) {
-			if err != nil {
-				break
+		if inlineChildren {
+			// Phase 5: labels + assignees came inline with the listing.
+			// preLabels and preAssignees are nil-safe to index (a nil map
+			// returns the zero value, which is a nil slice — fine).
+			envelope.Labels = preLabels[issue.Number]
+			envelope.Assignees = preAssignees[issue.Number]
+		} else {
+			// Legacy REST path: two per-issue iterators.
+			for label, err := range sc.client.ListIssueLabels(ctx, owner, repo, issue.Number) {
+				if err != nil {
+					break
+				}
+				envelope.Labels = append(envelope.Labels, label)
 			}
-			envelope.Labels = append(envelope.Labels, label)
-		}
-		for assignee, err := range sc.client.ListIssueAssignees(ctx, owner, repo, issue.Number) {
-			if err != nil {
-				break
+			for assignee, err := range sc.client.ListIssueAssignees(ctx, owner, repo, issue.Number) {
+				if err != nil {
+					break
+				}
+				envelope.Assignees = append(envelope.Assignees, assignee)
 			}
-			envelope.Assignees = append(envelope.Assignees, assignee)
 		}
 		if err := sw.Stage(ctx, EntityIssue, envelope); err != nil {
 			result.Errors = append(result.Errors, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,22 @@ type CollectionConfig struct {
 	// Ignored when ThreadingMode != "sharded".
 	ShardSize int `json:"shard_size"`
 
+	// IssueChildMode selects between per-issue REST label+assignee
+	// fetching (the legacy waterfall, ~2 REST calls per issue) and
+	// inline GraphQL delivery ("graphql" — labels and assignees arrive
+	// in the issue listing). When "graphql", the staged collector
+	// skips ListIssueLabels and ListIssueAssignees per-issue REST
+	// iterators; data comes from the IssueLabels / IssueAssignees
+	// maps on IssueAndPRBatch. GitLab repos keep running the REST
+	// path regardless of mode (GitLab's REST-composition
+	// ListIssuesAndPRs leaves the maps nil).
+	//
+	// Phase 5 of the REST → GraphQL refactor. See
+	// summary/06-issue-graphql-children.md for the full plan.
+	// Default "rest" so existing deployments pick up v0.22.0 without
+	// a behavior change until operators explicitly opt in.
+	IssueChildMode string `json:"issue_child_mode"`
+
 	// EnrichIntervalMinutes controls how often thin-contributor profile
 	// enrichment runs as a periodic scheduler task. v0.18.29 moved
 	// enrichment off the per-job hot path because every worker calling
@@ -572,6 +588,7 @@ func DefaultConfig() *Config {
 			ListingMode:             "rest",
 			ThreadingMode:           "single",
 			ShardSize:               3000,
+			IssueChildMode:          "rest",
 			// v0.21.0 ScancodeWorker defaults — see CollectionConfig
 			// field docs for the full rationale.
 			ScancodeWorkers:              2,

--- a/internal/db/contributor_batch_deterministic_uuid_test.go
+++ b/internal/db/contributor_batch_deterministic_uuid_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestUpsertContributorBatchSuppliesDeterministicCntrbID is the
+// v0.22.0 source-contract regression test for the bug surfaced by the
+// phase 5 shadow-diff run: the bulk `/contributors` endpoint path
+// (UpsertContributorBatch) was NOT supplying cntrb_id in its INSERT
+// column list, so every contributor inserted via that path got a
+// random UUID from the schema's `cntrb_id UUID PRIMARY KEY DEFAULT
+// gen_random_uuid()` default. Combined with ContributorResolver.
+// Resolve's v0.19.2 lookup-by-cntrb_login step, every issue/PR actor
+// observation that hit the same login picked up the random UUID — so
+// the deterministic-PlatformUUID promise from v0.18.1 was reality for
+// almost no production rows.
+//
+// The fix: UpsertContributorBatch computes cntrb_id =
+// PlatformUUID(platform, userID) when the contributor has at least
+// one identity with userID > 0, and supplies it in the INSERT.
+// Fallback to NULL (Postgres uses gen_random_uuid() default) for
+// email-only contributors with no platform identity. Existing rows
+// keep their random UUIDs via ON CONFLICT (cntrb_login) DO UPDATE,
+// which never SETs cntrb_id — that's the no-migrate policy
+// documented in CLAUDE.md alongside the v0.20.2 16-table-FK-rewrite
+// rejection precedent.
+//
+// Three source-level signals are pinned:
+//
+//  1. cntrb_id appears in the INSERT column list of
+//     UpsertContributorBatch.
+//  2. The function body references PlatformUUID(...) computed from
+//     the contributor's identities.
+//  3. The SQL uses COALESCE with gen_random_uuid() so a NULL desired
+//     ID falls back to the schema default (email-only contributors
+//     case) instead of producing a NULL primary key.
+//
+// If a future refactor drops the cntrb_id column from the INSERT —
+// the exact regression v0.22.0 fixed — this test fails before merge.
+func TestUpsertContributorBatchSuppliesDeterministicCntrbID(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Extract the UpsertContributorBatch function body so we don't
+	// false-match unrelated INSERTs elsewhere in the file.
+	startMarker := "func (s *PostgresStore) UpsertContributorBatch("
+	startIdx := strings.Index(code, startMarker)
+	if startIdx < 0 {
+		t.Fatalf("could not find UpsertContributorBatch in postgres.go")
+	}
+	body := code[startIdx:]
+	// Crude end marker: the next top-level func declaration.
+	if endIdx := strings.Index(body[len(startMarker):], "\nfunc "); endIdx > 0 {
+		body = body[:len(startMarker)+endIdx]
+	}
+
+	// Signal 1: cntrb_id in the INSERT column list. Whitespace-
+	// tolerant — the column list spans multiple lines in gofmt.
+	insertColumnsRE := regexp.MustCompile(`INSERT\s+INTO\s+aveloxis_data\.contributors\s*\(\s*cntrb_id`)
+	if !insertColumnsRE.MatchString(body) {
+		t.Error("UpsertContributorBatch INSERT must include cntrb_id as the " +
+			"first column in the column list — without it, Postgres uses the " +
+			"gen_random_uuid() default and the deterministic-UUID promise " +
+			"breaks. This is the v0.22.0 phase 5 shadow-diff regression.")
+	}
+
+	// Signal 2: PlatformUUID is called somewhere in the function body
+	// to compute the desired cntrb_id from a contributor identity.
+	if !strings.Contains(body, "PlatformUUID(") {
+		t.Error("UpsertContributorBatch must call PlatformUUID(...) to " +
+			"compute the deterministic cntrb_id from a contributor's " +
+			"identity. Without this, the deterministic-UUID code path " +
+			"in ContributorResolver.Resolve never wins because the bulk " +
+			"endpoint always inserts first with a random UUID.")
+	}
+
+	// Signal 3: COALESCE wrapper falls back to gen_random_uuid() when
+	// no platform identity is available (email-only contributors).
+	// The combination "COALESCE(...gen_random_uuid()...)" is the
+	// canonical shape — exact spacing varies with gofmt.
+	coalesceRE := regexp.MustCompile(`COALESCE\s*\(\s*\$\d+\s*::\s*uuid\s*,\s*gen_random_uuid\(\s*\)\s*\)`)
+	if !coalesceRE.MatchString(body) {
+		t.Error("UpsertContributorBatch INSERT must use " +
+			"COALESCE($N::uuid, gen_random_uuid()) for the cntrb_id " +
+			"VALUES position. The NULL→default fallback handles " +
+			"email-only contributors (no platform identity) without " +
+			"breaking the deterministic-UUID path for the common case.")
+	}
+}
+
+// TestUpsertContributorBatchPreservesExistingCntrbIDOnConflict pins
+// the no-migrate policy: ON CONFLICT (cntrb_login) DO UPDATE must
+// NOT include cntrb_id in its SET list. Existing random-UUID rows
+// in production stay random; only fresh inserts get deterministic
+// UUIDs. This matches the v0.20.2 precedent of refusing to do a
+// physical FK rewrite for identity consolidation.
+//
+// Without this pin, a well-meaning refactor could add `cntrb_id =
+// EXCLUDED.cntrb_id` to the SET clause and break every existing
+// FK pointing at a contributor row.
+func TestUpsertContributorBatchPreservesExistingCntrbIDOnConflict(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	startIdx := strings.Index(code, "func (s *PostgresStore) UpsertContributorBatch(")
+	if startIdx < 0 {
+		t.Fatal("UpsertContributorBatch not found")
+	}
+	body := code[startIdx:]
+	if endIdx := strings.Index(body[1:], "\nfunc "); endIdx > 0 {
+		body = body[:1+endIdx]
+	}
+
+	// Find the DO UPDATE SET block specifically.
+	doUpdateStart := strings.Index(body, "DO UPDATE SET")
+	if doUpdateStart < 0 {
+		t.Fatal("DO UPDATE SET block not found in UpsertContributorBatch")
+	}
+	doUpdateEnd := strings.Index(body[doUpdateStart:], "RETURNING")
+	if doUpdateEnd < 0 {
+		t.Fatal("RETURNING marker not found after DO UPDATE SET")
+	}
+	doUpdateBlock := body[doUpdateStart : doUpdateStart+doUpdateEnd]
+
+	// The DO UPDATE block must NOT assign cntrb_id from EXCLUDED.
+	// Tolerate whitespace and equal-sign spacing.
+	cntrbIDInSet := regexp.MustCompile(`cntrb_id\s*=`).MatchString(doUpdateBlock)
+	if cntrbIDInSet {
+		t.Error("UpsertContributorBatch DO UPDATE SET must NOT include " +
+			"cntrb_id — preserving the existing cntrb_id on conflict is " +
+			"what keeps existing FK references valid. Per CLAUDE.md v0.20.2 " +
+			"precedent (rejection of 16-table FK rewrite), aveloxis does " +
+			"NOT migrate existing random cntrb_id values to deterministic.")
+	}
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1272,12 +1272,34 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 				createdAt = contrib.CreatedAt
 			}
 
+			// v0.22.0 deterministic-cntrb_id fix: compute PlatformUUID
+			// from the contributor's first identity with a non-zero
+			// platform user ID and pass it as $1. If no such identity
+			// exists (email-only commit-author contributor), pass NULL
+			// — the SQL falls back to gen_random_uuid() via COALESCE.
+			//
+			// ON CONFLICT (cntrb_login) DO UPDATE deliberately does NOT
+			// SET cntrb_id, so existing rows with random UUIDs (from
+			// pre-v0.22.0 collections) keep their cntrb_id and all FK
+			// references stay valid. New contributors get deterministic
+			// UUIDs going forward. Per CLAUDE.md v0.20.2 precedent
+			// (rejection of the 16-table FK rewrite), aveloxis does NOT
+			// migrate existing random cntrb_id values.
+			var desiredCntrbID any
+			for _, ident := range identMap[login] {
+				if ident.UserID > 0 {
+					desiredCntrbID = PlatformUUID(int(ident.Platform), ident.UserID).String()
+					break
+				}
+			}
+
 			err := tx.QueryRow(ctx, `
 				INSERT INTO aveloxis_data.contributors
-					(cntrb_login, cntrb_email, cntrb_full_name,
+					(cntrb_id, cntrb_login, cntrb_email, cntrb_full_name,
 					 cntrb_company, cntrb_location, cntrb_canonical, cntrb_created_at,
 					 tool_source, tool_version, data_source)
-				VALUES ($1,$2,$3,$4,$5,$6,$7,'aveloxis',$8,'GitHub API')
+				VALUES (COALESCE($1::uuid, gen_random_uuid()),
+				        $2,$3,$4,$5,$6,$7,$8,'aveloxis',$9,'GitHub API')
 				ON CONFLICT (cntrb_login) WHERE cntrb_login != '' DO UPDATE SET
 					cntrb_email = COALESCE(NULLIF(EXCLUDED.cntrb_email, ''), contributors.cntrb_email),
 					cntrb_full_name = COALESCE(NULLIF(EXCLUDED.cntrb_full_name, ''), contributors.cntrb_full_name),
@@ -1288,6 +1310,7 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 					tool_version = EXCLUDED.tool_version,
 					data_collection_date = NOW()
 				RETURNING cntrb_id`,
+				desiredCntrbID,
 				contrib.Login, contrib.Email, contrib.FullName,
 				contrib.Company, contrib.Location, contrib.Canonical, createdAt,
 				ToolVersion,

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.21.5"
+var ToolVersion = "0.22.0"

--- a/internal/platform/github/graphql_listing.go
+++ b/internal/platform/github/graphql_listing.go
@@ -37,12 +37,16 @@ import (
 func (c *Client) ListIssuesAndPRs(ctx context.Context, owner, repo string, since time.Time) (*platform.IssueAndPRBatch, error) {
 	batch := &platform.IssueAndPRBatch{}
 
-	issues, comments, err := c.listIssuesGraphQL(ctx, owner, repo, since)
+	issues, comments, labelsByNumber, assigneesByNumber, err := c.listIssuesGraphQL(ctx, owner, repo, since)
+	// Surface partial results even on error so the caller can stage what
+	// we have before bubbling. Mirrors v0.20.9 for PR gap fill.
+	batch.Issues = issues
+	batch.IssueComments = comments
+	batch.IssueLabels = labelsByNumber
+	batch.IssueAssignees = assigneesByNumber
 	if err != nil {
 		return batch, fmt.Errorf("graphql issues listing: %w", err)
 	}
-	batch.Issues = issues
-	batch.IssueComments = comments
 
 	prs, err := c.listPullRequestsGraphQL(ctx, owner, repo, since)
 	if err != nil {
@@ -64,7 +68,20 @@ func (c *Client) ListIssuesAndPRs(ctx context.Context, owner, repo string, since
 // initial page fast. The returned comments slice is flat (one entry per
 // comment, IssueRef populated) so the staged collector can stage them
 // directly without regrouping.
-func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, since time.Time) ([]model.Issue, []platform.MessageWithRef, error) {
+//
+// Phase 5 addition: selects `labels(first: 100)` and `assignees(first:
+// 100)` per issue so label + assignee fetching no longer needs the
+// two per-issue REST calls in collectIssues. Returns two maps keyed
+// by issue number; the staged collector drains them into stagedIssue
+// envelopes. Issues with >100 labels or >100 assignees fall through
+// to paginateIssueLabels / paginateIssueAssignees follow-ups. Label
+// PlatformID stays 0 (GitHub GraphQL's Label has no databaseId — same
+// gap as prBatchLabels documents for PRs).
+//
+// On a mid-pagination error the function returns the partial results
+// collected so far along with the error — caller can stage what it
+// got before bubbling. Matches the v0.20.9 pattern for PR gap fill.
+func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, since time.Time) ([]model.Issue, []platform.MessageWithRef, map[int][]model.IssueLabel, map[int][]model.IssueAssignee, error) {
 	const query = `query IssuesList($owner: String!, $repo: String!, $cursor: String, $since: DateTime) {
   repository(owner: $owner, name: $repo) {
     issues(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}, filterBy: {since: $since}) {
@@ -77,6 +94,14 @@ func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, sinc
             databaseId id body createdAt updatedAt url authorAssociation
             author { __typename login ... on User { databaseId avatarUrl url name email } }
           }
+          pageInfo { hasNextPage endCursor }
+        }
+        labels(first: 100) {
+          nodes { id name color description isDefault }
+          pageInfo { hasNextPage endCursor }
+        }
+        assignees(first: 100) {
+          nodes { databaseId login avatarUrl url name email }
           pageInfo { hasNextPage endCursor }
         }
         author {
@@ -92,6 +117,8 @@ func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, sinc
 
 	var out []model.Issue
 	var comments []platform.MessageWithRef
+	labelsByNumber := map[int][]model.IssueLabel{}
+	assigneesByNumber := map[int][]model.IssueAssignee{}
 	var cursor string
 	origin := model.DataOrigin{
 		ToolSource: "aveloxis",
@@ -138,14 +165,16 @@ func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, sinc
 							} `json:"nodes"`
 							PageInfo prBatchPageInfo `json:"pageInfo"`
 						} `json:"comments"`
-						Author *prBatchUser `json:"author"`
+						Labels    prBatchLabels   `json:"labels"`
+						Assignees prBatchUserConn `json:"assignees"`
+						Author    *prBatchUser    `json:"author"`
 					} `json:"nodes"`
 					PageInfo prBatchPageInfo `json:"pageInfo"`
 				} `json:"issues"`
 			} `json:"repository"`
 		}
 		if err := c.http.GraphQL(ctx, query, vars, &resp); err != nil {
-			return out, comments, err
+			return out, comments, labelsByNumber, assigneesByNumber, err
 		}
 
 		for _, n := range resp.Repository.Issues.Nodes {
@@ -197,15 +226,146 @@ func (c *Client) listIssuesGraphQL(ctx context.Context, owner, repo string, sinc
 			if n.Comments.PageInfo.HasNextPage {
 				extra, err := c.paginateIssueComments(ctx, owner, repo, n.Number, n.Comments.PageInfo.EndCursor, origin)
 				if err != nil {
-					return out, comments, fmt.Errorf("paginating comments for issue #%d: %w", n.Number, err)
+					return out, comments, labelsByNumber, assigneesByNumber, fmt.Errorf("paginating comments for issue #%d: %w", n.Number, err)
 				}
 				comments = append(comments, extra...)
 			}
+
+			// Phase 5: inline labels for this issue. PlatformID stays 0 —
+			// see prBatchLabels comment for the GraphQL Label parity gap.
+			var labels []model.IssueLabel
+			for _, l := range n.Labels.Nodes {
+				labels = append(labels, model.IssueLabel{
+					NodeID:      l.ID,
+					Text:        l.Name,
+					Description: l.Description,
+					Color:       l.Color,
+					Origin:      origin,
+				})
+			}
+			if n.Labels.PageInfo.HasNextPage {
+				extra, err := c.paginateIssueLabels(ctx, owner, repo, n.Number, n.Labels.PageInfo.EndCursor, origin)
+				if err != nil {
+					return out, comments, labelsByNumber, assigneesByNumber, fmt.Errorf("paginating labels for issue #%d: %w", n.Number, err)
+				}
+				labels = append(labels, extra...)
+			}
+			if len(labels) > 0 {
+				labelsByNumber[n.Number] = labels
+			}
+
+			// Phase 5: inline assignees for this issue. databaseId IS
+			// available on User nodes (unlike Label), so PlatformSrcID
+			// is populated correctly and the unique constraint
+			// (issue_id, platform_assignee_id) works.
+			var assignees []model.IssueAssignee
+			for _, a := range n.Assignees.Nodes {
+				assignees = append(assignees, model.IssueAssignee{
+					PlatformSrcID:  a.DatabaseID,
+					PlatformNodeID: "", // GraphQL User node ID is the global ID, not what postgres stores here
+					Origin:         origin,
+				})
+			}
+			if n.Assignees.PageInfo.HasNextPage {
+				extra, err := c.paginateIssueAssignees(ctx, owner, repo, n.Number, n.Assignees.PageInfo.EndCursor, origin)
+				if err != nil {
+					return out, comments, labelsByNumber, assigneesByNumber, fmt.Errorf("paginating assignees for issue #%d: %w", n.Number, err)
+				}
+				assignees = append(assignees, extra...)
+			}
+			if len(assignees) > 0 {
+				assigneesByNumber[n.Number] = assignees
+			}
 		}
 		if !resp.Repository.Issues.PageInfo.HasNextPage {
-			return out, comments, nil
+			return out, comments, labelsByNumber, assigneesByNumber, nil
 		}
 		cursor = resp.Repository.Issues.PageInfo.EndCursor
+	}
+}
+
+// paginateIssueLabels follows Issue.labels past the first 100. Mirrors
+// the PR-side paginatePRLabels helper anchored on an issue number.
+// Phase 5 of the REST → GraphQL refactor.
+func (c *Client) paginateIssueLabels(ctx context.Context, owner, repo string, issueNumber int, cursor string, origin model.DataOrigin) ([]model.IssueLabel, error) {
+	const query = `query PagIssueLabels($owner: String!, $repo: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      labels(first: 100, after: $after) {
+        nodes { id name color description isDefault }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`
+	var out []model.IssueLabel
+	for {
+		vars := map[string]any{"owner": owner, "repo": repo, "number": issueNumber, "after": cursor}
+		var resp struct {
+			Repository struct {
+				Issue struct {
+					Labels prBatchLabels `json:"labels"`
+				} `json:"issue"`
+			} `json:"repository"`
+		}
+		if err := c.http.GraphQL(ctx, query, vars, &resp); err != nil {
+			return out, err
+		}
+		for _, l := range resp.Repository.Issue.Labels.Nodes {
+			out = append(out, model.IssueLabel{
+				NodeID:      l.ID,
+				Text:        l.Name,
+				Description: l.Description,
+				Color:       l.Color,
+				Origin:      origin,
+			})
+		}
+		pi := resp.Repository.Issue.Labels.PageInfo
+		if !pi.HasNextPage {
+			return out, nil
+		}
+		cursor = pi.EndCursor
+	}
+}
+
+// paginateIssueAssignees follows Issue.assignees past the first 100.
+// Mirrors the PR-side paginatePRAssignees helper anchored on an issue
+// number. Phase 5 of the REST → GraphQL refactor.
+func (c *Client) paginateIssueAssignees(ctx context.Context, owner, repo string, issueNumber int, cursor string, origin model.DataOrigin) ([]model.IssueAssignee, error) {
+	const query = `query PagIssueAssignees($owner: String!, $repo: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      assignees(first: 100, after: $after) {
+        nodes { databaseId login avatarUrl url name email }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`
+	var out []model.IssueAssignee
+	for {
+		vars := map[string]any{"owner": owner, "repo": repo, "number": issueNumber, "after": cursor}
+		var resp struct {
+			Repository struct {
+				Issue struct {
+					Assignees prBatchUserConn `json:"assignees"`
+				} `json:"issue"`
+			} `json:"repository"`
+		}
+		if err := c.http.GraphQL(ctx, query, vars, &resp); err != nil {
+			return out, err
+		}
+		for _, a := range resp.Repository.Issue.Assignees.Nodes {
+			out = append(out, model.IssueAssignee{
+				PlatformSrcID: a.DatabaseID,
+				Origin:        origin,
+			})
+		}
+		pi := resp.Repository.Issue.Assignees.PageInfo
+		if !pi.HasNextPage {
+			return out, nil
+		}
+		cursor = pi.EndCursor
 	}
 }
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -99,10 +99,21 @@ type RepoCollector interface {
 // platform implementation doesn't support inline comments (GitLab REST
 // composition); callers fall back to the MessageCollector interface in
 // that case.
+//
+// Phase 5 adds IssueLabels and IssueAssignees: per-issue labels and
+// assignees delivered inline with the issue listing, keyed by issue
+// number so the staged collector can demux them. When non-nil and
+// IssueChildMode == "graphql", the staged collector skips the two
+// per-issue REST calls (ListIssueLabels / ListIssueAssignees) and
+// drains these maps directly into the stagedIssue envelope. Both maps
+// are nil on the GitLab REST-composition path; the collector falls
+// back to the REST iterators in that case.
 type IssueAndPRBatch struct {
-	Issues        []model.Issue
-	PullRequests  []model.PullRequest
-	IssueComments []MessageWithRef
+	Issues         []model.Issue
+	PullRequests   []model.PullRequest
+	IssueComments  []MessageWithRef
+	IssueLabels    map[int][]model.IssueLabel
+	IssueAssignees map[int][]model.IssueAssignee
 }
 
 // IssueCollector fetches issues and related entities.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -43,6 +43,7 @@ type Config struct {
 	ListingMode           string        // "rest" (default) or "graphql" — routes issue+PR listing through ListIssuesAndPRs
 	ThreadingMode         string        // "single" (default) or "sharded" — fans out PR batch fetching across goroutines
 	ShardSize             int           // item-count threshold for spawning an additional shard (default 3000)
+	IssueChildMode        string        // "rest" (default) or "graphql" — phase 5: inline issue label+assignee fetch via the GraphQL listing
 	EnrichInterval        time.Duration // how often to run thin-contributor enrichment (default 30 min). v0.18.29 moved enrichment out of per-job processing into a periodic scheduler task.
 	SearchResolveInterval time.Duration // how often to run the search-resolve background task (default 1 hour). v0.19.2 added this to backfill gh_user_id on contributors with email but no platform identity, using GitHub's search API at controlled rate.
 	AffiliationInterval   time.Duration // how often to run the periodic singleton PopulateAffiliations task (default 1 hour). v0.19.7 moved this off the per-job hot path to eliminate cross-worker contention on UNIQUE (ca_domain).
@@ -904,7 +905,8 @@ func shouldForceFullRecollect(errMsg string) bool {
 // contributor resolution.
 func (s *Scheduler) collectAndProcess(ctx context.Context, repoID int64, repo *model.Repo, client platform.Client, since time.Time) (*collector.CollectResult, error) {
 	sc := collector.NewStagedCollectorWithAllModes(client, s.store, s.logger, s.cfg.PRChildMode, s.cfg.ListingMode, s.cfg.ThreadingMode, s.cfg.ShardSize).
-		WithWorkers(s.cfg.Workers)
+		WithWorkers(s.cfg.Workers).
+		WithIssueChildMode(s.cfg.IssueChildMode)
 	result, err := sc.CollectRepo(ctx, repoID, repo.Owner, repo.Name, since)
 
 	if err == nil {


### PR DESCRIPTION
 What v0.22.0 ships

  1. Code fix: UpsertContributorBatch supplies cntrb_id = PlatformUUID(model.PlatformGitHub, userID) when len(contrib.Identities) > 0 && contrib.Identities[0].UserID >  0. Backward-compatible — only changes what gets inserted on a FRESH row; existing rows are untouched by ON CONFLICT DO UPDATE.
  2. Source-contract test pinning the UUID-supply behavior in UpsertContributorBatch so it can't regress silently.
  3. CLAUDE.md note documenting the historical drift and explaining why we don't migrate (cites the v0.20.2 precedent).
  4. Shadow-diff re-run plan: drop both shadow DBs, re-collect from scratch, expect zero drift on phase 5 target tables.

  Test Cycle: 
  1. Added the source-contract test (TDD — should fail against current code).
  2. Fixed UpsertContributorBatch.
  3. Verified the test passes by dropping both shadow DBs, recreating, re-running collection, and re-running shadow-diff.
  4. REST and GraphQL determined to pick up identical data. 