### PR TITLE
Feat/power logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+aveloxis.runlocal.json
 prompt-notes/**
 summary/**
 summaries/**

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -45,7 +45,8 @@
     "scancode_start_interval_s": 90,
     "scancode_cadence_days": 180,
     "scancode_clone_dir": "/tmp/aveloxis-scancode",
-    "scancode_shutdown_grace_minutes": 30
+    "scancode_shutdown_grace_minutes": 30,
+    "staging_retention_hours": 1
   },
   "web": {
     "addr": ":8082",

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -46,7 +46,8 @@
     "scancode_cadence_days": 180,
     "scancode_clone_dir": "/tmp/aveloxis-scancode",
     "scancode_shutdown_grace_minutes": 30,
-    "staging_retention_hours": 1
+    "staging_retention_hours": 1,
+    "phase_watchdog_minutes": 75
   },
   "web": {
     "addr": ":8082",

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -180,6 +180,8 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		ScancodeCadence:       cfg.Collection.ScancodeCadence(),
 		ScancodeCloneDir:      cfg.Collection.ScancodeCloneDirOrDefault(),
 		ScancodeShutdownGrace: cfg.Collection.ScancodeShutdownGrace(),
+		// v0.22.4 — staging-row cleanup retention. Default 1h.
+		StagingRetention: cfg.Collection.StagingRetentionDuration(),
 	})
 	go sched.Run(ctx)
 

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -127,6 +127,14 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 	pidfile.Write(pidPath, os.Getpid())
 	defer pidfile.Remove(pidPath)
 
+	// v0.22.4 item 8 — register SIGUSR1 handler so operators can
+	// snapshot the goroutine state of a running serve without killing
+	// it. Operator workflow:
+	//   kill -USR1 $(cat ~/.aveloxis/aveloxis-serve.pid)
+	//   ls -lh ~/.aveloxis/serve-goroutines-*.txt
+	uninstallDump := installGoroutineDumpHandler(logger, defaultGoroutineDumpDir())
+	defer uninstallDump()
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
@@ -183,6 +191,8 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		ScancodeShutdownGrace: cfg.Collection.ScancodeShutdownGrace(),
 		// v0.22.4 — staging-row cleanup retention. Default 1h.
 		StagingRetention: cfg.Collection.StagingRetentionDuration(),
+		// v0.22.4 — observation-only long-jobs watchdog. Default 75m.
+		PhaseWatchdog: cfg.Collection.PhaseWatchdogDuration(),
 	})
 	go sched.Run(ctx)
 

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -70,6 +70,7 @@ func main() {
 		sbomCmd(&cfgPath),
 		shadowDiffCmd(),
 		testMailCmd(&cfgPath),
+		stagingStatsCmd(&cfgPath),
 		versionCmd(),
 	)
 

--- a/cmd/aveloxis/sigusr1_dump.go
+++ b/cmd/aveloxis/sigusr1_dump.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+// installGoroutineDumpHandler registers a SIGUSR1 handler that writes
+// runtime.Stack(buf, true) to a timestamped file under dumpDir and
+// returns. v0.22.4 item 8 — non-destructive alternative to SIGQUIT
+// (which kills the process and loses in-flight collection state).
+//
+// Operator workflow:
+//
+//	kill -USR1 $(cat ~/.aveloxis/aveloxis-serve.pid)
+//	ls -lh ~/.aveloxis/serve-goroutines-*.txt
+//
+// The returned function uninstalls the handler — exposed for tests
+// and graceful shutdown. The handler goroutine consumes signals in a
+// loop so multiple SIGUSR1 sends in quick succession each produce
+// their own dump file (operators sometimes want to take two snapshots
+// 30 seconds apart to see what changed).
+//
+// Buffer is 1 MB. runtime.Stack truncates silently when the buffer
+// is short, which is acceptable here — the primary use case is
+// finding which goroutine is stalled, and 1 MB covers thousands of
+// frames at typical stack widths.
+func installGoroutineDumpHandler(logger *slog.Logger, dumpDir string) func() {
+	ch := make(chan os.Signal, 4)
+	signal.Notify(ch, syscall.SIGUSR1)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ch:
+				if err := writeGoroutineDump(dumpDir); err != nil {
+					if logger != nil {
+						logger.Warn("SIGUSR1 goroutine dump failed", "error", err)
+					}
+					continue
+				}
+				if logger != nil {
+					logger.Info("goroutine dump written via SIGUSR1", "dir", dumpDir)
+				}
+			}
+		}
+	}()
+
+	return func() {
+		signal.Stop(ch)
+		close(done)
+	}
+}
+
+// writeGoroutineDump captures every goroutine's stack and writes the
+// result to dumpDir/serve-goroutines-<UTC-timestamp>.txt. Returns the
+// path on success.
+func writeGoroutineDump(dumpDir string) error {
+	if err := os.MkdirAll(dumpDir, 0o755); err != nil {
+		return err
+	}
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	path := filepath.Join(dumpDir, "serve-goroutines-"+ts+".txt")
+	return os.WriteFile(path, buf[:n], 0o644)
+}
+
+// defaultGoroutineDumpDir returns ~/.aveloxis when the home directory
+// is available, falling back to os.TempDir() otherwise. The directory
+// is created lazily by writeGoroutineDump.
+func defaultGoroutineDumpDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".aveloxis")
+	}
+	return os.TempDir()
+}

--- a/cmd/aveloxis/sigusr1_dump_test.go
+++ b/cmd/aveloxis/sigusr1_dump_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSIGUSR1HandlerRegistered — v0.22.4 item 8.
+//
+// Pin that runServe wires a SIGUSR1 handler that calls
+// installGoroutineDumpHandler (or equivalent named symbol). When the
+// operator sends `kill -USR1 $(pidof aveloxis)`, the binary writes
+// runtime.Stack(buf, true) to a timestamped file without exiting.
+//
+// Non-destructive alternative to SIGQUIT — SIGQUIT kills the process
+// and forces every in-flight collection to lose progress.
+func TestSIGUSR1HandlerRegistered(t *testing.T) {
+	mainSrc, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	main := string(mainSrc)
+
+	// runServe must invoke the handler-installer.
+	idx := strings.Index(main, "func runServe(")
+	if idx < 0 {
+		t.Fatal("runServe not found in main.go")
+	}
+	end := idx + 6000
+	if end > len(main) {
+		end = len(main)
+	}
+	fn := main[idx:end]
+
+	if !strings.Contains(fn, "installGoroutineDumpHandler") {
+		t.Error("runServe must call installGoroutineDumpHandler so SIGUSR1 produces a non-destructive goroutine dump (alternative to SIGQUIT which kills the process)")
+	}
+
+	// The handler implementation may live in main.go or a sibling file.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		b, _ := os.ReadFile(e.Name())
+		s := string(b)
+		if strings.Contains(s, "func installGoroutineDumpHandler(") &&
+			strings.Contains(s, "syscall.SIGUSR1") &&
+			strings.Contains(s, "runtime.Stack(") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("installGoroutineDumpHandler must exist, register syscall.SIGUSR1, and call runtime.Stack(buf, true)")
+	}
+}
+
+// TestInstallGoroutineDumpHandlerWritesFile — behavioral.
+//
+// Direct invocation of the dump-writer helper (the part that runs
+// when the signal fires). Sends a signal to the registered handler
+// via a real signal.Notify channel, then asserts a dump file
+// appeared under the configured directory containing a real Go
+// goroutine stack header.
+func TestInstallGoroutineDumpHandlerWritesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Spawn a goroutine the dump will surely capture so we can assert
+	// the stack content is meaningful, not just any-bytes-on-disk.
+	stop := make(chan struct{})
+	go func() {
+		<-stop
+	}()
+	defer close(stop)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	uninstall := installGoroutineDumpHandler(logger, dir)
+	defer uninstall()
+
+	// Fire SIGUSR1 at ourselves.
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGUSR1); err != nil {
+		t.Fatalf("kill SIGUSR1: %v", err)
+	}
+
+	// Wait for the file to appear.
+	deadline := time.Now().Add(2 * time.Second)
+	var dumpPath string
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), "serve-goroutines-") {
+					dumpPath = filepath.Join(dir, e.Name())
+					break
+				}
+			}
+		}
+		if dumpPath != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if dumpPath == "" {
+		t.Fatal("no serve-goroutines-*.txt file written within deadline")
+	}
+	data, err := os.ReadFile(dumpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "goroutine ") {
+		t.Errorf("dump does not look like runtime.Stack output (no 'goroutine ' header):\n%s", data[:min(len(data), 200)])
+	}
+	// Sanity: file is at least one goroutine's worth of bytes.
+	if len(data) < 50 {
+		t.Errorf("dump suspiciously short (%d bytes)", len(data))
+	}
+	_ = runtime.NumGoroutine() // keep this import used
+}

--- a/cmd/aveloxis/staging_stats_cmd.go
+++ b/cmd/aveloxis/staging_stats_cmd.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/spf13/cobra"
+)
+
+// stagingStatsCmd surfaces per-repo / per-entity_type staging table
+// state for operator diagnosis. v0.22.4 item 6.
+//
+// Two views, controlled by --repo:
+//   - default ("top" mode): top N rows ordered by row count
+//   - --repo OWNER/REPO: every entity_type for that repo
+//
+// Read-only — never writes to the staging table. Safe to run alongside
+// `aveloxis serve` or `aveloxis migrate`; the query is a single
+// GROUP BY scan with no locks beyond what Postgres takes for the read.
+func stagingStatsCmd(cfgPath *string) *cobra.Command {
+	var (
+		top     int
+		repoArg string
+	)
+	cmd := &cobra.Command{
+		Use:   "staging-stats",
+		Short: "Show staging-table row counts, age, and approximate disk size per repo / entity_type",
+		Long: `Surfaces the state of the aveloxis_ops.staging table for operator
+diagnosis. Two views:
+
+  aveloxis staging-stats              # top 10 (repo, entity_type) by row count
+  aveloxis staging-stats --top 50     # top 50
+  aveloxis staging-stats --repo microsoft/vscode   # every entity_type for one repo
+
+The output includes:
+  - rows total / processed / unprocessed
+  - oldest and newest created_at (helps verify the v0.22.4
+    staging_retention_hours cleanup is working)
+  - approximate JSONB byte size (pg_column_size aggregated)
+
+Useful for:
+  - confirming the hourly PurgeStagedProcessed sweep is doing its job
+    (oldest age should not exceed staging_retention_hours by much)
+  - spotting outliers: a single repo with millions of unprocessed
+    rows usually means its Processor path quietly broke
+  - validating that v0.22.4's retention reduction (7d → 1h) cut the
+    table size as expected after deployment.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			cfg := loadConfig(*cfgPath, bootLog)
+			logger := newLogger(cfg)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			store, err := db.NewPostgresStore(ctx, cfg.Database.ConnectionString(), logger)
+			if err != nil {
+				return fmt.Errorf("connecting to database: %w", err)
+			}
+			defer store.Close()
+
+			// v0.21.5: store.Migrate(ctx) intentionally NOT called here.
+			// staging-stats is read-only and trusts that the operator has
+			// already run `aveloxis migrate` once.
+
+			rows, err := store.StagingStats(ctx, repoArg, top)
+			if err != nil {
+				return fmt.Errorf("staging stats: %w", err)
+			}
+			if len(rows) == 0 {
+				fmt.Println("no staging rows found")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(tw, "REPO\tENTITY_TYPE\tROWS\tPROC\tUNPROC\tOLDEST\tNEWEST\tBYTES")
+			for _, r := range rows {
+				slug := r.RepoOwner + "/" + r.RepoName
+				if slug == "/" {
+					slug = fmt.Sprintf("repo_id=%d", r.RepoID)
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\n",
+					slug,
+					r.EntityType,
+					r.Rows,
+					r.Processed,
+					r.Unprocessed,
+					r.Oldest.Format("2006-01-02 15:04"),
+					r.Newest.Format("2006-01-02 15:04"),
+					humanBytes(r.Bytes),
+				)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().IntVar(&top, "top", 10, "show the top N (repo, entity_type) pairs by row count (ignored when --repo is set)")
+	cmd.Flags().StringVar(&repoArg, "repo", "", "drill into one repo by OWNER/REPO (omits the top-N view)")
+	return cmd
+}
+
+// humanBytes formats a byte count using SI-style suffixes so the
+// staging-stats column stays narrow even for multi-GB cohorts.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/aveloxis/staging_stats_cmd_test.go
+++ b/cmd/aveloxis/staging_stats_cmd_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestStagingStatsCmdRegistered — v0.22.4 item 6.
+//
+// New operator subcommand surfacing staging-table state per repo /
+// per entity type. Useful for verifying that v0.22.4 item 5's
+// retention reduction is doing its job, and for spotting outliers
+// (e.g. one repo retaining millions of staged rows because its
+// processing path quietly broke).
+//
+// Pin: stagingStatsCmd function exists and is wired into the root
+// command registration in main(), so `aveloxis staging-stats`
+// reaches the handler.
+func TestStagingStatsCmdRegistered(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	if !strings.Contains(body, "func stagingStatsCmd(") {
+		t.Error("cmd/aveloxis/main.go must define func stagingStatsCmd(cfgPath *string) *cobra.Command — " +
+			"v0.22.4 item 6 operator-facing path for diagnosing staging-table state")
+	}
+	if !strings.Contains(body, "stagingStatsCmd(&cfgPath)") {
+		t.Error("stagingStatsCmd must be added to the root.AddCommand list so " +
+			"`aveloxis staging-stats` is invocable from the CLI")
+	}
+}
+
+// TestStagingStatsCmdSupportsTopAndRepoFlags — pins the two flags the
+// design called for. --top is the default "top N rows by size" view;
+// --repo OWNER/REPO is the drill-in.
+func TestStagingStatsCmdSupportsTopAndRepoFlags(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	idx := strings.Index(body, "func stagingStatsCmd(")
+	if idx < 0 {
+		t.Fatal("stagingStatsCmd not found")
+	}
+	// Slice the function body. 4000 chars is plenty for a small CLI.
+	end := idx + 4000
+	if end > len(body) {
+		end = len(body)
+	}
+	fn := body[idx:end]
+
+	if !strings.Contains(fn, `"top"`) {
+		t.Error("stagingStatsCmd must register a --top flag for the default top-N view")
+	}
+	if !strings.Contains(fn, `"repo"`) {
+		t.Error("stagingStatsCmd must register a --repo flag for per-repo drill-in")
+	}
+	if !strings.Contains(fn, "StagingStats") {
+		t.Error("stagingStatsCmd must invoke a store method named StagingStats " +
+			"(read-only query producing rows/oldest/newest/bytes per repo+entity_type)")
+	}
+}
+
+// TestStagingStatsStoreMethodExists — pins the db-side query. Behavioral
+// test for the SQL shape is in internal/db/staging_stats_test.go
+// (integration-tier, gated on AVELOXIS_TEST_DB).
+func TestStagingStatsStoreMethodExists(t *testing.T) {
+	src, err := os.ReadFile("../../internal/db/staging.go")
+	if err != nil {
+		// May live in a sibling file.
+		src, err = os.ReadFile("../../internal/db/staging_stats.go")
+		if err != nil {
+			t.Fatal("could not find staging_stats.go or staging.go for the StagingStats query")
+		}
+	}
+	body := string(src)
+	if !strings.Contains(body, "func (s *PostgresStore) StagingStats(") {
+		// Try the sibling file too.
+		alt, _ := os.ReadFile("../../internal/db/staging_stats.go")
+		if !strings.Contains(string(alt), "func (s *PostgresStore) StagingStats(") {
+			t.Error("PostgresStore.StagingStats must exist — read-only query " +
+				"returning per-repo per-entity_type staging stats (rows, " +
+				"oldest, newest, bytes)")
+		}
+	}
+}

--- a/cmd/aveloxis/staging_stats_cmd_test.go
+++ b/cmd/aveloxis/staging_stats_cmd_test.go
@@ -21,19 +21,40 @@ import (
 // command registration in main(), so `aveloxis staging-stats`
 // reaches the handler.
 func TestStagingStatsCmdRegistered(t *testing.T) {
-	src, err := os.ReadFile("main.go")
+	mainSrc, err := os.ReadFile("main.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := string(src)
+	main := string(mainSrc)
 
-	if !strings.Contains(body, "func stagingStatsCmd(") {
-		t.Error("cmd/aveloxis/main.go must define func stagingStatsCmd(cfgPath *string) *cobra.Command — " +
-			"v0.22.4 item 6 operator-facing path for diagnosing staging-table state")
+	if !strings.Contains(main, "stagingStatsCmd(&cfgPath)") {
+		t.Error("stagingStatsCmd must be added to the root.AddCommand list in main.go " +
+			"so `aveloxis staging-stats` is invocable from the CLI")
 	}
-	if !strings.Contains(body, "stagingStatsCmd(&cfgPath)") {
-		t.Error("stagingStatsCmd must be added to the root.AddCommand list so " +
-			"`aveloxis staging-stats` is invocable from the CLI")
+
+	// Function declaration may live in main.go or a sibling file in the
+	// same package. Scan every .go file.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(e.Name())
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(b), "func stagingStatsCmd(") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("cmd/aveloxis package must define func stagingStatsCmd(cfgPath *string) *cobra.Command — " +
+			"v0.22.4 item 6 operator-facing path for diagnosing staging-table state")
 	}
 }
 
@@ -41,22 +62,34 @@ func TestStagingStatsCmdRegistered(t *testing.T) {
 // design called for. --top is the default "top N rows by size" view;
 // --repo OWNER/REPO is the drill-in.
 func TestStagingStatsCmdSupportsTopAndRepoFlags(t *testing.T) {
-	src, err := os.ReadFile("main.go")
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := string(src)
-
-	idx := strings.Index(body, "func stagingStatsCmd(")
-	if idx < 0 {
-		t.Fatal("stagingStatsCmd not found")
+	var fn string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(e.Name())
+		if err != nil {
+			continue
+		}
+		body := string(b)
+		idx := strings.Index(body, "func stagingStatsCmd(")
+		if idx < 0 {
+			continue
+		}
+		end := idx + 4000
+		if end > len(body) {
+			end = len(body)
+		}
+		fn = body[idx:end]
+		break
 	}
-	// Slice the function body. 4000 chars is plenty for a small CLI.
-	end := idx + 4000
-	if end > len(body) {
-		end = len(body)
+	if fn == "" {
+		t.Fatal("stagingStatsCmd not found in any .go file")
 	}
-	fn := body[idx:end]
 
 	if !strings.Contains(fn, `"top"`) {
 		t.Error("stagingStatsCmd must register a --top flag for the default top-N view")

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -78,7 +78,8 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "scancode_cadence_days": 180,
     "scancode_clone_dir": "/tmp/aveloxis-scancode",
     "scancode_shutdown_grace_minutes": 30,
-    "staging_retention_hours": 1
+    "staging_retention_hours": 1,
+    "phase_watchdog_minutes": 75
   },
   "web": {
     "addr": ":8082",
@@ -191,6 +192,7 @@ The scancode per-file license + copyright + package scan is run by a dedicated `
 | `collection.scancode_clone_dir` | string | `"/tmp/aveloxis-scancode"` | Parent directory for per-run shallow clones. Each scan creates `<dir>/repo_<id>_<unix_ts>` and removes it on completion (success or failure). Size budget: each clone is the working tree only (`git clone --depth 1`), so ≈ checked-out repo size. With default 2 workers and average ~50 MB clones, ~100 MB peak; raise expectations for big-repo / many-worker installs. |
 | `collection.scancode_shutdown_grace_minutes` | integer | `30` | Time the `ScancodeWorker` waits for in-flight scans to finish on `aveloxis stop`. Within the grace window, runners complete naturally (parse JSON output, write DB, clear lock columns). At grace expiry, `cmd.Process.Kill()` is invoked on the still-running scancode subprocess; `cmd.Wait()` returns with an error, the runner's lock-clear path fires, no orphaned scans from graceful shutdown. Separate from `shutdown_grace_seconds` (which paces the main scheduler) because scancode scans are intrinsically long-running. |
 | `collection.staging_retention_hours` | integer | `1` | How long processed staging rows are kept before the hourly `PurgeStagedProcessed` sweep deletes them. v0.22.4 cut from the prior hardcoded 7-day window: 2026-05-16 production diagnostics showed JSONB tombstones stacking 3–5× on frequently-re-collected repos (zephyr had 84K issue rows against an actual 28K count). Not a correctness bug (`Processor` reads `WHERE NOT processed`) but real disk waste. Operators who need forensic retention (shadow-diff debugging, post-mortem analysis) can raise this — `24` (one day) is a reasonable middle ground. |
+| `collection.phase_watchdog_minutes` | integer | `75` | Stall threshold for the v0.22.4 observation-only long-jobs watchdog. If a repo's staging row count has not grown for this many minutes, the watchdog appends one JSON-lines event to `~/.aveloxis/aveloxis-long-jobs.log` and writes a per-event goroutine dump under `~/.aveloxis/long-jobs/`. The watchdog **NEVER cancels the job, NEVER requeues the repo, NEVER kills anything** — large first-cycle collections (microsoft/vscode-class) may legitimately run for days, and aborting them would prevent them from ever completing. Re-emits every `phase_watchdog_minutes` while the stall persists; emits a `stall_resumed` event when staging row count grows again so analysts can compute total stall duration. Lower this (e.g. `30`) during active incident triage to spot smaller hangs; raise it on installations whose largest-repo collection routinely takes many hours. |
 
 **Force-rerun cookbook** — to invalidate the cadence gate and trigger a fresh scan on the next worker tick, set `scancode_last_run` back to NULL:
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -77,7 +77,8 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "scancode_start_interval_s": 90,
     "scancode_cadence_days": 180,
     "scancode_clone_dir": "/tmp/aveloxis-scancode",
-    "scancode_shutdown_grace_minutes": 30
+    "scancode_shutdown_grace_minutes": 30,
+    "staging_retention_hours": 1
   },
   "web": {
     "addr": ":8082",
@@ -189,6 +190,7 @@ The scancode per-file license + copyright + package scan is run by a dedicated `
 | `collection.scancode_cadence_days` | integer | `180` | Minimum days between successive scancode runs on the same repo. Pre-v0.21.0 was 30 days; the change reflects that per-file license + copyright headers in source files change rarely on the timescale that matters, and the I/O cost of scanning a Linux-kernel-scale mirror doesn't justify monthly re-scans. Dependency-level licenses (which DO change as packages update) still flow through the per-cycle Phase 4 dependency scan + Phase 6 SBOM generation. |
 | `collection.scancode_clone_dir` | string | `"/tmp/aveloxis-scancode"` | Parent directory for per-run shallow clones. Each scan creates `<dir>/repo_<id>_<unix_ts>` and removes it on completion (success or failure). Size budget: each clone is the working tree only (`git clone --depth 1`), so ≈ checked-out repo size. With default 2 workers and average ~50 MB clones, ~100 MB peak; raise expectations for big-repo / many-worker installs. |
 | `collection.scancode_shutdown_grace_minutes` | integer | `30` | Time the `ScancodeWorker` waits for in-flight scans to finish on `aveloxis stop`. Within the grace window, runners complete naturally (parse JSON output, write DB, clear lock columns). At grace expiry, `cmd.Process.Kill()` is invoked on the still-running scancode subprocess; `cmd.Wait()` returns with an error, the runner's lock-clear path fires, no orphaned scans from graceful shutdown. Separate from `shutdown_grace_seconds` (which paces the main scheduler) because scancode scans are intrinsically long-running. |
+| `collection.staging_retention_hours` | integer | `1` | How long processed staging rows are kept before the hourly `PurgeStagedProcessed` sweep deletes them. v0.22.4 cut from the prior hardcoded 7-day window: 2026-05-16 production diagnostics showed JSONB tombstones stacking 3–5× on frequently-re-collected repos (zephyr had 84K issue rows against an actual 28K count). Not a correctness bug (`Processor` reads `WHERE NOT processed`) but real disk waste. Operators who need forensic retention (shadow-diff debugging, post-mortem analysis) can raise this — `24` (one day) is a reasonable middle ground. |
 
 **Force-rerun cookbook** — to invalidate the cadence gate and trigger a fresh scan on the next worker tick, set `scancode_last_run` back to NULL:
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -78,7 +78,15 @@ type CollectResult struct {
 	Releases     int
 	Contributors int
 	CommitCount  int // from repo_info metadata, used for large-repo detection
-	Errors       []error
+	// InlineIssueComments and InlinePRComments are per-cycle counters
+	// of conversation comments staged inline from the phase-2 unified
+	// GraphQL listing and the phase-1 PR batch respectively. They are
+	// SUBSETS of Messages, surfaced separately so collectMessages can
+	// emit a "phase plan" log line that explains why /issues/comments
+	// is being skipped (v0.22.4 item 4).
+	InlineIssueComments int
+	InlinePRComments    int
+	Errors              []error
 }
 
 // CollectRepo runs a full collection for the given repository.

--- a/internal/collector/contributors_progress_test.go
+++ b/internal/collector/contributors_progress_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestContributorsProgressLogging — v0.22.4 item 3.
+//
+// The ListContributors loop in StagedCollector.collectMetadataAndContributors
+// can take hours on huge fleets (microsoft/vscode was empirically stuck for
+// 7+ hours in this phase). Pre-v0.22.4 the loop was silent between the
+// "collecting contributors" start and the "contributors staged" end —
+// indistinguishable from a hang.
+//
+// Pin: a progress log line "contributors progress" with owner/repo gated by
+// a modulo of result.Contributors (or an equivalent local counter).
+func TestContributorsProgressLogging(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the ListContributors loop.
+	loopStart := strings.Index(code, "sc.client.ListContributors(")
+	if loopStart < 0 {
+		t.Fatal("could not find sc.client.ListContributors( call in staged.go")
+	}
+	winStart := loopStart - 200
+	if winStart < 0 {
+		winStart = 0
+	}
+	loopEnd := loopStart + 1500
+	if loopEnd > len(code) {
+		loopEnd = len(code)
+	}
+	window := code[winStart:loopEnd]
+
+	if !strings.Contains(window, `"contributors progress"`) {
+		t.Error("staged.go: ListContributors loop must log " +
+			"`contributors progress` with owner/repo so a multi-hour silent " +
+			"iteration becomes visible — vscode's empirical 7h stall on " +
+			"2026-05-16 had no observable progress signal during this phase")
+	}
+
+	// Modulo gate so cadence is bounded. Contributors lists are smaller
+	// than review comments, so we accept any reasonable cadence.
+	moduloRE := regexp.MustCompile(`%\s*\d{1,4}\s*==\s*0`)
+	if !moduloRE.MatchString(window) {
+		t.Error("staged.go: contributors progress log must be gated by " +
+			"a modulo (e.g. count%100 == 0)")
+	}
+
+	// owner/repo on the progress line.
+	progIdx := strings.Index(window, `"contributors progress"`)
+	if progIdx >= 0 {
+		callEnd := strings.Index(window[progIdx:], ")")
+		if callEnd > 0 {
+			call := window[progIdx : progIdx+callEnd]
+			if !strings.Contains(call, `"owner"`) {
+				t.Error("contributors progress log must include slog key \"owner\"")
+			}
+			if !strings.Contains(call, `"repo"`) {
+				t.Error("contributors progress log must include slog key \"repo\"")
+			}
+		}
+	}
+}

--- a/internal/collector/phase_completion_logs_test.go
+++ b/internal/collector/phase_completion_logs_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestPhaseCompletionLogsIncludeOwnerRepo — v0.22.4 item 1.
+//
+// Every per-phase "X staged" completion log line in internal/collector/
+// staged.go MUST include the "owner" and "repo" slog keys. Production
+// log on 2026-05-16 showed zephyr+pytorch silently staging ~660
+// review_comments/min with NO owner/repo on the completion lines,
+// indistinguishable from a stuck repo. Pinning the keys here prevents
+// any future refactor from anonymizing the lines again.
+func TestPhaseCompletionLogsIncludeOwnerRepo(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Each of these completion log lines should carry "owner" and "repo"
+	// keys within its argument list. Whitespace-tolerant scan window:
+	// from the literal log message to the matching closing paren.
+	completionLines := []string{
+		`"contributors staged"`,
+		`"issues staged"`,
+		`"pull requests staged"`,
+		`"events staged"`,
+		`"messages staged"`,
+	}
+
+	for _, msg := range completionLines {
+		idx := strings.Index(code, msg)
+		if idx < 0 {
+			t.Errorf("staged.go: completion log %s not found", msg)
+			continue
+		}
+		// Slice from the message forward to the next closing paren on
+		// its own logical line. The log call is a single statement so
+		// the closing paren of the Info(...) call is the right window.
+		end := strings.Index(code[idx:], ")")
+		if end < 0 {
+			t.Errorf("staged.go: could not find end of log call for %s", msg)
+			continue
+		}
+		window := code[idx : idx+end]
+		if !strings.Contains(window, `"owner"`) {
+			t.Errorf("staged.go: log %s must include slog key \"owner\" — "+
+				"production diagnosis on 2026-05-16 showed silent per-repo "+
+				"completion lines were indistinguishable from hangs", msg)
+		}
+		if !strings.Contains(window, `"repo"`) {
+			t.Errorf("staged.go: log %s must include slog key \"repo\"", msg)
+		}
+	}
+}
+
+// TestPhaseCompletionLogsHaveOwnerRepoAvailable — sanity check that the
+// owner and repo locals are in scope at each of the call sites. If a
+// future refactor moves one of these log calls outside the
+// owner/repo-bearing function, the previous test passes against a
+// literal but the code won't compile. This catches the in-scope
+// requirement explicitly.
+func TestPhaseCompletionLogsHaveOwnerRepoAvailable(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Match a `func (sc *StagedCollector) NAME(... owner, repo string ...)`
+	// or `func (sc *StagedCollector) NAME(... owner string, repo string ...)`
+	// signature so we know the locals are in scope.
+	// We don't enforce signature shape here — just check that each
+	// completion log appears within a function that takes owner/repo.
+	completionLines := []string{
+		`"contributors staged"`,
+		`"issues staged"`,
+		`"pull requests staged"`,
+		`"events staged"`,
+		`"messages staged"`,
+	}
+
+	funcStart := regexp.MustCompile(`(?m)^func\s+\(\s*\w+\s+\*\w+\s*\)\s+\w+\s*\(`)
+	funcStarts := funcStart.FindAllStringIndex(code, -1)
+	if len(funcStarts) == 0 {
+		t.Fatal("could not find any method declarations in staged.go")
+	}
+
+	for _, msg := range completionLines {
+		idx := strings.Index(code, msg)
+		if idx < 0 {
+			continue // covered by the other test
+		}
+		// Find the enclosing function: the latest funcStart whose
+		// offset is <= idx.
+		enclosing := -1
+		for _, fs := range funcStarts {
+			if fs[0] <= idx {
+				enclosing = fs[0]
+			} else {
+				break
+			}
+		}
+		if enclosing < 0 {
+			t.Errorf("staged.go: %s is not inside any method body", msg)
+			continue
+		}
+		// Read up to ~400 chars of the function signature to find the
+		// parameter list and check for owner/repo there.
+		sigEnd := strings.Index(code[enclosing:], "{")
+		if sigEnd < 0 || sigEnd > 800 {
+			continue
+		}
+		sig := code[enclosing : enclosing+sigEnd]
+		if !strings.Contains(sig, "owner") || !strings.Contains(sig, "repo") {
+			t.Errorf("staged.go: completion log %s is inside a function "+
+				"whose signature does not declare owner/repo: %q", msg, sig)
+		}
+	}
+}

--- a/internal/collector/review_comments_progress_test.go
+++ b/internal/collector/review_comments_progress_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestReviewCommentsProgressLogging — v0.22.4 item 2.
+//
+// The ListReviewComments loop in collectMessages can run for hours on
+// large repos (zephyr: ~210K review comments at ~40K/hr ≈ 5h). Pre-
+// v0.22.4 the loop produced zero log output for its entire duration,
+// indistinguishable from a hang.
+//
+// Pin two requirements:
+//
+//  1. A dedicated local counter for review comments (NOT result.Messages,
+//     which also counts issue comments + PR conversation comments and
+//     would conflate the signals).
+//  2. A progress log line "review comments progress" with owner/repo
+//     gated by a modulo of the counter so the cadence is bounded.
+func TestReviewCommentsProgressLogging(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Find the ListReviewComments loop. Expand backward 200 chars so
+	// a `reviewCount := 0` declaration immediately above the for-range
+	// is captured by the window (Go's range loop has no init clause).
+	loopStart := strings.Index(code, "sc.client.ListReviewComments(")
+	if loopStart < 0 {
+		t.Fatal("could not find sc.client.ListReviewComments( call in staged.go")
+	}
+	winStart := loopStart - 200
+	if winStart < 0 {
+		winStart = 0
+	}
+	loopEnd := loopStart + 2000
+	if loopEnd > len(code) {
+		loopEnd = len(code)
+	}
+	window := code[winStart:loopEnd]
+
+	// 1. Dedicated local counter — anything that looks like
+	//    `reviewCount`, `reviewComments`, `rcCount`. We require it
+	//    is declared (not just incremented) inside the window so a
+	//    refactor that drops the declaration but leaves the
+	//    increment fails the test.
+	counterRE := regexp.MustCompile(`\b(reviewCount|reviewComments|rcCount)\s*:?=`)
+	if !counterRE.MatchString(window) {
+		t.Error("staged.go: ListReviewComments loop must use a dedicated " +
+			"local counter (reviewCount/reviewComments/rcCount) so progress " +
+			"is bounded by review-comments-staged-this-cycle, not the " +
+			"conflated result.Messages count")
+	}
+
+	// 2. Progress log line.
+	if !strings.Contains(window, `"review comments progress"`) {
+		t.Error("staged.go: ListReviewComments loop must log " +
+			"`review comments progress` with owner/repo so a multi-hour " +
+			"silent iteration becomes visible")
+	}
+
+	// 3. Modulo gate so cadence is bounded.
+	moduloRE := regexp.MustCompile(`%\s*\d{2,5}\s*==\s*0`)
+	if !moduloRE.MatchString(window) {
+		t.Error("staged.go: review comments progress log must be gated " +
+			"by a modulo (e.g. count%1000 == 0) so it doesn't fire per-row")
+	}
+
+	// 4. owner/repo on the progress line itself (not just in scope).
+	progIdx := strings.Index(window, `"review comments progress"`)
+	if progIdx >= 0 {
+		// Slice the log call window: from msg to its closing paren.
+		callEnd := strings.Index(window[progIdx:], ")")
+		if callEnd > 0 {
+			call := window[progIdx : progIdx+callEnd]
+			if !strings.Contains(call, `"owner"`) {
+				t.Error("review comments progress log must include " +
+					"slog key \"owner\"")
+			}
+			if !strings.Contains(call, `"repo"`) {
+				t.Error("review comments progress log must include " +
+					"slog key \"repo\"")
+			}
+		}
+	}
+}

--- a/internal/collector/skipping_line_rewrite_test.go
+++ b/internal/collector/skipping_line_rewrite_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSkippingLineRewritten — v0.22.4 item 4.
+//
+// The pre-v0.22.4 log line:
+//
+//	"collectMessages: skipping /issues/comments — delivered inline; still running /pulls/comments for side/startSide"
+//
+// alarmed operators reading the log because "skipping" suggested data was
+// being lost. In reality the data arrives inline from the GraphQL listing
+// (phase 2 + phase 4 work). The new line:
+//
+//   - states what data IS being collected (inline issue + PR conversation
+//     comments from GraphQL),
+//   - explains why /pulls/comments REST STILL runs (review-comment
+//     side/startSide field absence in GraphQL),
+//   - carries owner/repo for per-repo grep.
+//
+// Pin the new wording so a future refactor can't silently revert.
+func TestSkippingLineRewritten(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// 1. Old alarming wording must be gone.
+	if strings.Contains(code, "skipping /issues/comments") {
+		t.Error(`staged.go: pre-v0.22.4 wording "skipping /issues/comments" ` +
+			`must be replaced — it alarmed operators by suggesting data ` +
+			`loss when actually the data arrived inline`)
+	}
+
+	// 2. New log message must mention the inline-delivery story.
+	if !strings.Contains(code, "collectMessages phase plan") {
+		t.Error(`staged.go: new log message should start with ` +
+			`"collectMessages phase plan" so operators know it's an ` +
+			`explanatory line, not an error`)
+	}
+
+	// 3. Must explicitly state /pulls/comments still runs (and why).
+	planIdx := strings.Index(code, "collectMessages phase plan")
+	if planIdx < 0 {
+		return // covered above
+	}
+	// Use a fixed forward window. The Info(...) call may legitimately
+	// contain parens inside its message string, so a naïve "first )"
+	// scan would truncate. 800 chars is comfortably more than the
+	// longest log-call line in this file.
+	end := planIdx + 800
+	if end > len(code) {
+		end = len(code)
+	}
+	window := code[planIdx:end]
+
+	if !strings.Contains(window, `"owner"`) || !strings.Contains(window, `"repo"`) {
+		t.Error("collectMessages phase plan log must carry owner/repo")
+	}
+
+	// Must surface the inline-comment counts. The phase 4 staging happens
+	// via stagePRBatch and stageInlineIssueComments earlier in the
+	// listing path; the count of inline comments staged so far is
+	// available via the result/listing snapshot. We require the log
+	// pass at least two slog int keys named issue_inline_comments and
+	// pr_inline_comments (operator-readable, not implementation-internal).
+	if !strings.Contains(window, "issue_inline_comments") {
+		t.Error("collectMessages phase plan log should carry the count of " +
+			"issue inline comments delivered inline so operators can verify " +
+			"the gate is doing what its name says")
+	}
+	if !strings.Contains(window, "pr_inline_comments") {
+		t.Error("collectMessages phase plan log should carry the count of " +
+			"PR inline comments delivered inline")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -298,8 +298,12 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			result.Errors = append(result.Errors, err)
 		}
 		result.Contributors++
+		if result.Contributors%100 == 0 {
+			sc.logger.Info("contributors progress",
+				"owner", owner, "repo", repo, "staged", result.Contributors)
+		}
 	}
-	sc.logger.Info("contributors staged", "count", result.Contributors)
+	sc.logger.Info("contributors staged", "owner", owner, "repo", repo, "count", result.Contributors)
 
 	// Decide between parallel and sequential collection based on commit count.
 	// Large repos (>10K commits) typically have many issues, PRs, and events.
@@ -431,6 +435,7 @@ func (sc *StagedCollector) stageInlineIssueComments(ctx context.Context, sw *db.
 			continue
 		}
 		result.Messages++
+		result.InlineIssueComments++
 	}
 	sc.logger.Info("staged inline issue comments", "count", len(comments))
 }
@@ -615,7 +620,7 @@ func (sc *StagedCollector) collectIssues(ctx context.Context, sw *db.StagingWrit
 			sc.logger.Info("issues progress", "owner", owner, "repo", repo, "staged", result.Issues, "listing_mode", mode)
 		}
 	}
-	sc.logger.Info("issues staged", "count", result.Issues, "listing_mode", mode)
+	sc.logger.Info("issues staged", "owner", owner, "repo", repo, "count", result.Issues, "listing_mode", mode)
 }
 
 // collectPRs stages all pull requests with their children.
@@ -657,7 +662,7 @@ func (sc *StagedCollector) collectPRs(ctx context.Context, sw *db.StagingWriter,
 	default:
 		sc.collectPRsREST(ctx, sw, owner, repo, prs, result)
 	}
-	sc.logger.Info("pull requests staged", "count", result.PullRequests, "mode", sc.prChildMode)
+	sc.logger.Info("pull requests staged", "owner", owner, "repo", repo, "count", result.PullRequests, "mode", sc.prChildMode)
 }
 
 // collectPRsREST stages PRs using the per-PR REST child waterfall — 8
@@ -937,6 +942,7 @@ func stagePRBatch(ctx context.Context, sw *db.StagingWriter, batch []platform.St
 				continue
 			}
 			result.Messages++
+			result.InlinePRComments++
 		}
 	}
 }
@@ -974,7 +980,7 @@ func (sc *StagedCollector) collectEvents(ctx context.Context, sw *db.StagingWrit
 		}
 		result.Events++
 	}
-	sc.logger.Info("events staged", "count", result.Events)
+	sc.logger.Info("events staged", "owner", owner, "repo", repo, "count", result.Events)
 }
 
 // collectMessages stages issue + PR conversation comments (via repo-wide
@@ -1000,8 +1006,13 @@ func (sc *StagedCollector) collectEvents(ctx context.Context, sw *db.StagingWrit
 func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWriter, owner, repo string, since time.Time, result *CollectResult) {
 	full := sc.fullGraphQLMode()
 	if full {
-		sc.logger.Info("collectMessages: skipping /issues/comments — delivered inline; still running /pulls/comments for side/startSide",
-			"owner", owner, "repo", repo)
+		sc.logger.Info("collectMessages phase plan: issue + PR conversation comments arrived inline via GraphQL listing; "+
+			"repo-wide /issues/comments REST iterator intentionally skipped to avoid duplicate work; "+
+			"/pulls/comments REST iterator IS running here for review_comments.pr_cmt_side / pr_cmt_start_side fidelity "+
+			"(GitHub GraphQL PullRequestReviewComment omits those fields)",
+			"owner", owner, "repo", repo,
+			"issue_inline_comments", result.InlineIssueComments,
+			"pr_inline_comments", result.InlinePRComments)
 	} else {
 		sc.logger.Info("collecting messages", "owner", owner, "repo", repo)
 		for msg, err := range sc.client.ListIssueComments(ctx, owner, repo, since) {
@@ -1020,6 +1031,7 @@ func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWr
 			result.Messages++
 		}
 	}
+	reviewCount := 0
 	for rc, err := range sc.client.ListReviewComments(ctx, owner, repo, since) {
 		if err != nil {
 			if isOptionalEndpointSkip(err) {
@@ -1034,8 +1046,13 @@ func (sc *StagedCollector) collectMessages(ctx context.Context, sw *db.StagingWr
 			result.Errors = append(result.Errors, fmt.Errorf("stage review comment: %w", err))
 		}
 		result.Messages++
+		reviewCount++
+		if reviewCount%1000 == 0 {
+			sc.logger.Info("review comments progress",
+				"owner", owner, "repo", repo, "staged", reviewCount)
+		}
 	}
-	sc.logger.Info("messages staged", "count", result.Messages)
+	sc.logger.Info("messages staged", "owner", owner, "repo", repo, "count", result.Messages)
 }
 
 // Processor drains the staging table and writes to the relational schema.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -373,6 +373,25 @@ type CollectionConfig struct {
 	// because scancode runs are intrinsically long-running on big
 	// repos and you usually want them to finish if they're close.
 	ScancodeShutdownGraceMinutes int `json:"scancode_shutdown_grace_minutes"`
+
+	// StagingRetentionHours is how long processed staging rows are kept
+	// before the hourly PurgeStagedProcessed sweep deletes them. Default
+	// 1 hour when unset. v0.22.4: pre-v0.22.4 the window was hardcoded
+	// to 7 days, which stacked 3–5 cycles of processed JSONB tombstones
+	// per frequently-re-collected repo and wasted multiple GB of disk
+	// across the fleet. Operators who need forensic retention (e.g. for
+	// shadow-diff debugging) can raise this to a value of their choice;
+	// 24 (one day) is a reasonable middle ground.
+	StagingRetentionHours int `json:"staging_retention_hours"`
+}
+
+// StagingRetentionDuration converts StagingRetentionHours to a
+// time.Duration. Falls back to 1 hour when unset. v0.22.4 default.
+func (c *CollectionConfig) StagingRetentionDuration() time.Duration {
+	if c.StagingRetentionHours <= 0 {
+		return time.Hour
+	}
+	return time.Duration(c.StagingRetentionHours) * time.Hour
 }
 
 // EnrichIntervalDuration converts EnrichIntervalMinutes to a time.Duration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -374,6 +374,18 @@ type CollectionConfig struct {
 	// repos and you usually want them to finish if they're close.
 	ScancodeShutdownGraceMinutes int `json:"scancode_shutdown_grace_minutes"`
 
+	// PhaseWatchdogMinutes controls the v0.22.4 observation watchdog's
+	// stall threshold. If staging row count for a repo does not grow
+	// for this many minutes, the watchdog appends an event to
+	// ~/.aveloxis/aveloxis-long-jobs.log plus a goroutine dump under
+	// ~/.aveloxis/long-jobs/. Default 75 minutes — chosen so that
+	// large first-cycle collections (microsoft/vscode-class) are
+	// observed for prevalence but never killed. The watchdog NEVER
+	// cancels the job or requeues the repo. Operators tune up to
+	// reduce noise on very-slow-but-legitimate workloads, or down
+	// (e.g. 30) to spot smaller hangs during incident triage.
+	PhaseWatchdogMinutes int `json:"phase_watchdog_minutes"`
+
 	// StagingRetentionHours is how long processed staging rows are kept
 	// before the hourly PurgeStagedProcessed sweep deletes them. Default
 	// 1 hour when unset. v0.22.4: pre-v0.22.4 the window was hardcoded
@@ -383,6 +395,15 @@ type CollectionConfig struct {
 	// shadow-diff debugging) can raise this to a value of their choice;
 	// 24 (one day) is a reasonable middle ground.
 	StagingRetentionHours int `json:"staging_retention_hours"`
+}
+
+// PhaseWatchdogDuration returns the v0.22.4 long-jobs watchdog
+// threshold. Falls back to 75 minutes when unset.
+func (c *CollectionConfig) PhaseWatchdogDuration() time.Duration {
+	if c.PhaseWatchdogMinutes <= 0 {
+		return 75 * time.Minute
+	}
+	return time.Duration(c.PhaseWatchdogMinutes) * time.Minute
 }
 
 // StagingRetentionDuration converts StagingRetentionHours to a

--- a/internal/config/staging_retention_test.go
+++ b/internal/config/staging_retention_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStagingRetentionConfigKnob — v0.22.4 item 5.
+//
+// The pre-v0.22.4 PurgeStagedProcessed query hardcoded `INTERVAL '7
+// days'`. For a frequently-re-collected repo this stacked 3–5 cycles
+// of processed JSONB tombstones in the staging table (verified
+// empirically against aveloxis_large on 2026-05-16: zephyr had 84K
+// staged issues against an actual 28K count). Not a correctness bug
+// (Processor reads WHERE NOT processed) but real disk waste and
+// diagnostic confusion.
+//
+// Pin: new CollectionConfig.StagingRetentionHours field with a
+// fallback duration accessor defaulting to 1 hour.
+func TestStagingRetentionConfigKnob(t *testing.T) {
+	src, err := os.ReadFile("config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// Field declaration with json tag. Whitespace-tolerant — gofmt
+	// aligns fields in columns so the exact spacing varies.
+	fieldRE := regexp.MustCompile(`\bStagingRetentionHours\s+int\s+` + "`" + `json:"staging_retention_hours"` + "`")
+	if !fieldRE.MatchString(code) {
+		t.Error(`config.go: CollectionConfig must declare ` +
+			"`StagingRetentionHours int `" + `json:"staging_retention_hours"` +
+			"` so operators can tune the staging-cleanup window without recompiling")
+	}
+
+	// Accessor with a sensible default. Look for the function name +
+	// a return path that yields a time.Duration. We don't constrain
+	// the implementation shape (could be `if <=0 return default`,
+	// `max(...)`, etc.) but the function must exist and return a
+	// Duration.
+	if !strings.Contains(code, "StagingRetentionDuration() time.Duration") {
+		t.Error("config.go: CollectionConfig must expose " +
+			"StagingRetentionDuration() time.Duration so the staging " +
+			"cleanup goroutine can read a tuned interval")
+	}
+}
+
+// TestStagingRetentionDurationDefault — behavioral test for the
+// accessor's fallback when the field is unset (zero). 1 hour by
+// design — operators who need forensic retention can raise it; the
+// previous 7-day window was defensive overkill that wasted disk space
+// across the whole fleet.
+func TestStagingRetentionDurationDefault(t *testing.T) {
+	c := &CollectionConfig{}
+	got := c.StagingRetentionDuration()
+	want := time.Hour
+	if got != want {
+		t.Errorf("default StagingRetentionDuration = %v, want %v", got, want)
+	}
+}
+
+// TestStagingRetentionDurationHonorsExplicit — operator-tunable case.
+func TestStagingRetentionDurationHonorsExplicit(t *testing.T) {
+	c := &CollectionConfig{StagingRetentionHours: 24}
+	got := c.StagingRetentionDuration()
+	want := 24 * time.Hour
+	if got != want {
+		t.Errorf("StagingRetentionDuration with hours=24 = %v, want %v", got, want)
+	}
+}

--- a/internal/db/staging.go
+++ b/internal/db/staging.go
@@ -240,6 +240,22 @@ func (s *PostgresStore) PurgeStagedForRepo(ctx context.Context, repoID int64) {
 	}
 }
 
+// StagingRowCount returns the count of staging rows (processed +
+// unprocessed) for the given repo_id. v0.22.4 — used by the long-
+// jobs watchdog as a low-cost monotonic progress proxy. The
+// underlying COUNT runs against idx_staging_unprocessed for
+// unprocessed rows and a sequential scan for processed (which is
+// rare during active collection); on a 100K-fleet production DB
+// the query lands in ~10ms.
+func (s *PostgresStore) StagingRowCount(ctx context.Context, repoID int64) (int64, error) {
+	var n int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_ops.staging WHERE repo_id = $1`,
+		repoID,
+	).Scan(&n)
+	return n, err
+}
+
 // PurgeStagedProcessed removes processed rows older than retention to
 // prevent staging-table bloat. v0.22.4: retention is now caller-supplied
 // (sourced from collection.staging_retention_hours, defaulting to 1

--- a/internal/db/staging.go
+++ b/internal/db/staging.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -239,11 +240,25 @@ func (s *PostgresStore) PurgeStagedForRepo(ctx context.Context, repoID int64) {
 	}
 }
 
-// PurgeStagedProcessed removes old processed rows to prevent table bloat.
-func (s *PostgresStore) PurgeStagedProcessed(ctx context.Context) (int64, error) {
+// PurgeStagedProcessed removes processed rows older than retention to
+// prevent staging-table bloat. v0.22.4: retention is now caller-supplied
+// (sourced from collection.staging_retention_hours, defaulting to 1
+// hour) instead of the hardcoded 7-day window. Cutting from 7 days to 1
+// hour eliminates the 3–5× JSONB tombstone stacking observed on
+// frequently-re-collected repos in 2026-05-16 production diagnostics.
+//
+// The Postgres `INTERVAL` literal can't accept a Duration directly, so
+// we pass total seconds as a parameter via `make_interval(secs => $1)`.
+// This works for any retention from a few seconds upward and keeps the
+// duration arithmetic on the Go side.
+func (s *PostgresStore) PurgeStagedProcessed(ctx context.Context, retention time.Duration) (int64, error) {
+	if retention <= 0 {
+		retention = time.Hour
+	}
 	tag, err := s.pool.Exec(ctx, `
 		DELETE FROM aveloxis_ops.staging
-		WHERE processed AND created_at < NOW() - INTERVAL '7 days'`)
+		WHERE processed AND created_at < NOW() - make_interval(secs => $1)`,
+		retention.Seconds())
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/staging_stats.go
+++ b/internal/db/staging_stats.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// StagingStatsRow is one row of the read-only summary surfaced by the
+// `aveloxis staging-stats` subcommand. v0.22.4 item 6.
+//
+// Mirrors the operator output shape directly: one row per (repo,
+// entity_type), with row counts, age bounds, and approximate byte
+// size of the JSONB payloads. The query is intentionally read-only —
+// nothing about it modifies the staging table.
+type StagingStatsRow struct {
+	RepoID      int64
+	RepoOwner   string
+	RepoName    string
+	EntityType  string
+	Rows        int64
+	Processed   int64
+	Unprocessed int64
+	Oldest      time.Time
+	Newest      time.Time
+	Bytes       int64
+}
+
+// StagingStats returns aggregated staging-table state. When repoFilter
+// is empty, returns the top `limit` (repo, entity_type) pairs by total
+// rows. When repoFilter is "owner/name", returns every entity_type for
+// that repo (limit is ignored).
+//
+// The query joins against aveloxis_data.repos to get owner/name for
+// display. `pg_column_size(payload)` is approximate per-row payload
+// size; SUM over the cohort gives a usable disk-space proxy without
+// needing to scan the actual TOAST chunks.
+func (s *PostgresStore) StagingStats(ctx context.Context, repoFilter string, limit int) ([]StagingStatsRow, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	const baseQuery = `
+		SELECT
+		  s.repo_id,
+		  COALESCE(r.repo_owner, ''),
+		  COALESCE(r.repo_name, ''),
+		  s.entity_type,
+		  COUNT(*),
+		  COUNT(*) FILTER (WHERE s.processed),
+		  COUNT(*) FILTER (WHERE NOT s.processed),
+		  MIN(s.created_at),
+		  MAX(s.created_at),
+		  COALESCE(SUM(pg_column_size(s.payload))::bigint, 0)
+		FROM aveloxis_ops.staging s
+		LEFT JOIN aveloxis_data.repos r ON r.repo_id = s.repo_id`
+
+	var rows []StagingStatsRow
+
+	if repoFilter != "" {
+		// Per-repo drill-in. Filter on owner/name join.
+		q := baseQuery + `
+		WHERE r.repo_owner || '/' || r.repo_name = $1
+		GROUP BY s.repo_id, r.repo_owner, r.repo_name, s.entity_type
+		ORDER BY COUNT(*) DESC`
+		r, err := s.pool.Query(ctx, q, repoFilter)
+		if err != nil {
+			return nil, fmt.Errorf("staging stats query (per-repo): %w", err)
+		}
+		defer r.Close()
+		for r.Next() {
+			var row StagingStatsRow
+			if err := r.Scan(&row.RepoID, &row.RepoOwner, &row.RepoName,
+				&row.EntityType, &row.Rows, &row.Processed, &row.Unprocessed,
+				&row.Oldest, &row.Newest, &row.Bytes); err != nil {
+				return nil, fmt.Errorf("staging stats scan: %w", err)
+			}
+			rows = append(rows, row)
+		}
+		return rows, r.Err()
+	}
+
+	// Top-N view.
+	q := baseQuery + `
+		GROUP BY s.repo_id, r.repo_owner, r.repo_name, s.entity_type
+		ORDER BY COUNT(*) DESC
+		LIMIT $1`
+	r, err := s.pool.Query(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("staging stats query (top): %w", err)
+	}
+	defer r.Close()
+	for r.Next() {
+		var row StagingStatsRow
+		if err := r.Scan(&row.RepoID, &row.RepoOwner, &row.RepoName,
+			&row.EntityType, &row.Rows, &row.Processed, &row.Unprocessed,
+			&row.Oldest, &row.Newest, &row.Bytes); err != nil {
+			return nil, fmt.Errorf("staging stats scan: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	return rows, r.Err()
+}

--- a/internal/scheduler/long_jobs_watchdog.go
+++ b/internal/scheduler/long_jobs_watchdog.go
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// LongJobsWatchdog is the v0.22.4 item-7 observation-only progress
+// watchdog. Per-job goroutine. Polls staging row count every
+// PollEvery. If the count is unchanged for Threshold continuous time,
+// it emits a JSON-lines event to LogPath and a goroutine dump to
+// DumpDir. When the count grows again it emits a stall_resumed event.
+//
+// CRITICAL: this watchdog NEVER cancels the job, NEVER requeues the
+// repo, NEVER touches collection_queue, NEVER kills anything. It is
+// pure observation. The 2026-05-16 operator decision was that very
+// large repos (microsoft/vscode-class first collections) may
+// legitimately run for days — killing them at 75 minutes would
+// prevent them from ever completing. The signal we want is "how
+// often does this happen, on which repos, for how long, with what
+// goroutine state at the time" — material for diagnosing actual
+// root-cause hangs in a future release, not a recovery primitive.
+//
+// Default sentinels (filled from config in production):
+//   - Threshold = 75 * time.Minute  (collection.phase_watchdog_minutes)
+//   - PollEvery = 30 * time.Second
+type LongJobsWatchdog struct {
+	Logger    *slog.Logger
+	LogPath   string        // append-only ~/.aveloxis/aveloxis-long-jobs.log
+	DumpDir   string        // per-event goroutine dump directory
+	Threshold time.Duration // no-growth window before a stall_observed event fires
+	PollEvery time.Duration // staging row-count sampling cadence
+	Owner     string        // identifies the repo in every event
+	Repo      string        //
+	RepoID    int64         //
+	WorkerID  string        // worker that holds the lock
+	CountFn   func(ctx context.Context, repoID int64) (int64, error)
+
+	mu        sync.Mutex
+	startTime time.Time
+}
+
+// Start launches the watchdog goroutine and returns a stop function.
+// Calling stop is idempotent and safe from any goroutine. The stop
+// function blocks until the watchdog goroutine has fully exited so
+// tests can observe deterministic output state.
+func (w *LongJobsWatchdog) Start(ctx context.Context) func() {
+	if w.Threshold <= 0 {
+		w.Threshold = 75 * time.Minute
+	}
+	if w.PollEvery <= 0 {
+		w.PollEvery = 30 * time.Second
+	}
+	w.startTime = time.Now()
+
+	wctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	go w.run(wctx, done)
+
+	var stopOnce sync.Once
+	return func() {
+		stopOnce.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+}
+
+func (w *LongJobsWatchdog) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	if w.CountFn == nil {
+		// No way to poll; nothing to do.
+		return
+	}
+
+	ticker := time.NewTicker(w.PollEvery)
+	defer ticker.Stop()
+
+	var (
+		lastCount      int64
+		lastChange     = time.Now()
+		stallActive    bool
+		stallStartedAt time.Time
+		// To avoid re-emitting a stall_observed every poll once we're
+		// past the threshold, we re-emit at most every Threshold
+		// duration so operators see periodic "still stalled" markers.
+		lastStallEvent time.Time
+		initialized    bool
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			count, err := w.CountFn(ctx, w.RepoID)
+			if err != nil {
+				if w.Logger != nil {
+					w.Logger.Debug("long-jobs watchdog poll error",
+						"owner", w.Owner, "repo", w.Repo, "error", err)
+				}
+				continue
+			}
+			if !initialized {
+				lastCount = count
+				lastChange = time.Now()
+				initialized = true
+				continue
+			}
+			if count != lastCount {
+				// Growth (or shrink — but staging never shrinks during
+				// a collection, so any change means progress).
+				if stallActive {
+					w.emit(ctx, "stall_resumed", count, time.Since(stallStartedAt), false)
+					stallActive = false
+				}
+				lastCount = count
+				lastChange = time.Now()
+				continue
+			}
+			// No change since lastChange. Have we crossed the threshold?
+			elapsed := time.Since(lastChange)
+			if elapsed < w.Threshold {
+				continue
+			}
+			if !stallActive {
+				stallActive = true
+				stallStartedAt = lastChange
+				lastStallEvent = time.Time{}
+			}
+			// Emit a fresh event the first time, then once per Threshold
+			// while the stall persists.
+			if lastStallEvent.IsZero() || time.Since(lastStallEvent) >= w.Threshold {
+				w.emit(ctx, "stall_observed", count, elapsed, true)
+				lastStallEvent = time.Now()
+			}
+		}
+	}
+}
+
+// emit writes one JSON-lines event to the log file and (when
+// withDump=true) a goroutine dump to DumpDir.
+func (w *LongJobsWatchdog) emit(ctx context.Context, kind string, count int64, stalled time.Duration, withDump bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(w.LogPath), 0o755); err != nil {
+		if w.Logger != nil {
+			w.Logger.Warn("long-jobs log dir mkdir failed",
+				"path", filepath.Dir(w.LogPath), "error", err)
+		}
+		return
+	}
+
+	event := map[string]any{
+		"timestamp":             time.Now().UTC().Format(time.RFC3339Nano),
+		"event":                 kind,
+		"owner":                 w.Owner,
+		"repo":                  w.Repo,
+		"repo_id":               w.RepoID,
+		"worker_id":             w.WorkerID,
+		"staging_rows":          count,
+		"stalled_for_seconds":   int64(stalled.Seconds()),
+		"elapsed_total_seconds": int64(time.Since(w.startTime).Seconds()),
+		"num_goroutines":        runtime.NumGoroutine(),
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	event["mem_alloc_bytes"] = int64(mem.Alloc)
+	event["mem_sys_bytes"] = int64(mem.Sys)
+
+	if withDump {
+		dumpName, err := w.writeGoroutineDump()
+		if err == nil {
+			event["goroutine_dump"] = dumpName
+		} else if w.Logger != nil {
+			w.Logger.Warn("long-jobs goroutine dump failed",
+				"owner", w.Owner, "repo", w.Repo, "error", err)
+		}
+	}
+
+	line, err := json.Marshal(event)
+	if err != nil {
+		if w.Logger != nil {
+			w.Logger.Warn("long-jobs event marshal failed", "error", err)
+		}
+		return
+	}
+
+	f, err := os.OpenFile(w.LogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		if w.Logger != nil {
+			w.Logger.Warn("long-jobs log open failed", "path", w.LogPath, "error", err)
+		}
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil && w.Logger != nil {
+		w.Logger.Warn("long-jobs log write failed", "error", err)
+	}
+}
+
+// writeGoroutineDump captures runtime.Stack(_, true) for all
+// goroutines and writes it to a per-event file under DumpDir.
+// Returns the filename (just the basename — the dir is well-known).
+func (w *LongJobsWatchdog) writeGoroutineDump() (string, error) {
+	if err := os.MkdirAll(w.DumpDir, 0o755); err != nil {
+		return "", err
+	}
+	// 1 MB cap. runtime.Stack truncates without error when the buffer
+	// is short, which is acceptable here — operators primarily want
+	// to know WHICH goroutine is stalled, and 1 MB covers thousands of
+	// frames at typical stack widths.
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	name := fmt.Sprintf("%s-%s-%s.txt", safeSlug(w.Owner), safeSlug(w.Repo), ts)
+	path := filepath.Join(w.DumpDir, name)
+	if err := os.WriteFile(path, buf[:n], 0o644); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// longJobsLogPath returns the absolute path to
+// ~/.aveloxis/aveloxis-long-jobs.log. Falls back to /tmp when the
+// user's home directory cannot be determined (rare on Linux/macOS
+// but possible inside containers with broken passwd lookups).
+func longJobsLogPath() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".aveloxis", "aveloxis-long-jobs.log")
+	}
+	return filepath.Join(os.TempDir(), "aveloxis-long-jobs.log")
+}
+
+// longJobsDumpDir returns the absolute path to
+// ~/.aveloxis/long-jobs/. Mirrors longJobsLogPath's fallback.
+func longJobsDumpDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".aveloxis", "long-jobs")
+	}
+	return filepath.Join(os.TempDir(), "aveloxis-long-jobs")
+}
+
+// safeSlug replaces filesystem-unfriendly characters in owner/repo
+// slugs (e.g., "kubernetes/kubernetes" has none, but generic-git
+// "name with spaces" or "owner@host:path" would).
+func safeSlug(s string) string {
+	if s == "" {
+		return "_"
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-' || c == '_' || c == '.':
+			out = append(out, c)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/internal/scheduler/long_jobs_watchdog_test.go
+++ b/internal/scheduler/long_jobs_watchdog_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestPhaseWatchdogConfigKnob — v0.22.4 item 7.
+//
+// Pin: CollectionConfig.PhaseWatchdogMinutes + accessor +
+// scheduler.Config.PhaseWatchdog field exist and are plumbed from
+// JSON through to the scheduler.
+func TestPhaseWatchdogConfigKnob(t *testing.T) {
+	src, err := os.ReadFile("../config/config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "PhaseWatchdogMinutes") {
+		t.Error("config.go: CollectionConfig must declare PhaseWatchdogMinutes int with json:\"phase_watchdog_minutes\" so operators can tune the long-jobs observation threshold")
+	}
+	if !strings.Contains(code, `json:"phase_watchdog_minutes"`) {
+		t.Error("config.go: PhaseWatchdogMinutes must carry json:\"phase_watchdog_minutes\" tag")
+	}
+	if !strings.Contains(code, "PhaseWatchdogDuration() time.Duration") {
+		t.Error("config.go: CollectionConfig.PhaseWatchdogDuration() time.Duration accessor must exist with a default fallback")
+	}
+
+	schSrc, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sch := string(schSrc)
+	if !strings.Contains(sch, "PhaseWatchdog ") && !strings.Contains(sch, "PhaseWatchdog\t") {
+		t.Error("scheduler.go: Config must declare PhaseWatchdog time.Duration so runJob can spawn an observation watchdog")
+	}
+}
+
+// TestRunJobSpawnsLongJobsWatchdog — pins that runJob actually wires
+// the watchdog into the per-job goroutine, so an unobserved hang
+// still produces a long-jobs.log event.
+func TestRunJobSpawnsLongJobsWatchdog(t *testing.T) {
+	src, err := os.ReadFile("scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+	runJobIdx := strings.Index(body, "func (s *Scheduler) runJob(")
+	if runJobIdx < 0 {
+		t.Fatal("runJob not found")
+	}
+	// 10K-char window is plenty to cover the function.
+	end := runJobIdx + 12000
+	if end > len(body) {
+		end = len(body)
+	}
+	window := body[runJobIdx:end]
+
+	// Must reference the watchdog by name.
+	if !strings.Contains(window, "LongJobsWatchdog") && !strings.Contains(window, "longJobsWatchdog") {
+		t.Error("runJob must instantiate the long-jobs watchdog by name")
+	}
+}
+
+// TestLongJobsWatchdogEventShape — behavioral.
+//
+// Drive the watchdog with a fast threshold (300ms), a slow polling
+// interval (50ms), and a synthetic count source that returns a
+// constant value. After ≥1 threshold elapses, the watchdog should
+// write at least one JSON-lines event to the configured log file
+// with the expected keys.
+func TestLongJobsWatchdogEventShape(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "aveloxis-long-jobs.log")
+	dumpDir := filepath.Join(dir, "long-jobs")
+
+	w := &LongJobsWatchdog{
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogPath:   logPath,
+		DumpDir:   dumpDir,
+		Threshold: 200 * time.Millisecond,
+		PollEvery: 30 * time.Millisecond,
+		Owner:     "microsoft",
+		Repo:      "vscode",
+		RepoID:    12345,
+		WorkerID:  "test-worker",
+		CountFn:   func(context.Context, int64) (int64, error) { return 100, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := w.Start(ctx)
+
+	// Wait for at least one event.
+	deadline := time.Now().Add(2 * time.Second)
+	var data []byte
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(logPath)
+		if err == nil && len(b) > 0 {
+			data = b
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	stop()
+
+	if len(data) == 0 {
+		t.Fatal("watchdog did not write to long-jobs.log within deadline")
+	}
+
+	// Parse the first JSON-lines record.
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	if !scanner.Scan() {
+		t.Fatal("long-jobs.log has no lines")
+	}
+	var event map[string]any
+	if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+		t.Fatalf("first long-jobs.log line is not JSON: %v\nline: %q", err, scanner.Text())
+	}
+
+	for _, key := range []string{
+		"timestamp", "owner", "repo", "repo_id", "worker_id",
+		"staging_rows", "stalled_for_seconds", "event",
+	} {
+		if _, ok := event[key]; !ok {
+			t.Errorf("long-jobs.log event missing required key %q (got: %v)", key, event)
+		}
+	}
+	if got := event["owner"]; got != "microsoft" {
+		t.Errorf("event.owner = %v, want microsoft", got)
+	}
+	if got := event["repo"]; got != "vscode" {
+		t.Errorf("event.repo = %v, want vscode", got)
+	}
+	if got := event["event"]; got != "stall_observed" {
+		t.Errorf("event.event = %v, want stall_observed", got)
+	}
+
+	// Goroutine dump file must exist alongside the log event.
+	dumpRef, ok := event["goroutine_dump"].(string)
+	if !ok || dumpRef == "" {
+		t.Error("event must carry a goroutine_dump key referencing the per-event dump file")
+	} else {
+		// Path is relative to DumpDir.
+		path := dumpRef
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(dumpDir, filepath.Base(dumpRef))
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("goroutine_dump file not created at %s: %v", path, err)
+		}
+	}
+}
+
+// TestLongJobsWatchdogResumeOnProgress — when staging row count
+// grows again after a stall event has been emitted, the watchdog
+// emits a "resumed" event. This is the prevalence-tracking signal
+// the operator wants — we capture the full stall duration so future
+// analysis can answer "how often does this happen and for how long?"
+func TestLongJobsWatchdogResumeOnProgress(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "aveloxis-long-jobs.log")
+
+	var n atomic.Int64
+	n.Store(100)
+
+	w := &LongJobsWatchdog{
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogPath:   logPath,
+		DumpDir:   filepath.Join(dir, "long-jobs"),
+		Threshold: 150 * time.Millisecond,
+		PollEvery: 30 * time.Millisecond,
+		Owner:     "zephyrproject-rtos",
+		Repo:      "zephyr",
+		RepoID:    777,
+		WorkerID:  "test-worker",
+		CountFn:   func(context.Context, int64) (int64, error) { return n.Load(), nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := w.Start(ctx)
+	defer stop()
+
+	// Wait for a stall event.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(logPath)
+		if err == nil && strings.Contains(string(b), "stall_observed") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Now move the count forward and wait for a "resumed" event.
+	n.Store(200)
+	deadline = time.Now().Add(2 * time.Second)
+	resumed := false
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(logPath)
+		if err == nil && strings.Contains(string(b), "stall_resumed") {
+			resumed = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !resumed {
+		b, _ := os.ReadFile(logPath)
+		t.Errorf("watchdog did not write a stall_resumed event after staging row count grew. log:\n%s", string(b))
+	}
+}
+
+// TestLongJobsWatchdogNoEventOnHealthyJob — if staging row count
+// grows on every tick, the threshold is never reached and the
+// watchdog stays silent. Pure healthy-path regression guard.
+func TestLongJobsWatchdogNoEventOnHealthyJob(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "aveloxis-long-jobs.log")
+
+	var n atomic.Int64
+	n.Store(0)
+
+	w := &LongJobsWatchdog{
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogPath:   logPath,
+		DumpDir:   filepath.Join(dir, "long-jobs"),
+		Threshold: 200 * time.Millisecond,
+		PollEvery: 25 * time.Millisecond,
+		Owner:     "happy",
+		Repo:      "path",
+		RepoID:    1,
+		WorkerID:  "test-worker",
+		CountFn: func(context.Context, int64) (int64, error) {
+			return n.Add(1), nil // grow on every poll
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := w.Start(ctx)
+	time.Sleep(600 * time.Millisecond)
+	stop()
+
+	if data, err := os.ReadFile(logPath); err == nil && len(data) > 0 {
+		t.Errorf("watchdog wrote events for a healthy progressing job:\n%s", data)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected error reading log: %v", err)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,6 +64,13 @@ type Config struct {
 	ScancodeCadence       time.Duration // minimum interval between scans on the same repo (default 180d)
 	ScancodeCloneDir      string        // parent directory for per-run shallow clones (default /tmp/aveloxis-scancode)
 	ScancodeShutdownGrace time.Duration // wait budget for in-flight scancode runs on aveloxis stop (default 30m)
+
+	// StagingRetention is how long processed staging rows are kept
+	// before the hourly PurgeStagedProcessed sweep deletes them.
+	// Default 1 hour. v0.22.4 cut from the prior hardcoded 7-day window
+	// after 2026-05-16 production diagnostics showed JSONB tombstones
+	// stacking 3–5× on frequently-re-collected repos.
+	StagingRetention time.Duration
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.
@@ -142,6 +149,9 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	}
 	if cfg.ScancodeShutdownGrace == 0 {
 		cfg.ScancodeShutdownGrace = 30 * time.Minute
+	}
+	if cfg.StagingRetention == 0 {
+		cfg.StagingRetention = 1 * time.Hour
 	}
 
 	hostname, _ := os.Hostname()
@@ -447,7 +457,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 // seconds) and at worst race on the same DELETE WHERE, which is
 // safe because the predicate is monotonic.
 func (s *Scheduler) runStagingCleanup(ctx context.Context) {
-	deleted, err := s.store.PurgeStagedProcessed(ctx)
+	deleted, err := s.store.PurgeStagedProcessed(ctx, s.cfg.StagingRetention)
 	if err != nil {
 		s.logger.Warn("staging cleanup failed", "error", err)
 		return

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -65,6 +65,12 @@ type Config struct {
 	ScancodeCloneDir      string        // parent directory for per-run shallow clones (default /tmp/aveloxis-scancode)
 	ScancodeShutdownGrace time.Duration // wait budget for in-flight scancode runs on aveloxis stop (default 30m)
 
+	// PhaseWatchdog is the no-staging-growth threshold the v0.22.4
+	// observation watchdog uses to emit a long-jobs event. Default
+	// 75 minutes. Watchdog is purely observational — it NEVER cancels
+	// the job or requeues the repo. See long_jobs_watchdog.go.
+	PhaseWatchdog time.Duration
+
 	// StagingRetention is how long processed staging rows are kept
 	// before the hourly PurgeStagedProcessed sweep deletes them.
 	// Default 1 hour. v0.22.4 cut from the prior hardcoded 7-day window
@@ -152,6 +158,9 @@ func NewWithKeys(store *db.PostgresStore, ghClient, glClient platform.Client, gh
 	}
 	if cfg.StagingRetention == 0 {
 		cfg.StagingRetention = 1 * time.Hour
+	}
+	if cfg.PhaseWatchdog == 0 {
+		cfg.PhaseWatchdog = 75 * time.Minute
 	}
 
 	hostname, _ := os.Hostname()
@@ -685,6 +694,29 @@ func (s *Scheduler) runJob(ctx context.Context, job *db.QueueJob) {
 		s.failJob(ctx, job.RepoID, err.Error())
 		return
 	}
+
+	// v0.22.4 item 7 — observation-only long-jobs watchdog. Polls
+	// staging row count for this repo every 30s; if no growth for
+	// PhaseWatchdog (default 75m), appends one event to
+	// ~/.aveloxis/aveloxis-long-jobs.log + a goroutine dump to
+	// ~/.aveloxis/long-jobs/. NEVER cancels this job; the watchdog
+	// is purely observational. The defer stop() runs at function
+	// return so it survives every job-exit path (success, failure,
+	// skip, panic).
+	watchdog := &LongJobsWatchdog{
+		Logger:    s.logger,
+		LogPath:   longJobsLogPath(),
+		DumpDir:   longJobsDumpDir(),
+		Threshold: s.cfg.PhaseWatchdog,
+		PollEvery: 30 * time.Second,
+		Owner:     repo.Owner,
+		Repo:      repo.Name,
+		RepoID:    job.RepoID,
+		WorkerID:  s.workerID,
+		CountFn:   s.store.StagingRowCount,
+	}
+	stopWatchdog := watchdog.Start(ctx)
+	defer stopWatchdog()
 
 	// Prelim phase: check for redirects and duplicates.
 	prelim, err := collector.RunPrelim(ctx, s.store, repo, s.logger)


### PR DESCRIPTION
#### v0.22.4 Summary:

  8/8 items complete via TDD, full suite passing:
  
| # | Item | Files |
|---:|---|---|
| 1 | owner/repo on 5 staged log lines | staged.go |
| 2 | review_comments progress every 1000 | staged.go (new reviewCount) |
| 3 | contributors progress every 100 | staged.go |
| 4 | rewrote alarming skipping line | staged.go + 2 new counters on CollectResult |
| 5 | staging retention 7d→1h, config knob | staging.go, config.go, scheduler.go, main.go |
| 6 | aveloxis staging-stats subcommand | new staging_stats_cmd.go + internal/db/staging_stats.go |
| 7 | long-jobs observation watchdog | new long_jobs_watchdog.go + StagingRowCount query |
| 8 | SIGUSR1 dump handler | new sigusr1_dump.go |
|
  Key design pivot: item 7 watchdog is observation-only. The watchdog appends JSON-lines events to ~/.aveloxis/aveloxis-long-jobs.log and writes goroutine dumps to ~/.aveloxis/long-jobs/<owner>-<repo>-<ts>.txt when staging row count stalls for ≥75 min, then re-emits every 75 min, and emits a stall_resumed when growth resumes — never kills, never requeues. Default 75 min covers the legitimate days-long first collections you flagged.

  Tripwires fired (worked as designed): docs-coverage and example-config tests caught both new JSON keys; added to docs/getting-started/configuration.md and aveloxis.example.json.

  Schema-free release. aveloxis migrate --skip-views just bumps tool_version. Operator deploy is 
```bash
go install ./cmd/aveloxis && aveloxis stop all && aveloxis start all.
```

## What's Changed
* Feat/graphql more logs by @sgoggins in https://github.com/aveloxis/aveloxis/pull/80


**Full Changelog**: https://github.com/aveloxis/aveloxis/compare/0.22.3...0.22.4