### PR TITLE
updating version for powerlogging release 0.22.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+aveloxis.runlocal.json
 prompt-notes/**
 summary/**
 summaries/**

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.22.4"
+var ToolVersion = "0.22.5"


### PR DESCRIPTION
#### v0.22.5 Summary:

(Buried release 0.22.4 because it was issued before merging the PR.)

  8/8 items complete via TDD, full suite passing:
  
| # | Item | Files |
|---:|---|---|
| 1 | owner/repo on 5 staged log lines | staged.go |
| 2 | review_comments progress every 1000 | staged.go (new reviewCount) |
| 3 | contributors progress every 100 | staged.go |
| 4 | rewrote alarming skipping line | staged.go + 2 new counters on CollectResult |
| 5 | staging retention 7d→1h, config knob | staging.go, config.go, scheduler.go, main.go |
| 6 | aveloxis staging-stats subcommand | new staging_stats_cmd.go + internal/db/staging_stats.go |
| 7 | long-jobs observation watchdog | new long_jobs_watchdog.go + StagingRowCount query |
| 8 | SIGUSR1 dump handler | new sigusr1_dump.go |
|
  Key design pivot: item 7 watchdog is observation-only. The watchdog appends JSON-lines events to ~/.aveloxis/aveloxis-long-jobs.log and writes goroutine dumps to ~/.aveloxis/long-jobs/<owner>-<repo>-<ts>.txt when staging row count stalls for ≥75 min, then re-emits every 75 min, and emits a stall_resumed when growth resumes — never kills, never requeues. Default 75 min covers the legitimate days-long first collections you flagged.

  Tripwires fired (worked as designed): docs-coverage and example-config tests caught both new JSON keys; added to docs/getting-started/configuration.md and aveloxis.example.json.

  Schema-free release. aveloxis migrate --skip-views just bumps tool_version. Operator deploy is 
```bash
go install ./cmd/aveloxis && aveloxis stop all && aveloxis start all.
```
