### PR TITLE
Debug/contrib rename transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+aveloxis.kate.json
 aveloxis.runlocal.json
 prompt-notes/**
 summary/**

--- a/docs/architecture/contributor-resolution.md
+++ b/docs/architecture/contributor-resolution.md
@@ -217,6 +217,70 @@ The 8-byte fallback for IDs above 2³² is non-Augur-compatible by necessity (Au
 
 ---
 
+## Rename handling: which columns track renames, which don't
+
+GitHub and GitLab both allow users to rename their account. The numeric `user_id` is stable across renames, so the deterministic `cntrb_id = PlatformUUID(platform, user_id)` keeps every cross-table reference valid. But the **login** field has multiple representations in the schema, and they behave differently on a rename. This is the contract.
+
+### Three tables, three rename behaviors
+
+#### `aveloxis_data.contributors` (one row per person)
+
+| Column | Updated on rename? | Purpose |
+|---|---|---|
+| `cntrb_id` (PK) | **Never** | Stable identity. All FK references (16 columns across 15 tables — see [R10](#r10-foreign-key-integrity)) depend on this. |
+| `cntrb_login` | **Never** (R2 invariant) | Durable audit trail — the login as first observed for this contributor. Subject to `idx_contributors_login` partial unique index. Use this when asking "what was this person originally called?" |
+| `gh_login` / `gl_username` | **Yes** | The "current display name" mirror. Updated by `RenameContributorGhLogin` (v0.22.12, breadth-worker 404 path) and by `UpsertContributorBatch`'s rename-recovery branch (v0.22.13, batch-upsert pkey-collision path). Indexed by `idx_contributors_gh_login` for case-insensitive lookups. Use this when asking "what is this person called RIGHT NOW?" |
+| `gh_user_id` / `gl_id` | Never (write-once via COALESCE) | Stable platform integer ID. Drives the deterministic `cntrb_id`. |
+
+A renamed contributor ends up with `cntrb_login='oldname'` and `gh_login='newname'` on **the same row**. Two different login values, each authoritative for a different question.
+
+#### `aveloxis_data.contributor_identities` (one row per `(platform_id, platform_user_id)`)
+
+The unique key is `(platform_id, platform_user_id)`, so there is **one identity row per platform user** — not one per observation. On every observation:
+
+```sql
+INSERT INTO contributor_identities (cntrb_id, platform_id, platform_user_id, login, ...)
+VALUES (...)
+ON CONFLICT (platform_id, platform_user_id) DO UPDATE SET
+    login = EXCLUDED.login,        -- overwritten in place
+    name = EXCLUDED.name,
+    email = COALESCE(NULLIF(EXCLUDED.email,''), contributor_identities.email),
+    avatar_url = EXCLUDED.avatar_url,
+    profile_url = EXCLUDED.profile_url;
+```
+
+The previous login is **overwritten** on the existing identity row. **We do NOT create a new identity row for a rename.** The identity row is a "current state per platform user" record, not a history. After a rename, the previous login at the identity layer is lost.
+
+#### `aveloxis_data.commits` (one row per file per commit)
+
+- `cmt_author_platform_username TEXT` — a **frozen raw string** set once at commit-resolution time. No FK constraint; just text. It stays at whatever login was current when the commit was attributed. Renames after the fact do not update it.
+- `cmt_ght_author_id UUID` — the stable FK to `contributors(cntrb_id)`. **This is what keeps commit attribution correct across renames**, because the cntrb_id is deterministic from gh_user_id and the gh_user_id never changes.
+
+`BackfillCommitAuthorIDs` resolves unresolved commits via `LOWER(cmt_author_platform_username) = LOWER(cn.gh_login)` (v0.20.12 Fix H, case-insensitive). It joins against the **current** `gh_login`, not `cntrb_login`. The function only updates rows with `cmt_ght_author_id IS NULL`, so once a commit is attributed it stays attributed regardless of subsequent renames.
+
+### Operational consequences
+
+**"Show me commits by user X (where X is the current login)"** — JOIN commits ON `cmt_ght_author_id`, then filter on `contributors.gh_login = 'X'`. The FK is stable; the gh_login mirror reflects current state. Works.
+
+**"What was this commit's author at write time?"** — Read `commits.cmt_author_platform_username` directly. Frozen string. Useful for audit logs and historical accuracy.
+
+**"What was this user's first observed login on aveloxis?"** — Read `contributors.cntrb_login`. Never mutates.
+
+**"What login has this person been known by between then and now?"** — **Not stored.** Only the original observation (`cntrb_login`) and the current state (`gh_login`) survive. Intermediate renames are not tracked anywhere in the current schema. A `contributor_login_history` table is planned post-v0.22.13 to capture this; until then, the rename event itself is logged at INFO level (`"contributor gh_login renamed"` from `RenameContributorGhLogin` and `"contributor rename recovered in batch upsert"` from v0.22.13's batch path) and operators can grep the application log for retrospective audit.
+
+### Why the two write paths exist (v0.22.12 vs v0.22.13)
+
+Both paths update `gh_login` on the existing contributor row and never touch `cntrb_login`. They differ in *trigger*:
+
+| Path | Trigger | Code |
+|---|---|---|
+| `RenameContributorGhLogin` (v0.22.12) | Breadth worker hits HTTP 404 on `/users/{stored_login}/events`, falls back to `/user/{stored_id}`, finds a different login | `internal/db/contributor_search_resolve.go` |
+| `UpsertContributorBatch` rename-recovery (v0.22.13) | Enrichment ticker / staged collector calls batch upsert with new login; deterministic-UUID INSERT trips `contributors_pkey` | `internal/db/postgres.go` |
+
+The v0.22.13 path is inlined inside the batch transaction (rather than calling out to `RenameContributorGhLogin`) because the batch tx already holds the savepoint scope and a nested transaction would deadlock against itself. The shape of the UPDATE statement is identical between the two paths: `SET gh_login = $newLogin, cntrb_email = COALESCE(...)` — preserving the contract uniformly.
+
+---
+
 ## Data-quality FAQ
 
 ### Why do I see two rows for the same person?

--- a/internal/db/contributor_batch_rename_recovery_test.go
+++ b/internal/db/contributor_batch_rename_recovery_test.go
@@ -98,7 +98,7 @@ func TestUpsertContributorBatchRecoversFromPkeyRenameCollision(t *testing.T) {
 	if pkeyIdx < 0 {
 		t.Fatal("contributors_pkey marker not found in UpsertContributorBatch body")
 	}
-	end := pkeyIdx + 1600
+	end := pkeyIdx + 2400
 	if end > len(body) {
 		end = len(body)
 	}

--- a/internal/db/contributor_batch_rename_recovery_test.go
+++ b/internal/db/contributor_batch_rename_recovery_test.go
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// v0.22.13 — UpsertContributorBatch must handle the deterministic-
+// cntrb_id rename collision without poisoning the whole batch tx.
+//
+// Pre-v0.22.13 failure shape (observed in production 2026-05-18):
+//
+//	A contributor was first observed under cntrb_login='oldname' and
+//	written with cntrb_id = PlatformUUID(1, gh_user_id). Later the
+//	user renamed on GitHub. The enrichment ticker re-fetches them by
+//	gh_user_id, computes the same deterministic cntrb_id, and tries
+//	to INSERT with cntrb_login='newname'. ON CONFLICT (cntrb_login)
+//	does not match (case-sensitive btree; the existing login is
+//	different anyway), the INSERT proceeds, and trips contributors_pkey.
+//	The pre-v0.22.13 captureErr/continue pattern then silently failed
+//	every subsequent contributor in the batch (Postgres "current
+//	transaction is aborted") and tx.Commit returned "commit
+//	unexpectedly resulted in rollback." 79 of 93 23505 events in the
+//	2026-05-18 Postgres log hit contributors_pkey via this path.
+//
+// v0.22.13 fix: SAVEPOINT per contributor + rename recovery branch
+// that detects 23505/contributors_pkey and routes it to an UPDATE on
+// the existing row. Preserves R2 (cntrb_login is the original-
+// observation audit trail and must never be mutated by a rename); only
+// gh_login (the "current display name" mirror) is updated.
+
+// TestUpsertContributorBatchUsesSavepoint pins that the batch loop
+// brackets each contributor in SAVEPOINT/RELEASE so a single failure
+// does not poison the rest of the batch.
+func TestUpsertContributorBatchUsesSavepoint(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+
+	if !strings.Contains(body, "SAVEPOINT") {
+		t.Error("UpsertContributorBatch must use SAVEPOINT to isolate per-contributor " +
+			"failures from the rest of the batch transaction. Pre-v0.22.13 a single " +
+			"23505 poisoned the entire tx; v0.22.13 adds savepoint isolation so other " +
+			"contributors in the same batch can still commit.")
+	}
+	if !strings.Contains(body, "ROLLBACK TO SAVEPOINT") {
+		t.Error("UpsertContributorBatch must call ROLLBACK TO SAVEPOINT on a per-contributor " +
+			"failure to clear the aborted-tx state before continuing to the next contributor. " +
+			"Without this, subsequent statements in the same tx fail with " +
+			"'current transaction is aborted, commands ignored until end of transaction block.'")
+	}
+	if !strings.Contains(body, "RELEASE SAVEPOINT") {
+		t.Error("UpsertContributorBatch must call RELEASE SAVEPOINT on the success path. " +
+			"Postgres lazily reclaims savepoint resources but explicit RELEASE keeps the " +
+			"per-tx savepoint stack shallow on large batches (hundreds of contributors).")
+	}
+}
+
+// TestUpsertContributorBatchRecoversFromPkeyRenameCollision pins the
+// rename-recovery branch. The condition that distinguishes a rename
+// (recoverable) from any other 23505 (skip + log) is:
+//
+//   - pgErr.Code == "23505"
+//   - pgErr.ConstraintName == "contributors_pkey"
+//   - desiredCntrbID was non-NULL (we computed a deterministic UUID
+//     from gh_user_id, so the colliding row IS the same person)
+func TestUpsertContributorBatchRecoversFromPkeyRenameCollision(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+
+	if !strings.Contains(body, "pgconn.PgError") {
+		t.Error("UpsertContributorBatch must inspect the typed pgconn.PgError to distinguish " +
+			"a pkey collision (rename, recoverable) from a partial-unique-index collision " +
+			"(handled by ON CONFLICT already) or any other SQLSTATE.")
+	}
+	if !regexp.MustCompile(`pgErr\.Code\s*==\s*"23505"`).MatchString(body) {
+		t.Error("UpsertContributorBatch must gate the rename-recovery branch on " +
+			`pgErr.Code == "23505" (unique violation). Any other SQLSTATE means the row ` +
+			"truly cannot be inserted; capture the diagnostic and skip.")
+	}
+	if !strings.Contains(body, "contributors_pkey") {
+		t.Error("UpsertContributorBatch must gate the rename-recovery branch on " +
+			`pgErr.ConstraintName == "contributors_pkey" specifically. A 23505 on ` +
+			"idx_contributors_login means ON CONFLICT (cntrb_login) somehow didn't catch " +
+			"the conflict (e.g. cntrb_login was empty); that's not a rename, don't route to " +
+			"the rename-recovery path.")
+	}
+
+	// The recovery UPDATE itself: set gh_login to the new login,
+	// match on the existing cntrb_id (the deterministic UUID we tried
+	// to insert). Without these two signals the recovery cannot work.
+	// Anchor on the contributors_pkey marker so we test the recovery
+	// region specifically (not the unrelated gh_*/gl_* backfill UPDATE
+	// further down the same function).
+	pkeyIdx := strings.Index(body, "contributors_pkey")
+	if pkeyIdx < 0 {
+		t.Fatal("contributors_pkey marker not found in UpsertContributorBatch body")
+	}
+	end := pkeyIdx + 1600
+	if end > len(body) {
+		end = len(body)
+	}
+	recoveryRegion := body[pkeyIdx:end]
+
+	if !regexp.MustCompile(`UPDATE\s+aveloxis_data\.contributors`).MatchString(recoveryRegion) {
+		t.Error("UpsertContributorBatch's rename-recovery branch must execute an " +
+			"UPDATE aveloxis_data.contributors ... — this is what actually records the " +
+			"rename on the existing row. Mirrors RenameContributorGhLogin (v0.22.12) " +
+			"but inlined to share the batch tx.")
+	}
+	if !regexp.MustCompile(`gh_login\s*=\s*\$\d`).MatchString(recoveryRegion) {
+		t.Error("UpsertContributorBatch's rename-recovery UPDATE must set gh_login = $N " +
+			"unconditionally (no COALESCE), per the v0.22.12 RenameContributorGhLogin " +
+			"contract. The caller knows the existing gh_login is stale by definition — " +
+			"we just got a 23505 trying to insert with the new login.")
+	}
+	if !regexp.MustCompile(`WHERE\s+cntrb_id\s*=\s*\$\d::uuid`).MatchString(recoveryRegion) {
+		t.Error("UpsertContributorBatch's rename-recovery UPDATE must target the existing " +
+			"row by cntrb_id (the deterministic UUID we computed and tried to insert with). " +
+			"That's the only join key guaranteed to identify the same person across renames.")
+	}
+}
+
+// TestUpsertContributorBatchRenameRecoveryPreservesCntrbLogin pins R2:
+// cntrb_login is the durable audit trail of the original observation
+// and MUST NOT be updated on rename. Only gh_login changes.
+func TestUpsertContributorBatchRenameRecoveryPreservesCntrbLogin(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+
+	// Find the rename-recovery UPDATE block specifically. It's
+	// distinguished from the gh_*/gl_* backfill UPDATE by also
+	// touching gh_login (the backfill UPDATEs don't — that's only set
+	// in the rename-recovery path inside the batch upsert).
+	startIdx := strings.Index(body, "contributors_pkey")
+	if startIdx < 0 {
+		t.Fatal("rename-recovery branch not found (contributors_pkey marker missing). " +
+			"Implement TestUpsertContributorBatchRecoversFromPkeyRenameCollision's contract first.")
+	}
+	// Slice ~1600 chars from the contributors_pkey marker — large
+	// enough to contain the recovery UPDATE statement.
+	end := startIdx + 1600
+	if end > len(body) {
+		end = len(body)
+	}
+	recoveryRegion := body[startIdx:end]
+
+	// Negative pin: the rename-recovery UPDATE must NOT set cntrb_login.
+	// Any of these patterns would violate R2:
+	//   SET cntrb_login = $N
+	//   cntrb_login = EXCLUDED.cntrb_login
+	//   cntrb_login = $N  (in the middle of a SET clause)
+	bad := regexp.MustCompile(`cntrb_login\s*=\s*(\$\d|EXCLUDED)`)
+	if bad.MatchString(recoveryRegion) {
+		t.Error("v0.22.13 rename-recovery UPDATE must NOT modify cntrb_login. " +
+			"R2 (per docs/architecture/contributor-resolution.md): cntrb_login is the " +
+			"durable audit trail of the contributor's first observation and is " +
+			"deliberately frozen — gh_login is the 'current display name' mirror that " +
+			"tracks renames. Same invariant RenameContributorGhLogin (v0.22.12) preserves.")
+	}
+}
+
+// TestUpsertContributorBatchSavepointsPerIdentity pins that the inner
+// per-identity loop also gets savepoint protection so a stale identity
+// row failure (rare, but possible if the (platform_id, platform_user_id)
+// unique constraint is violated in some corner case the ON CONFLICT
+// doesn't catch) doesn't poison the rest of the batch either.
+func TestUpsertContributorBatchSavepointsPerIdentity(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+
+	// Find the identity insert loop. It's the for-range over the
+	// identity slice that calls contributor_identities INSERT.
+	identIdx := strings.Index(body, "contributor_identities")
+	if identIdx < 0 {
+		t.Fatal("contributor_identities insert not found in UpsertContributorBatch")
+	}
+	// Slice the surrounding region (3000 chars ought to cover the loop).
+	start := identIdx - 1500
+	if start < 0 {
+		start = 0
+	}
+	end := identIdx + 1500
+	if end > len(body) {
+		end = len(body)
+	}
+	identRegion := body[start:end]
+
+	// The identity loop must use a SAVEPOINT too. Distinguish from the
+	// outer contributor savepoint by checking for a *second* SAVEPOINT
+	// marker within the slice. The marker name itself doesn't matter
+	// (sp_N counter or any other unique scheme) — only that there is
+	// one.
+	spCount := strings.Count(identRegion, "SAVEPOINT")
+	if spCount < 2 {
+		t.Errorf("UpsertContributorBatch's per-identity loop must bracket each identity "+
+			"INSERT/UPDATE in its own SAVEPOINT so a single bad identity row doesn't poison "+
+			"the rest of the batch. Found %d SAVEPOINT mentions in the identity region; "+
+			"expected at least 2 (SAVEPOINT + ROLLBACK TO SAVEPOINT or RELEASE SAVEPOINT).",
+			spCount)
+	}
+}
+
+// extractFunctionBody returns the source text of a single Go function
+// from a file in the same package. Used by source-contract tests to
+// constrain assertions to one function's body.
+func extractFunctionBody(t *testing.T, filename, funcName string) string {
+	t.Helper()
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	code := string(src)
+	marker := "func (s *PostgresStore) " + funcName + "("
+	startIdx := strings.Index(code, marker)
+	if startIdx < 0 {
+		t.Fatalf("function %s not found in %s", funcName, filename)
+	}
+	tail := code[startIdx+1:]
+	endRel := strings.Index(tail, "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail)
+	}
+	return code[startIdx : startIdx+1+endRel]
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1432,7 +1432,21 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 			}
 
 			// Upsert platform identities and backfill gh_*/gl_* columns.
+			// v0.22.13: each identity is bracketed in its own SAVEPOINT so a
+			// stale identity row (rare — would require a (platform_id,
+			// platform_user_id) collision the ON CONFLICT clause somehow
+			// missed, or any other constraint violation) doesn't poison
+			// the rest of the batch tx. Pre-v0.22.13 a single bad
+			// identity caused `break` and the gh_*/gl_* backfill UPDATE
+			// to be skipped for ALL subsequent identities of this
+			// contributor AND every later contributor in the batch.
 			for _, ident := range identMap[login] {
+				spCounter++
+				identSP := fmt.Sprintf("ident_sp_%d", spCounter)
+				if _, spErr := tx.Exec(ctx, "SAVEPOINT "+identSP); spErr != nil {
+					return spErr
+				}
+
 				_, identErr := tx.Exec(ctx, `
 					INSERT INTO aveloxis_data.contributor_identities
 						(cntrb_id, platform_id, platform_user_id, login, name, email,
@@ -1448,13 +1462,16 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 					ident.Email, ident.AvatarURL, ident.URL, ident.NodeID, ident.Type, ident.IsAdmin,
 				)
 				if identErr != nil {
+					if _, rbErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+identSP); rbErr != nil {
+						return rbErr
+					}
 					captureErr("contributor_identities_insert", login, identErr)
-					// Once one Exec fails the tx is poisoned; further
-					// Execs will also fail with "current transaction is
-					// aborted." Skip the rest of this contributor's
-					// identities so we don't pile up duplicate
-					// diagnostic logs from the same root cause.
-					break
+					if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+identSP); relErr != nil {
+						return relErr
+					}
+					// Try the next identity — savepoint isolation
+					// means one bad identity doesn't block the others.
+					continue
 				}
 
 				// Backfill denormalized gh_*/gl_* columns on the contributors row
@@ -1508,6 +1525,14 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 						cntrb_id, ident.UserID, ident.Login, ident.AvatarURL,
 						ident.URL, ident.Name, ident.State,
 					)
+				}
+
+				// v0.22.13: identity savepoint released after the
+				// gh_*/gl_* backfill (still under the same savepoint
+				// scope so any unforeseen failure in the backfill
+				// UPDATE is also contained).
+				if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+identSP); relErr != nil {
+					return relErr
 				}
 			}
 		}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1260,6 +1260,13 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 			}
 		}
 
+		// v0.22.13: monotonic counter for SAVEPOINT names. SQL
+		// identifiers can't contain quotes or arbitrary user input
+		// (login strings might contain '[', ']', '-', etc. as in
+		// "openshift-merge-bot[bot]"), so we never embed login text
+		// in the savepoint name.
+		var spCounter int
+
 		for login, contrib := range merged {
 			var cntrb_id string
 
@@ -1293,6 +1300,22 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 				}
 			}
 
+			// v0.22.13 (Fix for production WARN flood on 2026-05-18):
+			// wrap each contributor's INSERT in a SAVEPOINT so a
+			// single failure does not poison the rest of the batch
+			// transaction. Without this, the very first 23505 marks
+			// the entire tx as aborted and every subsequent statement
+			// (including OTHER contributors' INSERTs and the final
+			// Commit) fails with "current transaction is aborted."
+			// Pre-fix the operator saw "count=420" batches drop
+			// ~419 innocent contributors after a single rename
+			// collision on the head of the batch.
+			spCounter++
+			cntrbSP := fmt.Sprintf("cntrb_sp_%d", spCounter)
+			if _, spErr := tx.Exec(ctx, "SAVEPOINT "+cntrbSP); spErr != nil {
+				return spErr
+			}
+
 			err := tx.QueryRow(ctx, `
 				INSERT INTO aveloxis_data.contributors
 					(cntrb_id, cntrb_login, cntrb_email, cntrb_full_name,
@@ -1316,19 +1339,96 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 				ToolVersion,
 			).Scan(&cntrb_id)
 			if err != nil {
-				// Once any statement fails inside the tx, PostgreSQL
-				// puts the transaction in aborted state — every
-				// subsequent statement fails until ROLLBACK. Pre-Fix-G
-				// we `continue`d the for loop, which meant the
-				// remaining contributors all silently failed too, and
-				// the final Commit returned the cryptic "commit
-				// unexpectedly resulted in rollback." We still
-				// continue (changing behavior is deferred to a later
-				// fix once we have data on the SQLSTATE distribution),
-				// but we now capture enough diagnostic context to
-				// plan the real fix.
-				captureErr("contributors_insert", login, err)
-				continue
+				// v0.22.13: classify the failure to decide between
+				// rename-recovery (recoverable, this person already
+				// exists under a different login) and skip (any
+				// other 23505 or any other SQLSTATE).
+				var pgErr *pgconn.PgError
+				isRenameCollision := errors.As(err, &pgErr) &&
+					pgErr.Code == "23505" &&
+					pgErr.ConstraintName == "contributors_pkey" &&
+					desiredCntrbID != nil
+
+				// Always roll back to savepoint first to clear the
+				// aborted-tx state — required before any further
+				// statement in this tx (including the recovery
+				// UPDATE) can run.
+				if _, rbErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+cntrbSP); rbErr != nil {
+					return rbErr
+				}
+
+				if isRenameCollision {
+					// v0.22.13 rename recovery: the deterministic UUID
+					// already exists on a different row — same person,
+					// renamed on GitHub (gh_user_id stable → cntrb_id
+					// stable, but cntrb_login on the existing row
+					// holds the OLDER observation). Update gh_login
+					// on the existing row (the "current display name"
+					// mirror) and backfill any empty profile fields.
+					// cntrb_login is deliberately NOT modified — R2
+					// (per docs/architecture/contributor-resolution.md):
+					// cntrb_login is the durable audit trail of the
+					// first observation. Same shape as v0.22.12's
+					// RenameContributorGhLogin, inlined here so it
+					// runs inside the batch tx.
+					existingID := desiredCntrbID.(string)
+					if _, updErr := tx.Exec(ctx, `
+						UPDATE aveloxis_data.contributors
+						SET gh_login        = $2,
+						    cntrb_email     = COALESCE(NULLIF(cntrb_email, ''),     $3),
+						    cntrb_full_name = COALESCE(NULLIF(cntrb_full_name, ''), $4),
+						    cntrb_company   = COALESCE(NULLIF(cntrb_company, ''),   $5),
+						    cntrb_location  = COALESCE(NULLIF(cntrb_location, ''),  $6),
+						    cntrb_canonical = COALESCE(NULLIF(cntrb_canonical, ''), $7),
+						    tool_version    = $8,
+						    data_collection_date = NOW()
+						WHERE cntrb_id = $1::uuid`,
+						existingID, contrib.Login, contrib.Email,
+						contrib.FullName, contrib.Company, contrib.Location,
+						contrib.Canonical, ToolVersion,
+					); updErr != nil {
+						// Recovery UPDATE itself failed (rare —
+						// would require some other constraint
+						// violation on this row). Roll back, capture
+						// diagnostic, skip this contributor.
+						if _, rbErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+cntrbSP); rbErr != nil {
+							return rbErr
+						}
+						captureErr("contributors_rename_update", login, updErr)
+						if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+cntrbSP); relErr != nil {
+							return relErr
+						}
+						continue
+					}
+					cntrb_id = existingID
+					s.logger.Info("contributor rename recovered in batch upsert",
+						"cntrb_id", existingID,
+						"new_gh_login", contrib.Login,
+						"cause", "contributors_pkey collision on deterministic UUID — same gh_user_id, different login")
+					// Fall through to identity-row inserts below.
+				} else {
+					// Non-rename failure (e.g. 23505 on
+					// idx_contributors_login with cntrb_login='',
+					// which ON CONFLICT WHERE cntrb_login!='' would
+					// not catch; or any other SQLSTATE). Capture the
+					// diagnostic and skip this contributor. Tx is
+					// alive — savepoint rollback restored a clean
+					// state, so the next contributor in the for loop
+					// can still commit.
+					captureErr("contributors_insert", login, err)
+					if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+cntrbSP); relErr != nil {
+						return relErr
+					}
+					continue
+				}
+			}
+
+			// Contributor row is now either freshly inserted,
+			// upserted via ON CONFLICT (cntrb_login match), or
+			// rename-recovered via UPDATE. Release the outer
+			// savepoint before processing identities.
+			if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+cntrbSP); relErr != nil {
+				return relErr
 			}
 
 			// Upsert platform identities and backfill gh_*/gl_* columns.

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.22.12"
+var ToolVersion = "0.22.13"


### PR DESCRIPTION
v0.22.13 : UpsertContributorBatch rename recovery + SAVEPOINT isolation

  Code change (internal/db/postgres.go):
  - Each contributor's INSERT now bracketed in its own SAVEPOINT (cntrb_sp_N); each identity INSERT in its own (ident_sp_N). Failures roll back to the savepoint instead
  of poisoning the whole tx.
  - Classifies INSERT errors: 23505 + contributors_pkey + non-null desiredCntrbID → rename-recovery branch runs UPDATE contributors SET gh_login = $newLogin, ... WHERE 
  cntrb_id = $existingUUID::uuid. cntrb_login deliberately not touched (R2 invariant).
  - Logs "contributor rename recovered in batch upsert" at INFO when the recovery fires — operators can grep this to confirm the fix is working post-deploy.

  4 new source-contract tests in internal/db/contributor_batch_rename_recovery_test.go, including a negative pin on cntrb_login to fail the build if a future refactor inadvertently mutates the audit trail.

  Documentation (CRITICAL per your direction):
  - docs/architecture/contributor-resolution.md got a new "Rename handling: which columns track renames, which don't" section with the three-table contract, the operational consequences ("what was this person originally called?" vs "what is this person called now?"), and a forward reference to the planned contributor_login_history table.
  - CLAUDE.md got the full v0.22.13 entry with the 12 rename collisions tabulated, the diagnostic narrative, the contract summary, and explicit "what v0.22.13 does NOT do" — including why case-insensitivity wouldn't have worked.
  
  Test results: go test ./... green across all 19 packages. No schema migration needed — deploy with go install ./cmd/aveloxis && aveloxis stop all && aveloxis start  all. The 12 existing rename-collided rows will heal on the next enrichment-ticker cycle.
