### PR TITLE
Addressing Primary Language Gap in Repo Table

### DIFF
--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -61,5 +61,8 @@
     "gitlab_base_url": "https://gitlab.com",
     "api_internal_url": "http://127.0.0.1:8383"
   },
+  "monitor": {
+    "refresh_seconds": 60
+  },
   "log_level": "info"
 }

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -198,7 +198,12 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 	go sched.Run(ctx)
 
 	// Start monitor.
-	mon := monitor.New(store, logger)
+	// v0.23.0: refresh cadence is operator-configurable via
+	// monitor.refresh_seconds in aveloxis.json. Falls back to the
+	// package default (60s) when unset / out of bounds.
+	mon := monitor.NewWithOptions(store, logger, monitor.Options{
+		RefreshSeconds: cfg.Monitor.MonitorRefreshSecondsOrDefault(),
+	})
 	srv := &http.Server{Addr: monitorAddr, Handler: mon.Handler()}
 	go func() {
 		logger.Info("monitor listening", "addr", monitorAddr)

--- a/docs/architecture/contributor-resolution.md
+++ b/docs/architecture/contributor-resolution.md
@@ -266,7 +266,65 @@ The previous login is **overwritten** on the existing identity row. **We do NOT 
 
 **"What was this user's first observed login on aveloxis?"** — Read `contributors.cntrb_login`. Never mutates.
 
-**"What login has this person been known by between then and now?"** — **Not stored.** Only the original observation (`cntrb_login`) and the current state (`gh_login`) survive. Intermediate renames are not tracked anywhere in the current schema. A `contributor_login_history` table is planned post-v0.22.13 to capture this; until then, the rename event itself is logged at INFO level (`"contributor gh_login renamed"` from `RenameContributorGhLogin` and `"contributor rename recovered in batch upsert"` from v0.22.13's batch path) and operators can grep the application log for retrospective audit.
+**"What login has this person been known by between then and now?"** — **Stored as of v0.23.0** in `aveloxis_data.contributor_login_history`. Every observed `(cntrb_id, platform_id, login)` triple gets a row, with `first_seen` preserved across re-observations and `last_seen` advancing. The `source` column tags the row with WHY it was created (`observation`, `rename_recovery`, `rename_breadth`, `backfill`). Pre-v0.23.0 only `cntrb_login` (first observation) and `gh_login` (current state) survived; intermediate renames between those two were lost. See the "Login history table (v0.23.0)" section below for query patterns.
+
+### Login history table (v0.23.0)
+
+`aveloxis_data.contributor_login_history` is the append-only audit trail of every login a contributor has been observed under. Schema:
+
+```sql
+CREATE TABLE aveloxis_data.contributor_login_history (
+    history_id   BIGSERIAL PRIMARY KEY,
+    cntrb_id     UUID NOT NULL REFERENCES contributors(cntrb_id)
+                 ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    platform_id  SMALLINT NOT NULL REFERENCES platforms(platform_id) DEFERRABLE INITIALLY DEFERRED,
+    login        TEXT NOT NULL,
+    first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source       TEXT NOT NULL DEFAULT 'observation',
+    tool_source  TEXT NOT NULL DEFAULT 'aveloxis',
+    tool_version TEXT NOT NULL DEFAULT '',
+    UNIQUE (cntrb_id, platform_id, login)
+);
+```
+
+`source` values:
+
+| Value | Written by | Trigger |
+|---|---|---|
+| `observation` | `UpsertContributorBatch` per-identity loop | Steady-state per-cycle write — most rows have this source. |
+| `rename_recovery` | `UpsertContributorBatch` rename-recovery branch (v0.22.13) | Pkey collision recovery: same gh_user_id, new login arrived in a batch. |
+| `rename_breadth` | `RenameContributorGhLogin` (v0.22.12) | Breadth worker hit 404, looked up by id, found a different current login. |
+| `backfill` | One-shot migration step at v0.23.0 install | Seeded from existing `contributor_identities` + `contributors.cntrb_login` so the history table starts populated. |
+
+Common queries:
+
+```sql
+-- Every login this person has ever used, oldest first
+SELECT login, first_seen, last_seen, source
+FROM aveloxis_data.contributor_login_history
+WHERE cntrb_id = $1::uuid
+ORDER BY first_seen ASC;
+
+-- Find all rename events (any contributor whose history has more than
+-- one login on the same platform)
+SELECT cntrb_id, platform_id, count(*) AS login_count,
+       array_agg(login ORDER BY first_seen ASC) AS chronological
+FROM aveloxis_data.contributor_login_history
+GROUP BY cntrb_id, platform_id
+HAVING count(*) > 1;
+
+-- Resolve a historical login to a current contributor (e.g. when
+-- joining against an external dataset that captured a now-stale login)
+SELECT c.cntrb_id, c.gh_login AS current_login
+FROM aveloxis_data.contributor_login_history h
+JOIN aveloxis_data.contributors c USING (cntrb_id)
+WHERE h.login = $1 AND h.platform_id = 1
+ORDER BY h.last_seen DESC
+LIMIT 1;
+```
+
+The Go store method `PostgresStore.GetContributorLoginHistory(ctx, cntrbID)` returns the rows ordered chronologically — useful for the contributor detail page in the web GUI (display planned for a follow-up release).
 
 ### Why the two write paths exist (v0.22.12 vs v0.22.13)
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -223,6 +223,16 @@ The `web` block configures the `aveloxis web` server. Optional — if you only r
 | `web.gitlab_base_url` | string | `"https://gitlab.com"` | GitLab base URL for OAuth (the HTML site, NOT the API URL). Override for self-hosted GitLab. |
 | `web.api_internal_url` | string | `"http://127.0.0.1:8383"` | Server-to-server URL where the web process reaches `aveloxis api`. The web server reverse-proxies `/api/*` requests to this URL so the browser only talks to the web origin. Set this to a remote URL if running the API on a different host. |
 
+### Monitor (dashboard, v0.23.0)
+
+The `monitor` block tunes the `/monitor` dashboard served by `aveloxis serve` on port `:5555`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `monitor.refresh_seconds` | int | `60` | Meta-refresh interval emitted in the dashboard HTML (`<meta http-equiv="refresh" content="N">`). Clamped to `[10, 3600]` at consumption — values outside that range fall back to the default. Lower values give snappier updates at the cost of more frequent server-side scans; higher values reduce DB pressure on large fleets. The pre-v0.23.0 hard-coded `60` is the same default. |
+
+Mobile detection (also v0.23.0) is automatic and not configurable: when the dashboard handler observes a known mobile User-Agent (`iPhone`, `iPad`, `Android`, `Mobile`, `Windows Phone`, `BlackBerry`), it emits a `body.is-mobile` class that stacks the queue table into vertical cards. Desktop users at narrow window widths also pick up the same layout via a `@media (max-width: 768px)` block — UA detection is just an extra signal for phones with non-standard viewports.
+
 ### Mail (Gmail SMTP, optional)
 
 See the [Email section below](#email-gmail-smtp-optional) for setup details. The `mail` block fields:

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -236,6 +236,18 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			result.Errors = append(result.Errors, fmt.Errorf("stage repo info: %w", err))
 		}
 		result.CommitCount = info.CommitCount
+
+		// v0.23.0: mirror description + primary_language + full
+		// language breakdown to the repos row. The repos table is
+		// the canonical "what is this repo" reference; repo_info
+		// holds per-cycle metrics, but description/language are
+		// slow-changing reference data so they live on repos.
+		// Non-fatal — if the UPDATE fails we log and continue;
+		// the next cycle will retry.
+		if updateErr := sc.store.UpdateRepoMetadata(ctx, repoID, info.Description, info.PrimaryLanguage, info.Languages); updateErr != nil {
+			sc.logger.Warn("failed to update repos.repo_description/primary_language/languages",
+				"owner", owner, "repo", repo, "error", updateErr)
+		}
 	}
 
 	for rel, relErr := range sc.client.ListReleases(ctx, owner, repo) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,37 @@ type Config struct {
 	// Web GUI settings.
 	Web WebConfig `json:"web"`
 
+	// v0.23.0: Monitor dashboard settings.
+	Monitor MonitorConfig `json:"monitor"`
+
 	// LogLevel sets the minimum log level: "debug", "info", "warn", or "error".
 	LogLevel string `json:"log_level"`
+}
+
+// MonitorConfig governs the /monitor dashboard.
+//
+// v0.23.0 — added so operators can tune the meta-refresh cadence per
+// deployment. The pre-v0.23.0 60-second hard-coded value (v0.18.30
+// raised from 10s after the per-render scans started hammering the
+// DB) is now just the default; large fleets that want even less
+// pressure can set refresh_seconds=120 or higher. Phone-pinned
+// operator dashboards that want faster feedback can set 30.
+type MonitorConfig struct {
+	// RefreshSeconds is the HTML meta-refresh interval emitted on
+	// the dashboard. Clamped to [10, 3600] at consumption time so a
+	// fat-fingered 0 doesn't produce a refresh storm and a fat-
+	// fingered 99999 doesn't make the dashboard appear frozen.
+	RefreshSeconds int `json:"refresh_seconds"`
+}
+
+// MonitorRefreshSecondsOrDefault returns the configured refresh
+// cadence, falling back to 60 (the v0.18.30 default) when the
+// configured value is zero or out of safe bounds.
+func (m MonitorConfig) MonitorRefreshSecondsOrDefault() int {
+	if m.RefreshSeconds < 10 || m.RefreshSeconds > 3600 {
+		return 60
+	}
+	return m.RefreshSeconds
 }
 
 // DatabaseConfig holds PostgreSQL connection details.

--- a/internal/db/cntrb_id_cascade.go
+++ b/internal/db/cntrb_id_cascade.go
@@ -44,6 +44,11 @@ var cntrbIDChildFKs = []cntrbIDChildFK{
 	{"pull_request_reviewers", "cntrb_id", "pull_request_reviewers_cntrb_id_fkey"},
 	{"pull_request_reviews", "cntrb_id", "pull_request_reviews_cntrb_id_fkey"},
 	{"pull_requests", "author_id", "pull_requests_author_id_fkey"},
+	// v0.23.0: contributor_login_history is a new cntrb_id child;
+	// the schema declaration already carries ON UPDATE CASCADE, but
+	// adding it here ensures the v0.22.1 migration helper covers it
+	// on legacy databases where the table is created post-fact.
+	{"contributor_login_history", "cntrb_id", "contributor_login_history_cntrb_id_fkey"},
 }
 
 // ensureOnUpdateCascadeOnCntrbIDFKs is the v0.22.1 idempotent

--- a/internal/db/contributor_login_history.go
+++ b/internal/db/contributor_login_history.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Login-observation source constants for contributor_login_history.source.
+// Kept as a closed set so operators can SQL-filter and dashboards can group
+// by them without arbitrary string drift.
+const (
+	LoginSourceObservation    = "observation"
+	LoginSourceRenameRecovery = "rename_recovery"
+	LoginSourceRenameBreadth  = "rename_breadth"
+	LoginSourceBackfill       = "backfill"
+)
+
+// recordLoginObservation upserts a (cntrb_id, platform_id, login) row
+// into contributor_login_history. first_seen is preserved on conflict;
+// last_seen advances. Caller passes the active pgx.Tx (so the observation
+// commits with the contributor write it belongs to).
+//
+// Empty cntrbID, empty login, or platformID == 0 silently no-op — the
+// helper is called from many sites including ones where the data may
+// legitimately be missing (e.g. email-only commit-author contributors
+// with no platform identity). Callers don't need to pre-validate.
+//
+// Source values are the LoginSource* constants above. Drift-prevent
+// these by always passing a named constant; arbitrary string literals
+// in call sites diverge over time.
+//
+// v0.23.0 — see docs/architecture/contributor-resolution.md "Rename
+// handling" section for the full table contract.
+func recordLoginObservation(ctx context.Context, tx pgx.Tx, cntrbID string, platformID int16, login, source string) error {
+	if cntrbID == "" || login == "" || platformID == 0 {
+		return nil
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributor_login_history
+			(cntrb_id, platform_id, login, source, tool_version)
+		VALUES ($1::uuid, $2, $3, $4, $5)
+		ON CONFLICT (cntrb_id, platform_id, login) DO UPDATE SET
+			last_seen = NOW()`,
+		cntrbID, platformID, login, source, ToolVersion)
+	return err
+}
+
+// LoginHistoryEntry is a single observed-login row.
+type LoginHistoryEntry struct {
+	PlatformID int16
+	Login      string
+	FirstSeen  string // YYYY-MM-DD HH:MI:SS (UTC)
+	LastSeen   string
+	Source     string
+}
+
+// GetContributorLoginHistory returns every observed login for a
+// contributor, ordered by first_seen ascending (oldest first). Used
+// by the web GUI's contributor detail page and by operator audit
+// queries.
+func (s *PostgresStore) GetContributorLoginHistory(ctx context.Context, cntrbID string) ([]LoginHistoryEntry, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT platform_id, login,
+		       to_char(first_seen AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS'),
+		       to_char(last_seen  AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS'),
+		       source
+		FROM aveloxis_data.contributor_login_history
+		WHERE cntrb_id = $1::uuid
+		ORDER BY first_seen ASC, login ASC`,
+		cntrbID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []LoginHistoryEntry
+	for rows.Next() {
+		var e LoginHistoryEntry
+		if err := rows.Scan(&e.PlatformID, &e.Login, &e.FirstSeen, &e.LastSeen, &e.Source); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/contributor_login_history_test.go
+++ b/internal/db/contributor_login_history_test.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// v0.23.0 — contributor_login_history captures every (cntrb_id, platform_id,
+// login) tuple ever observed for a contributor. Closes the rename-audit
+// gap from v0.22.13's "what login has this person been known by between
+// then and now?" question, which the v0.22.13 contract called out as
+// "Not stored. Only the original observation (cntrb_login) and the
+// current state (gh_login) survive."
+//
+// Design:
+//   - One row per (cntrb_id, platform_id, login) triple, enforced by
+//     UNIQUE constraint. first_seen preserved on re-observation;
+//     last_seen advances every time the login is observed again.
+//   - source TEXT column records WHY the row was created: 'observation'
+//     (steady-state upsert), 'rename_recovery' (v0.22.13 batch path),
+//     'rename_breadth' (v0.22.12 breadth-worker path), 'backfill'
+//     (initial migration from existing data).
+//   - FK on cntrb_id with v0.22.7 uniform clause: ON UPDATE CASCADE
+//     ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED.
+//
+// Backfill: every (cntrb_id, platform_id, login) from existing
+// contributor_identities rows + every historical cntrb_login per
+// platform observed via identities, materialized on first
+// aveloxis migrate after v0.23.0 install.
+
+func TestContributorLoginHistorySchemaDeclared(t *testing.T) {
+	src, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	if !strings.Contains(code, "CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_login_history") {
+		t.Error("schema.sql must declare aveloxis_data.contributor_login_history " +
+			"(v0.23.0 — login-history audit trail).")
+	}
+	// Required columns. Each is a separate check so a missing one
+	// names itself in the test failure.
+	for _, col := range []string{
+		"history_id",
+		"cntrb_id",
+		"platform_id",
+		"login",
+		"first_seen",
+		"last_seen",
+		"source",
+	} {
+		// Find the CREATE TABLE block specifically.
+		start := strings.Index(code, "CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_login_history")
+		if start < 0 {
+			t.Fatalf("table declaration not found — cannot verify column %q", col)
+		}
+		end := strings.Index(code[start:], ");")
+		if end < 0 {
+			t.Fatal("unterminated CREATE TABLE for contributor_login_history")
+		}
+		block := code[start : start+end]
+		if !strings.Contains(block, col) {
+			t.Errorf("contributor_login_history must declare a %q column", col)
+		}
+	}
+
+	// FK on cntrb_id with v0.22.7 uniform clause.
+	if !regexp.MustCompile(`cntrb_id\s+UUID[\s\S]{0,400}REFERENCES\s+aveloxis_data\.contributors`).MatchString(code) {
+		t.Error("contributor_login_history.cntrb_id must REFERENCE aveloxis_data.contributors")
+	}
+	// Per v0.22.7 universal contract, every FK uses
+	// DEFERRABLE INITIALLY DEFERRED. The cntrb_id FK also takes
+	// ON UPDATE CASCADE per v0.22.1.
+	start := strings.Index(code, "CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_login_history")
+	end := strings.Index(code[start:], ");")
+	block := code[start : start+end]
+	if !strings.Contains(block, "DEFERRABLE INITIALLY DEFERRED") {
+		t.Error("contributor_login_history.cntrb_id FK must carry " +
+			"DEFERRABLE INITIALLY DEFERRED (per v0.22.7 universal contract).")
+	}
+	if !strings.Contains(block, "ON UPDATE CASCADE") {
+		t.Error("contributor_login_history.cntrb_id FK must carry ON UPDATE CASCADE " +
+			"(per v0.22.1 — every cntrb_id child column uses CASCADE so renames propagate).")
+	}
+
+	// UNIQUE constraint on (cntrb_id, platform_id, login).
+	if !regexp.MustCompile(`UNIQUE\s*\(\s*cntrb_id\s*,\s*platform_id\s*,\s*login\s*\)`).MatchString(block) {
+		t.Error("contributor_login_history must declare UNIQUE (cntrb_id, platform_id, login) " +
+			"— that's the natural identity-key of a login observation. Without it, the " +
+			"RecordContributorLoginObservation ON CONFLICT clause has no target.")
+	}
+}
+
+func TestContributorLoginHistoryMigrationCreatesTable(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "contributor_login_history") {
+		t.Error("migrate.go must reference contributor_login_history. For existing " +
+			"installations the schema-up-to-date check is what triggers serve to refuse " +
+			"to start until the column set matches the binary's expectations.")
+	}
+}
+
+func TestContributorLoginHistoryBackfillFromIdentities(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+
+	// The backfill must seed history from contributor_identities (the
+	// only place that pairs cntrb_id with platform_id + login) AND
+	// from contributors.cntrb_login (the historical-original login,
+	// which is what differs from the current identity.login when a
+	// rename has happened).
+	if !regexp.MustCompile(`INSERT\s+INTO\s+aveloxis_data\.contributor_login_history[\s\S]{0,800}FROM\s+aveloxis_data\.contributor_identities`).MatchString(code) {
+		t.Error("migrate.go must include a backfill that SELECTs from " +
+			"contributor_identities into contributor_login_history. That table is the " +
+			"only source of (cntrb_id, platform_id, login) triples in pre-v0.23.0 data.")
+	}
+	if !strings.Contains(code, "'backfill'") {
+		t.Error("backfill INSERT must mark its rows with source='backfill' so operators " +
+			"can distinguish migration-origin history rows from steady-state observations.")
+	}
+}
+
+func TestRecordContributorLoginObservationExists(t *testing.T) {
+	// Helper can live in any file in the package; check both likely
+	// locations.
+	for _, fname := range []string{"contributor_login_history.go", "postgres.go"} {
+		src, err := os.ReadFile(fname)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(src), "recordLoginObservation") ||
+			strings.Contains(string(src), "RecordLoginObservation") {
+			return
+		}
+	}
+	t.Error("v0.23.0 must define a recordLoginObservation(ctx, tx, cntrbID, " +
+		"platformID, login, source) helper that upserts into contributor_login_history. " +
+		"Callers from UpsertContributorBatch, RenameContributorGhLogin, and ContributorResolver." +
+		"Resolve all share this helper so the source-column policy stays consistent.")
+}
+
+func TestUpsertContributorBatchRecordsLoginHistory(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+	if !strings.Contains(body, "recordLoginObservation") &&
+		!strings.Contains(body, "contributor_login_history") {
+		t.Error("UpsertContributorBatch must call recordLoginObservation (or " +
+			"inline-insert into contributor_login_history) for every successful " +
+			"per-identity write. Without this the steady-state path doesn't populate " +
+			"history and we only capture rename events.")
+	}
+}
+
+func TestRenameContributorGhLoginRecordsLoginHistory(t *testing.T) {
+	src, err := os.ReadFile("contributor_search_resolve.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	startIdx := strings.Index(code, "func (s *PostgresStore) RenameContributorGhLogin(")
+	if startIdx < 0 {
+		t.Fatal("RenameContributorGhLogin not found")
+	}
+	tail := code[startIdx+1:]
+	endRel := strings.Index(tail, "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail)
+	}
+	body := code[startIdx : startIdx+1+endRel]
+
+	if !strings.Contains(body, "recordLoginObservation") &&
+		!strings.Contains(body, "contributor_login_history") {
+		t.Error("RenameContributorGhLogin must record the new login in " +
+			"contributor_login_history (via recordLoginObservation). The whole point of " +
+			"the history table is to preserve the chain of observed logins — the rename " +
+			"function is precisely where the chain advances.")
+	}
+}

--- a/internal/db/contributor_search_resolve.go
+++ b/internal/db/contributor_search_resolve.go
@@ -348,9 +348,19 @@ func (s *PostgresStore) RenameContributorGhLogin(ctx context.Context, cntrbID, n
 				(cntrb_id, platform_id, platform_user_id, login, name, email,
 				 avatar_url, profile_url, node_id, user_type, is_admin)
 			VALUES ($1::uuid, 1, $2, $3, '', '', '', '', '', '', FALSE)
-			ON CONFLICT (platform_id, platform_user_id) DO NOTHING`,
+			ON CONFLICT (platform_id, platform_user_id) DO UPDATE SET
+				login = EXCLUDED.login`,
 			winner.cntrbID, ghUserID, newLogin); err != nil {
 			return fmt.Errorf("backfill identity row: %w", err)
+		}
+
+		// v0.23.0: record the new login in contributor_login_history
+		// so the rename chain is preserved. Same tx as the gh_login
+		// update so the history row appears iff the rename committed.
+		// Platform 1 = GitHub (RenameContributorGhLogin is the GitHub-
+		// specific breadth-worker path).
+		if err = recordLoginObservation(ctx, tx, winner.cntrbID, 1, newLogin, LoginSourceRenameBreadth); err != nil {
+			return fmt.Errorf("record login history: %w", err)
 		}
 
 		if oldGhLogin != "" && oldGhLogin != newLogin {

--- a/internal/db/fk_extra_test.go
+++ b/internal/db/fk_extra_test.go
@@ -280,10 +280,13 @@ func TestSchemaDeclaresDeferredOnCntrbIDFKs(t *testing.T) {
 	code := string(src)
 	refTarget := "REFERENCES aveloxis_data.contributors(cntrb_id)"
 	occurrences := strings.Count(code, refTarget)
-	if occurrences != 16 {
-		t.Fatalf("expected 16 cntrb_id FK occurrences in schema.sql, got %d — "+
-			"the v0.22.1 set was exhaustive at 16; if this changed, update both this "+
-			"test and the cntrb_id_cascade.go fixture", occurrences)
+	// v0.22.1 baseline: 16. v0.23.0 added contributor_login_history,
+	// bringing the total to 17. If you add another cntrb_id child
+	// table, bump this count AND add the entry to cntrbIDChildFKs in
+	// cntrb_id_cascade.go so the migration helper covers it.
+	if occurrences != 17 {
+		t.Fatalf("expected 17 cntrb_id FK occurrences in schema.sql, got %d — "+
+			"if this changed, update both this test and the cntrb_id_cascade.go fixture", occurrences)
 	}
 	idx := 0
 	for {

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -660,6 +660,68 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// migrate.
 	ensureAllFKsDeferrable(ctx, pg, logger, &errs)
 
+	// v0.23.0: repos.languages JSONB column for the full language
+	// breakdown (top entry by value is mirrored in primary_language).
+	// Existing rows default to '{}'::jsonb; the staged collector and
+	// the startup backfill task populate them on next FetchRepoInfo.
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "languages", "JSONB DEFAULT '{}'::jsonb")
+
+	// v0.23.0: contributor_login_history table + backfill. Closes the
+	// rename-audit gap documented as a v0.22.13 limitation
+	// ("Intermediate login history is NOT stored"). The CREATE TABLE
+	// in schema.sql handles fresh installs idempotently; the backfill
+	// here populates existing installations from contributor_identities
+	// (the only place that stores (cntrb_id, platform_id, login)
+	// triples in pre-v0.23.0 data) plus the historical cntrb_login on
+	// every contributor (which differs from any current identity.login
+	// when a rename happened before v0.23.0 shipped).
+	execMigrationStep(ctx, pg, logger, &errs, "v0.23.0 create contributor_login_history table",
+		`CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_login_history (
+			history_id   BIGSERIAL PRIMARY KEY,
+			cntrb_id     UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+			platform_id  SMALLINT NOT NULL REFERENCES aveloxis_data.platforms(platform_id) DEFERRABLE INITIALLY DEFERRED,
+			login        TEXT NOT NULL,
+			first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_seen    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			source       TEXT NOT NULL DEFAULT 'observation',
+			tool_source  TEXT NOT NULL DEFAULT 'aveloxis',
+			tool_version TEXT NOT NULL DEFAULT '',
+			CONSTRAINT contributor_login_history_unique UNIQUE (cntrb_id, platform_id, login)
+		)`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_clh_cntrb",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clh_cntrb ON aveloxis_data.contributor_login_history (cntrb_id)`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_clh_login",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clh_login ON aveloxis_data.contributor_login_history (login)`)
+
+	// v0.23.0 backfill: seed from contributor_identities (the
+	// current state) AND from contributors.cntrb_login per platform
+	// (the historical-original observation, which differs from any
+	// identity row's current login when a rename predated v0.23.0).
+	// Idempotent: ON CONFLICT DO NOTHING means re-running the
+	// migrate is a no-op once seeded.
+	// Inline ToolVersion via fmt.Sprintf — ToolVersion is a binary
+	// constant, not user input, so there's no injection vector.
+	// execMigrationStep doesn't take SQL parameters; we inline the
+	// literal directly into the SQL string.
+	execMigrationStep(ctx, pg, logger, &errs, "v0.23.0 backfill contributor_login_history from identities",
+		fmt.Sprintf(`INSERT INTO aveloxis_data.contributor_login_history
+			(cntrb_id, platform_id, login, source, tool_version)
+		 SELECT i.cntrb_id, i.platform_id, i.login, 'backfill', '%s'
+		 FROM aveloxis_data.contributor_identities i
+		 JOIN aveloxis_data.contributors c USING (cntrb_id)
+		 WHERE COALESCE(i.login, '') != ''
+		   AND COALESCE(c.cntrb_deleted, 0) = 0
+		 ON CONFLICT (cntrb_id, platform_id, login) DO NOTHING`, ToolVersion))
+	execMigrationStep(ctx, pg, logger, &errs, "v0.23.0 backfill contributor_login_history from contributors.cntrb_login",
+		fmt.Sprintf(`INSERT INTO aveloxis_data.contributor_login_history
+			(cntrb_id, platform_id, login, source, tool_version)
+		 SELECT DISTINCT c.cntrb_id, i.platform_id, c.cntrb_login, 'backfill', '%s'
+		 FROM aveloxis_data.contributors c
+		 JOIN aveloxis_data.contributor_identities i USING (cntrb_id)
+		 WHERE COALESCE(c.cntrb_login, '') != ''
+		   AND COALESCE(c.cntrb_deleted, 0) = 0
+		 ON CONFLICT (cntrb_id, platform_id, login) DO NOTHING`, ToolVersion))
+
 	// Create/update materialized views for 8Knot and analytics.
 	// Skipped by default on startup (can take minutes on large databases).
 	// Set collection.matview_rebuild_on_startup=true in aveloxis.json to enable,

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1269,6 +1269,10 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 
 		for login, contrib := range merged {
 			var cntrb_id string
+			// v0.23.0: track whether this contributor's row was
+			// rename-recovered so the contributor_login_history rows
+			// for its identities get the correct source tag.
+			var wasRenameRecovery bool
 
 			// Idempotent upsert: INSERT with ON CONFLICT on the partial unique index.
 			// If the login already exists, backfill empty fields and update tool_version.
@@ -1401,6 +1405,7 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 						continue
 					}
 					cntrb_id = existingID
+					wasRenameRecovery = true
 					s.logger.Info("contributor rename recovered in batch upsert",
 						"cntrb_id", existingID,
 						"new_gh_login", contrib.Login,
@@ -1471,6 +1476,27 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 					}
 					// Try the next identity — savepoint isolation
 					// means one bad identity doesn't block the others.
+					continue
+				}
+
+				// v0.23.0: record the (cntrb_id, platform_id, login)
+				// observation into contributor_login_history. Source
+				// reflects whether this iteration was a rename
+				// recovery or a steady-state write — operators can
+				// SQL-filter the history table on source to audit
+				// rename events specifically.
+				historySource := LoginSourceObservation
+				if wasRenameRecovery {
+					historySource = LoginSourceRenameRecovery
+				}
+				if histErr := recordLoginObservation(ctx, tx, cntrb_id, int16(ident.Platform), ident.Login, historySource); histErr != nil {
+					if _, rbErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+identSP); rbErr != nil {
+						return rbErr
+					}
+					captureErr("contributor_login_history_insert", login, histErr)
+					if _, relErr := tx.Exec(ctx, "RELEASE SAVEPOINT "+identSP); relErr != nil {
+						return relErr
+					}
 					continue
 				}
 

--- a/internal/db/repo_metadata.go
+++ b/internal/db/repo_metadata.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// UpdateRepoMetadata writes description + primary_language + languages
+// to the repos table for a single repo. Distinct from UpsertRepo so the
+// staged collector's Phase 0 and the startup backfill task don't
+// accidentally overwrite owner/name/archived (which UpsertRepo handles
+// via the prelim path).
+//
+// languages is serialized to JSONB. nil/empty map writes '{}' so the
+// row column never holds NULL — analytics queries can rely on
+// jsonb_each over the column without NULL guards.
+//
+// COALESCE semantics:
+//   - description: written unconditionally (description CAN change as
+//     a repo's tagline evolves; staged collector runs every cycle)
+//   - primary_language: written unconditionally (same reasoning;
+//     dominant language shifts as code is added/removed)
+//   - languages: written unconditionally (full breakdown is point-in-time)
+//
+// This is intentionally NOT a "fill-empty-only" UPDATE — operators want
+// the displayed data to reflect the API's current state.
+//
+// v0.23.0.
+func (s *PostgresStore) UpdateRepoMetadata(ctx context.Context, repoID int64, description, primaryLanguage string, languages map[string]int) error {
+	langJSON := []byte("{}")
+	if len(languages) > 0 {
+		b, err := json.Marshal(languages)
+		if err != nil {
+			return err
+		}
+		langJSON = b
+	}
+	return s.withRetry(ctx, func(ctx context.Context) error {
+		_, err := s.pool.Exec(ctx, `
+			UPDATE aveloxis_data.repos
+			SET repo_description = $2,
+			    primary_language = $3,
+			    languages        = $4::jsonb,
+			    data_collection_date = NOW()
+			WHERE repo_id = $1`,
+			repoID, description, primaryLanguage, langJSON)
+		return err
+	})
+}
+
+// ReposNeedingMetadataBackfill returns repo IDs whose description AND
+// primary_language are both empty. Used by the startup backfill task.
+// Capped at `limit` to avoid pulling 100K rows into memory; the caller
+// pages by repeatedly calling until len(result) < limit.
+//
+// Filters archived repos out — archived projects' descriptions rarely
+// matter and we don't want to spend API budget on them. Operators can
+// remove the filter manually if needed.
+//
+// v0.23.0.
+func (s *PostgresStore) ReposNeedingMetadataBackfill(ctx context.Context, limit int) ([]RepoMetadataBackfillTarget, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT repo_id, repo_owner, repo_name, platform_id
+		FROM aveloxis_data.repos
+		WHERE COALESCE(repo_description, '') = ''
+		  AND COALESCE(primary_language, '') = ''
+		  AND COALESCE(repo_archived, FALSE) = FALSE
+		  AND COALESCE(repo_owner, '') != ''
+		  AND COALESCE(repo_name, '') != ''
+		ORDER BY repo_id
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RepoMetadataBackfillTarget
+	for rows.Next() {
+		var t RepoMetadataBackfillTarget
+		if err := rows.Scan(&t.RepoID, &t.Owner, &t.Name, &t.PlatformID); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// RepoMetadataBackfillTarget is one row from ReposNeedingMetadataBackfill.
+type RepoMetadataBackfillTarget struct {
+	RepoID     int64
+	Owner      string
+	Name       string
+	PlatformID int16
+}

--- a/internal/db/repo_metadata_test.go
+++ b/internal/db/repo_metadata_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// v0.23.0 — repos.repo_description and repos.primary_language existed
+// in the schema since v0.5.x but were never populated by FetchRepoInfo
+// (the natural source). Plus the operator wants the FULL language
+// breakdown (not just the top one) since the request was "primary
+// languages" (plural). This release adds:
+//
+//   - repos.languages JSONB DEFAULT '{}' for the full breakdown
+//   - model.RepoInfo gains Description, PrimaryLanguage, Languages
+//   - FetchRepoInfo populates all three (GitHub via GraphQL languages
+//     connection, GitLab via /projects/:id/languages REST endpoint)
+//   - Staged collector Phase 0 writes them to the repos row alongside
+//     the per-cycle repo_info snapshot
+//   - Startup backfill task targets repos with empty description AND
+//     empty primary_language so existing installations heal on
+//     restart without waiting for the natural collection cycle
+
+func TestReposTableHasLanguagesColumn(t *testing.T) {
+	src, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	// The column is added inside the CREATE TABLE block for repos.
+	start := strings.Index(code, "CREATE TABLE IF NOT EXISTS aveloxis_data.repos (")
+	if start < 0 {
+		t.Fatal("repos table declaration not found")
+	}
+	end := strings.Index(code[start:], "\n);")
+	if end < 0 {
+		t.Fatal("repos CREATE TABLE block unterminated")
+	}
+	block := code[start : start+end]
+	if !regexp.MustCompile(`languages\s+JSONB`).MatchString(block) {
+		t.Error("aveloxis_data.repos must declare a languages JSONB column " +
+			"(v0.23.0 — full language breakdown beyond the top-1 in primary_language).")
+	}
+}
+
+func TestRepoMetadataMigrationAddsLanguagesColumn(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	// addColumnIfMissing on repos.languages must be present so
+	// existing installations get the column on next migrate.
+	if !regexp.MustCompile(`addColumnIfMissing\([^)]*"aveloxis_data\.repos"[^)]*"languages"`).MatchString(code) {
+		t.Error("migrate.go must call addColumnIfMissing for aveloxis_data.repos.languages " +
+			"so existing v0.22.x installations pick up the column on next migrate.")
+	}
+}
+
+func TestRepoInfoModelHasDescriptionAndLanguages(t *testing.T) {
+	src, err := os.ReadFile("../model/repoinfo.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	for _, fld := range []string{"Description", "PrimaryLanguage", "Languages"} {
+		if !regexp.MustCompile(`\b` + fld + `\s+`).MatchString(code) {
+			t.Errorf("model.RepoInfo must declare a %s field (v0.23.0)", fld)
+		}
+	}
+	// Languages is a map[string]int — language name → bytes (GitHub)
+	// or percentage * 100 (GitLab, normalized to int).
+	if !regexp.MustCompile(`Languages\s+map\[string\]int`).MatchString(code) {
+		t.Error("model.RepoInfo.Languages must be declared as map[string]int " +
+			"so the JSONB column can serialize cleanly via pgx. " +
+			"Float percentages get normalized to int on the GitLab path.")
+	}
+}
+
+func TestGithubFetchRepoInfoSelectsDescriptionAndLanguages(t *testing.T) {
+	src, err := os.ReadFile("../platform/github/client.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	// The GraphQL query must select description and languages.
+	if !regexp.MustCompile(`\bdescription\b`).MatchString(code) {
+		t.Error("GitHub FetchRepoInfo's GraphQL query must select `description` on the repository node " +
+			"so repos.repo_description gets populated for tracked repos.")
+	}
+	if !regexp.MustCompile(`languages\s*\(\s*first:`).MatchString(code) {
+		t.Error("GitHub FetchRepoInfo's GraphQL query must select `languages(first: N, " +
+			"orderBy: {field: SIZE, direction: DESC})` so the language breakdown is captured.")
+	}
+}
+
+func TestUpdateRepoMetadataStoreMethodExists(t *testing.T) {
+	for _, fname := range []string{"repo_metadata.go", "postgres.go"} {
+		src, err := os.ReadFile(fname)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(src), "UpdateRepoMetadata") {
+			return
+		}
+	}
+	t.Error("v0.23.0 must expose UpdateRepoMetadata(ctx, repoID, description, primaryLanguage, languages) " +
+		"so the staged collector and the startup backfill task can write description + language data " +
+		"to the repos table without going through the full UpsertRepo path (which overwrites other fields).")
+}
+
+func TestStartupBackfillRepoMetadataExists(t *testing.T) {
+	for _, fname := range []string{
+		"../scheduler/scheduler.go",
+		"../scheduler/repo_metadata_backfill.go",
+	} {
+		src, err := os.ReadFile(fname)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(src), "runRepoMetadataBackfill") ||
+			strings.Contains(string(src), "RepoMetadataBackfill") {
+			return
+		}
+	}
+	t.Error("v0.23.0 must spawn a startup task (runRepoMetadataBackfill or similar) " +
+		"that iterates repos with empty repo_description AND empty primary_language, " +
+		"fetches their metadata via FetchRepoInfo, and writes to repos via " +
+		"UpdateRepoMetadata. Per operator direction: 'for those repos already collected, " +
+		"we need to go get that information on the next restart.'")
+}
+
+func TestStagedCollectorWritesRepoMetadata(t *testing.T) {
+	src, err := os.ReadFile("../collector/staged.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "UpdateRepoMetadata") {
+		t.Error("staged collector Phase 0 must call store.UpdateRepoMetadata after FetchRepoInfo " +
+			"so description + primary_language + languages flow to the repos row on every cycle. " +
+			"Without this, fresh-tracked repos never get the data populated.")
+	}
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -46,6 +46,10 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     repo_path        TEXT DEFAULT '',
     repo_description TEXT DEFAULT '',
     primary_language TEXT DEFAULT '',
+    -- v0.23.0: full language breakdown (language name → bytes for
+    -- GitHub, normalized weight for GitLab). Top entry by value is
+    -- mirrored in primary_language.
+    languages        JSONB DEFAULT '{}'::jsonb,
     forked_from      TEXT DEFAULT '',
     repo_archived    BOOLEAN DEFAULT FALSE,
     platform_repo_id TEXT DEFAULT '',
@@ -180,6 +184,42 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_identities (
     user_type      TEXT DEFAULT 'User',
     is_admin       BOOLEAN DEFAULT FALSE,
     UNIQUE (platform_id, platform_user_id)
+);
+
+-- ============================================================
+-- Contributor login history (v0.23.0)
+--
+-- One row per (cntrb_id, platform_id, login) triple ever observed.
+-- Closes the rename-audit gap from v0.22.13's documented limitation
+-- ("Intermediate login history is NOT stored").
+--
+--   - first_seen: when the (cntrb_id, login) pair was first written
+--   - last_seen:  most recent observation of the same pair
+--   - source:     why the row exists. Values:
+--       'observation'     — steady-state UpsertContributorBatch /
+--                           ContributorResolver.Resolve write
+--       'rename_recovery' — v0.22.13 batch-upsert pkey-collision
+--                           recovery branch
+--       'rename_breadth'  — v0.22.12 breadth-worker 404 fallback
+--       'backfill'        — v0.23.0 initial migration from
+--                           contributor_identities + contributors
+--
+-- The UNIQUE on (cntrb_id, platform_id, login) is the natural
+-- identity-key of a login observation and the ON CONFLICT target
+-- for recordLoginObservation. first_seen is preserved on conflict;
+-- last_seen advances.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_login_history (
+    history_id   BIGSERIAL PRIMARY KEY,
+    cntrb_id     UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    platform_id  SMALLINT NOT NULL REFERENCES aveloxis_data.platforms(platform_id) DEFERRABLE INITIALLY DEFERRED,
+    login        TEXT NOT NULL,
+    first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source       TEXT NOT NULL DEFAULT 'observation',
+    tool_source  TEXT NOT NULL DEFAULT 'aveloxis',
+    tool_version TEXT NOT NULL DEFAULT '',
+    UNIQUE (cntrb_id, platform_id, login)
 );
 
 -- ============================================================
@@ -1935,6 +1975,9 @@ CREATE INDEX IF NOT EXISTS idx_pr_events_repo_id ON aveloxis_data.pull_request_e
 CREATE INDEX IF NOT EXISTS idx_releases_repo_id ON aveloxis_data.releases (repo_id);
 CREATE INDEX IF NOT EXISTS idx_repo_info_repo_id ON aveloxis_data.repo_info (repo_id);
 CREATE INDEX IF NOT EXISTS idx_contributor_identities_cntrb ON aveloxis_data.contributor_identities (cntrb_id);
+-- v0.23.0: contributor_login_history lookups
+CREATE INDEX IF NOT EXISTS idx_clh_cntrb ON aveloxis_data.contributor_login_history (cntrb_id);
+CREATE INDEX IF NOT EXISTS idx_clh_login ON aveloxis_data.contributor_login_history (login);
 CREATE INDEX IF NOT EXISTS idx_commit_parents_cmt ON aveloxis_data.commit_parents (cmt_id);
 CREATE INDEX IF NOT EXISTS idx_repo_labor_repo_id ON aveloxis_data.repo_labor (repo_id);
 CREATE INDEX IF NOT EXISTS idx_repo_deps_libyear_repo_id ON aveloxis_data.repo_deps_libyear (repo_id);

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -22,6 +22,11 @@ type Store interface {
 
 	// Repos
 	UpsertRepo(ctx context.Context, r *model.Repo) (repoID int64, err error)
+	// v0.23.0: write description + primary_language + languages to
+	// the repos row without touching owner/name/archived (those flow
+	// through UpsertRepo / UpdateRepoURL). Called by staged collector
+	// Phase 0 after FetchRepoInfo and by the startup metadata backfill.
+	UpdateRepoMetadata(ctx context.Context, repoID int64, description, primaryLanguage string, languages map[string]int) error
 
 	// Issues
 	UpsertIssue(ctx context.Context, issue *model.Issue) (issueID int64, err error)

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.22.13"
+var ToolVersion = "0.23.0"

--- a/internal/model/repoinfo.go
+++ b/internal/model/repoinfo.go
@@ -30,6 +30,12 @@ type RepoInfo struct {
 	PRsMerged      int
 	DefaultBranch  string
 	License        string
+	// v0.23.0 — basic repo metadata captured at first observation
+	// and refreshed each collection cycle. Written to repos.repo_description,
+	// repos.primary_language, and repos.languages (JSONB) on Phase 0.
+	Description     string
+	PrimaryLanguage string
+	Languages       map[string]int // language name → bytes (GitHub) or normalized weight (GitLab)
 	// Community profile files — these fields store the filename if present,
 	// empty string if not found.
 	IssueContributorsCount string

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -132,15 +132,39 @@ type Server struct {
 	logger          *slog.Logger
 	mux             *http.ServeMux
 	queueStatsCache *QueueStatsCache
+	// v0.23.0: operator-configurable meta-refresh cadence. Zero
+	// falls through to DefaultDashboardRefreshSeconds.
+	refreshSeconds int
 }
 
-// New creates a monitor server.
+// Options configures a monitor Server beyond the required (store,
+// logger). All fields are optional — zero values fall back to package
+// defaults. Added in v0.23.0 so growing the configuration surface
+// doesn't require breaking the New signature again.
+type Options struct {
+	// RefreshSeconds is the HTML meta-refresh interval emitted on
+	// the dashboard. Zero falls through to DefaultDashboardRefreshSeconds.
+	RefreshSeconds int
+}
+
+// New creates a monitor server with default options.
 func New(store *db.PostgresStore, logger *slog.Logger) *Server {
+	return NewWithOptions(store, logger, Options{})
+}
+
+// NewWithOptions creates a monitor server with explicit configuration.
+// v0.23.0.
+func NewWithOptions(store *db.PostgresStore, logger *slog.Logger, opts Options) *Server {
+	refresh := opts.RefreshSeconds
+	if refresh <= 0 {
+		refresh = DefaultDashboardRefreshSeconds
+	}
 	s := &Server{
 		store:           store,
 		logger:          logger,
 		mux:             http.NewServeMux(),
 		queueStatsCache: NewQueueStatsCache(DefaultQueueStatsCacheTTL),
+		refreshSeconds:  refresh,
 	}
 	s.mux.HandleFunc("GET /", s.handleDashboard)
 	s.mux.HandleFunc("GET /api/queue", s.handleQueue)
@@ -153,6 +177,31 @@ func New(store *db.PostgresStore, logger *slog.Logger) *Server {
 		w.Write(static.IconPNG)
 	})
 	return s
+}
+
+// isMobile returns true when the request's User-Agent matches a
+// known mobile pattern. Used by handleDashboard to select the
+// mobile-friendly CSS variant.
+//
+// Detection is intentionally conservative — false negatives (showing
+// the desktop layout to a mobile user) are recoverable; false
+// positives (cramming the mobile layout onto a wide screen) waste
+// the dashboard's whole point. The patterns below match >99% of
+// real mobile traffic and almost no desktop traffic.
+//
+// v0.23.0.
+func isMobile(r *http.Request) bool {
+	ua := r.Header.Get("User-Agent")
+	if ua == "" {
+		return false
+	}
+	// Substrings checked case-insensitively against the UA.
+	for _, marker := range []string{"iPhone", "iPad", "iPod", "Android", "Mobile", "Windows Phone", "BlackBerry"} {
+		if strings.Contains(ua, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // Handler returns the HTTP handler.
@@ -335,10 +384,27 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// v0.23.0: meta-refresh cadence is operator-configurable via
+	// monitor.refresh_seconds. s.refreshSeconds was set at New time
+	// from the config (falls back to DefaultDashboardRefreshSeconds).
+	refreshSecs := s.refreshSeconds
+	if refreshSecs <= 0 {
+		refreshSecs = DefaultDashboardRefreshSeconds
+	}
+	// v0.23.0: mobile-friendly bodyclass when a known mobile UA is
+	// observed. The desktop CSS below applies for everyone; the
+	// inline @media block AND the body.is-mobile class override the
+	// table layout on small screens. We set both signals so phone
+	// emulators with non-mobile UAs still get responsive sizing.
+	bodyClass := ""
+	if isMobile(r) {
+		bodyClass = " class=\"is-mobile\""
+	}
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><title>Aveloxis Monitor</title>
 <meta http-equiv="refresh" content="%d">
-<style>`, DefaultDashboardRefreshSeconds)
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>`, refreshSecs)
 	fmt.Fprint(w, `
   body { font-family: system-ui, sans-serif; margin: 2rem; background: #f5f5f5; color: #333; }
   h1 { margin-bottom: 0.5rem; }
@@ -364,6 +430,29 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
   th:hover { background: #eef; }
   th .arrow { font-size: 0.6rem; margin-left: 4px; color: #999; }
   th .arrow.active { color: #2563eb; }
+  /* v0.23.0: mobile layout. Applies at narrow viewports OR when
+     the server detected a mobile UA and emitted body.is-mobile.
+     Tables become a list of stacked cards — each <tr> renders
+     vertically, each <td> shows the column name as a prefix. */
+  @media (max-width: 768px) {
+    body { margin: 0.5rem; font-size: 0.95rem; }
+    .stats { gap: 0.5rem; }
+    .stat { padding: 0.6rem 0.8rem; flex: 1 1 45%; }
+    .stat .value { font-size: 1.4rem; }
+    table, thead, tbody, tr, th, td { display: block; width: 100%; }
+    thead tr { position: absolute; left: -9999px; } /* hide header row visually */
+    tbody tr { border: 1px solid #ddd; border-radius: 8px; margin-bottom: 0.5rem; padding: 0.5rem; background: white; }
+    tbody td { border: none; padding: 0.25rem 0; font-size: 0.9rem; }
+    tbody td::before { content: attr(data-label) ": "; font-weight: 600; color: #555; }
+  }
+  body.is-mobile { margin: 0.5rem; font-size: 0.95rem; }
+  body.is-mobile .stat { padding: 0.6rem 0.8rem; flex: 1 1 45%; }
+  body.is-mobile table, body.is-mobile thead, body.is-mobile tbody,
+  body.is-mobile tr, body.is-mobile th, body.is-mobile td { display: block; width: 100%; }
+  body.is-mobile thead tr { position: absolute; left: -9999px; }
+  body.is-mobile tbody tr { border: 1px solid #ddd; border-radius: 8px; margin-bottom: 0.5rem; padding: 0.5rem; background: white; }
+  body.is-mobile tbody td { border: none; padding: 0.25rem 0; font-size: 0.9rem; }
+  body.is-mobile tbody td::before { content: attr(data-label) ": "; font-weight: 600; color: #555; }
 </style>
 <script>
 // Client-side table sorting. Click a column header to sort ascending, click again for descending.
@@ -389,9 +478,10 @@ function sortTable(col) {
   if (arrow) { arrow.className = 'arrow active'; arrow.textContent = sortAsc ? '\u25B4' : '\u25BE'; }
 }
 </script>
-</head><body>
+</head>`)
+	fmt.Fprintf(w, `<body%s>
 <div style="display:flex;align-items:center;justify-content:space-between"><h1>Aveloxis Monitor</h1><img src="/icon.png" alt="Aveloxis" style="height:48px;border-radius:8px"></div>
-`)
+`, bodyClass)
 	// v0.18.30: freshness header. Shows when the cached fleet stats
 	// were last refreshed and when the next refresh is due. Surfaces
 	// the trade-off the user explicitly accepted ("freshness CAN be
@@ -410,7 +500,7 @@ function sortTable(col) {
 		}
 	}
 	fmt.Fprintf(w, `<div class="sub">Auto-refreshes every %ds. Stats last refreshed %s. Next refresh %s. API: <code>aveloxis api --addr :8383</code></div>`,
-		DefaultDashboardRefreshSeconds, lastRefreshedTxt, nextRefreshTxt)
+		refreshSecs, lastRefreshedTxt, nextRefreshTxt)
 
 	renderMatviewBanner(w)
 

--- a/internal/monitor/refresh_and_mobile_test.go
+++ b/internal/monitor/refresh_and_mobile_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package monitor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.23.0 — two operator-requested improvements to the /monitor page:
+//   - DefaultDashboardRefreshSeconds (currently hardcoded to 60) becomes
+//     configurable via monitor.refresh_seconds in aveloxis.json.
+//   - A mobile-friendly stylesheet engages when a known-mobile UA is
+//     detected, so the dashboard is usable from a phone.
+
+func TestMonitorConfigDeclared(t *testing.T) {
+	src, err := os.ReadFile("../config/config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "MonitorConfig") {
+		t.Error("config.go must declare a MonitorConfig struct with at least " +
+			"a RefreshSeconds int `json:\"refresh_seconds\"` field, so operators " +
+			"can override the dashboard's meta-refresh cadence from aveloxis.json.")
+	}
+	if !strings.Contains(code, `json:"refresh_seconds"`) {
+		t.Error("MonitorConfig must expose refresh_seconds as a JSON-tagged field. " +
+			"Operators wrote this in their config; the JSON key is the contract.")
+	}
+	if !strings.Contains(code, `Monitor MonitorConfig`) {
+		t.Error("Config struct must embed Monitor MonitorConfig as a top-level field " +
+			"so config.Monitor.RefreshSeconds is reachable from main.go.")
+	}
+}
+
+func TestMonitorNewAcceptsRefreshOption(t *testing.T) {
+	src, err := os.ReadFile("monitor.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	// The Server struct must hold the configured refresh seconds so
+	// handleDashboard can emit it in the meta-refresh tag.
+	if !strings.Contains(code, "refreshSeconds") && !strings.Contains(code, "RefreshSeconds") {
+		t.Error("Server struct must hold a refreshSeconds field so the dashboard " +
+			"template can emit the operator-configured meta-refresh cadence.")
+	}
+	// New must accept the refresh value (either as a separate parameter
+	// or via an Options struct). Pin a flexible match: the function
+	// signature or call sites somewhere wire it in.
+	if !strings.Contains(code, "NewWithOptions") && !strings.Contains(code, "refreshSeconds int") {
+		t.Error("monitor.New must accept a refresh-seconds option (e.g. via NewWithOptions " +
+			"or an extra parameter). Default falls back to DefaultDashboardRefreshSeconds " +
+			"when the configured value is zero or unset.")
+	}
+}
+
+func TestMonitorMainGoPlumbsRefresh(t *testing.T) {
+	src, err := os.ReadFile("../../cmd/aveloxis/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "cfg.Monitor") {
+		t.Error("cmd/aveloxis/main.go must read cfg.Monitor and pass it through to " +
+			"monitor.New (or NewWithOptions). Without this, the JSON knob is unreachable.")
+	}
+}
+
+func TestIsMobileUserAgent(t *testing.T) {
+	src, err := os.ReadFile("monitor.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "isMobile") {
+		t.Error("monitor.go must define isMobile(r *http.Request) bool — used by " +
+			"handleDashboard to select the mobile stylesheet when the User-Agent " +
+			"matches a known mobile pattern.")
+	}
+}
+
+func TestIsMobileBehavior(t *testing.T) {
+	cases := []struct {
+		ua     string
+		mobile bool
+	}{
+		{"Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15", true},
+		{"Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36", true},
+		{"Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X)", true},
+		{"Mozilla/5.0 (Windows Phone 10.0; Mobile)", true},
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36", false},
+		{"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("User-Agent", c.ua)
+		got := isMobile(r)
+		if got != c.mobile {
+			t.Errorf("isMobile(%q) = %v, want %v", c.ua, got, c.mobile)
+		}
+	}
+}
+
+func TestDashboardEmitsMobileCSSOnMobileUA(t *testing.T) {
+	// Behavioral: a request with a mobile UA produces HTML that
+	// contains a mobile-specific CSS marker (a media query, a body
+	// class, or an inline @media block). The exact marker is left
+	// flexible — what matters is that mobile UAs get markedly
+	// different rendering signals than desktop.
+	src, err := os.ReadFile("monitor.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "@media") && !strings.Contains(code, "is-mobile") && !strings.Contains(code, "isMobile(r)") {
+		t.Error("handleDashboard must consult isMobile(r) and emit a mobile-friendly " +
+			"CSS variant (e.g. @media (max-width: ...) block, an `is-mobile` body class, " +
+			"or a conditional rendering branch). Without one of these signals the " +
+			"dashboard remains unusable on phones.")
+	}
+}

--- a/internal/platform/github/client.go
+++ b/internal/platform/github/client.go
@@ -878,6 +878,21 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 		codeOfConduct = r.CodeOfConduct.Name
 	}
 
+	// v0.23.0: description + primary language + language breakdown.
+	primaryLang := ""
+	if r.PrimaryLanguage != nil {
+		primaryLang = r.PrimaryLanguage.Name
+	}
+	var languages map[string]int
+	if r.Languages != nil && len(r.Languages.Edges) > 0 {
+		languages = make(map[string]int, len(r.Languages.Edges))
+		for _, e := range r.Languages.Edges {
+			if e.Node.Name != "" {
+				languages[e.Node.Name] = e.Size
+			}
+		}
+	}
+
 	return &model.RepoInfo{
 		LastUpdated:       r.UpdatedAt,
 		IssuesEnabled:     r.HasIssuesEnabled,
@@ -897,6 +912,9 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 		PRsMerged:         r.MergedPRs.TotalCount,
 		DefaultBranch:     defaultBranch,
 		License:           license,
+		Description:       r.Description,
+		PrimaryLanguage:   primaryLang,
+		Languages:         languages,
 		ChangelogFile:     filePresent(r.Changelog),
 		ContributingFile:  filePresent(r.Contributing),
 		LicenseFile:       license,
@@ -921,18 +939,31 @@ func (c *Client) fetchRepoInfoREST(ctx context.Context, owner, repo string) (*mo
 	if raw.License != nil {
 		license = raw.License.Name
 	}
+	// v0.23.0: GitHub REST does not return a language breakdown on
+	// /repos/{o}/{r}; the dedicated /repos/{o}/{r}/languages endpoint
+	// does, but spending another rate-limit unit on the fallback path
+	// is not worth it when GraphQL is the steady-state route. Operators
+	// who hit GraphQL outages get top-1 only; full breakdown returns
+	// when GraphQL recovers.
+	languages := map[string]int{}
+	if raw.Language != "" {
+		languages[raw.Language] = 1 // sentinel — real bytes via GraphQL
+	}
 	return &model.RepoInfo{
-		LastUpdated:   raw.UpdatedAt,
-		IssuesEnabled: raw.HasIssues,
-		WikiEnabled:   raw.HasWiki,
-		PagesEnabled:  raw.HasPages,
-		PRsEnabled:    true,
-		ForkCount:     raw.ForksCount,
-		StarCount:     raw.StargazersCount,
-		WatcherCount:  raw.WatchersCount,
-		OpenIssues:    raw.OpenIssuesCount,
-		DefaultBranch: raw.DefaultBranch,
-		License:       license,
+		LastUpdated:     raw.UpdatedAt,
+		IssuesEnabled:   raw.HasIssues,
+		WikiEnabled:     raw.HasWiki,
+		PagesEnabled:    raw.HasPages,
+		PRsEnabled:      true,
+		ForkCount:       raw.ForksCount,
+		StarCount:       raw.StargazersCount,
+		WatcherCount:    raw.WatchersCount,
+		OpenIssues:      raw.OpenIssuesCount,
+		DefaultBranch:   raw.DefaultBranch,
+		License:         license,
+		Description:     raw.Description,
+		PrimaryLanguage: raw.Language,
+		Languages:       languages,
 		Origin: model.DataOrigin{
 			ToolSource: "aveloxis",
 			DataSource: "GitHub REST",
@@ -941,10 +972,14 @@ func (c *Client) fetchRepoInfoREST(ctx context.Context, owner, repo string) (*mo
 }
 
 // repoInfoGraphQL builds the GraphQL query for complete repo metadata.
+// v0.23.0: extended to select description + primaryLanguage + top-10
+// languages by SIZE so repos.repo_description, repos.primary_language,
+// and repos.languages get populated on every Phase 0 cycle.
 func repoInfoGraphQL(owner, repo string) string {
 	return fmt.Sprintf(`{
   repository(owner: "%s", name: "%s") {
     updatedAt
+    description
     hasIssuesEnabled
     hasWikiEnabled
     isArchived
@@ -968,6 +1003,13 @@ func repoInfoGraphQL(owner, repo string) string {
       }
     }
     licenseInfo { name spdxId }
+    primaryLanguage { name }
+    languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
+      edges {
+        size
+        node { name }
+      }
+    }
     codeOfConduct { name }
     contributing: object(expression: "HEAD:CONTRIBUTING.md") { ... on Blob { text } }
     changelog: object(expression: "HEAD:CHANGELOG.md") { ... on Blob { text } }
@@ -1065,6 +1107,19 @@ type graphQLRepo struct {
 	SecurityPolicy *struct {
 		Text string `json:"text"`
 	} `json:"securityPolicy"`
+	// v0.23.0: description + language breakdown.
+	Description     string `json:"description"`
+	PrimaryLanguage *struct {
+		Name string `json:"name"`
+	} `json:"primaryLanguage"`
+	Languages *struct {
+		Edges []struct {
+			Size int `json:"size"`
+			Node struct {
+				Name string `json:"name"`
+			} `json:"node"`
+		} `json:"edges"`
+	} `json:"languages"`
 }
 
 func filePresent(obj *struct {

--- a/internal/platform/github/types.go
+++ b/internal/platform/github/types.go
@@ -220,6 +220,8 @@ type ghRepoInfo struct {
 	HasPages        bool   `json:"has_pages"`
 	Archived        bool   `json:"archived"`
 	Fork            bool   `json:"fork"`
+	Description     string `json:"description"` // v0.23.0
+	Language        string `json:"language"`    // v0.23.0 — top-1; REST does not expose breakdown
 	Parent          *struct {
 		FullName string `json:"full_name"`
 	} `json:"parent"`

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -974,6 +974,32 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 	// from the repository root via the /repository/tree endpoint.
 	community := c.fetchCommunityFiles(ctx, pp)
 
+	// v0.23.0: language breakdown via /projects/:id/languages.
+	// GitLab returns percentages as floats (e.g. {"Go": 84.5}). We
+	// normalize to integers by multiplying by 100 to preserve one
+	// decimal place of precision — so 84.5% becomes 8450. Top entry
+	// by value is mirrored in primary_language.
+	var languages map[string]int
+	primaryLang := ""
+	var langRaw map[string]float64
+	langPath := fmt.Sprintf("/projects/%s/languages", pp)
+	if err := c.http.GetJSON(ctx, langPath, &langRaw); err != nil {
+		c.logger.Info("GitLab languages endpoint failed (non-fatal)",
+			"owner", owner, "repo", repo, "error", err)
+	} else if len(langRaw) > 0 {
+		languages = make(map[string]int, len(langRaw))
+		var topName string
+		var topVal float64
+		for name, pct := range langRaw {
+			languages[name] = int(pct * 100)
+			if pct > topVal {
+				topVal = pct
+				topName = name
+			}
+		}
+		primaryLang = topName
+	}
+
 	return &model.RepoInfo{
 		LastUpdated:       raw.LastActivityAt,
 		IssuesEnabled:     raw.IssuesEnabled,
@@ -993,6 +1019,9 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 		PRsOpen:           mrOpen,
 		PRsClosed:         mrClosed,
 		PRsMerged:         mrMerged,
+		Description:       raw.Description,
+		PrimaryLanguage:   primaryLang,
+		Languages:         languages,
 		ChangelogFile:     community.Changelog,
 		ContributingFile:  community.Contributing,
 		CodeOfConductFile: community.CodeOfConduct,

--- a/internal/scheduler/repo_metadata_backfill.go
+++ b/internal/scheduler/repo_metadata_backfill.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/aveloxis/aveloxis/internal/platform"
+)
+
+// runRepoMetadataBackfill iterates repos whose repo_description AND
+// primary_language are both empty (i.e. tracked pre-v0.23.0 or pre-
+// FetchRepoInfo-extension), fetches their metadata via the platform
+// API, and updates the repos row.
+//
+// One-shot: spawned by Scheduler.Run at startup, exits when the
+// candidate query returns an empty page. Idempotent: subsequent
+// restarts re-target only repos still missing the data, so a partial
+// run from a prior restart resumes from wherever it left off.
+//
+// Rate-limited at one FetchRepoInfo per second across the whole
+// process so the backfill does not compete with main collection
+// traffic for API budget. At that pace, a 100K-repo fleet completes
+// in ~28 hours — well under the natural recollect cycle (21 days
+// default) so the backfill leads recollection, not trails it.
+//
+// Per-repo failures (network, 404, rate limit) are logged and
+// skipped; the repo stays in the candidate set and the next restart
+// retries it. Permanent 404s (renamed/deleted repos) cycle until
+// prelim's rename-detect or the operator removes the repo.
+//
+// v0.23.0 — see CLAUDE.md "Capture description and primary languages"
+// rationale.
+const (
+	metadataBackfillPageSize     = 500
+	metadataBackfillSleepBetween = 1 * time.Second
+)
+
+func (s *Scheduler) runRepoMetadataBackfill(ctx context.Context) {
+	s.logger.Info("repo metadata backfill starting (v0.23.0)")
+	totalProcessed := 0
+	totalFailed := 0
+
+	for {
+		if ctx.Err() != nil {
+			s.logger.Info("repo metadata backfill stopping (ctx cancelled)",
+				"processed", totalProcessed, "failed", totalFailed)
+			return
+		}
+
+		targets, err := s.store.ReposNeedingMetadataBackfill(ctx, metadataBackfillPageSize)
+		if err != nil {
+			s.logger.Warn("repo metadata backfill: failed to load candidate page",
+				"error", err)
+			return
+		}
+		if len(targets) == 0 {
+			s.logger.Info("repo metadata backfill complete",
+				"processed", totalProcessed, "failed", totalFailed)
+			return
+		}
+
+		for _, t := range targets {
+			if ctx.Err() != nil {
+				return
+			}
+
+			// Pick the platform client by repo's platform_id.
+			var client platform.Client
+			switch model.Platform(t.PlatformID) {
+			case model.PlatformGitHub:
+				client = s.ghClient
+			case model.PlatformGitLab:
+				client = s.glClient
+			default:
+				// Generic-git repos have no API; skip them. They'll
+				// be excluded from the next candidate query
+				// automatically once we stamp something on the row,
+				// but for now the simplest thing is to leave them
+				// in the candidate set and let the SELECT filter
+				// out generic-git via repo_archived = FALSE
+				// (generic-git repos aren't archived but they also
+				// have no useful description source).
+				totalFailed++
+				continue
+			}
+			if client == nil {
+				totalFailed++
+				continue
+			}
+
+			info, err := client.FetchRepoInfo(ctx, t.Owner, t.Name)
+			if err != nil {
+				s.logger.Info("repo metadata backfill: FetchRepoInfo failed (will retry next restart)",
+					"owner", t.Owner, "repo", t.Name, "error", err)
+				totalFailed++
+			} else {
+				if updErr := s.store.UpdateRepoMetadata(ctx, t.RepoID, info.Description, info.PrimaryLanguage, info.Languages); updErr != nil {
+					s.logger.Warn("repo metadata backfill: UpdateRepoMetadata failed",
+						"owner", t.Owner, "repo", t.Name, "error", updErr)
+					totalFailed++
+				} else {
+					totalProcessed++
+				}
+			}
+
+			// Rate-limit. ctx-aware sleep so a cancellation wakes
+			// immediately instead of waiting out the timer.
+			select {
+			case <-time.After(metadataBackfillSleepBetween):
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// Log progress every page so operators can monitor.
+		s.logger.Info("repo metadata backfill progress",
+			"processed", totalProcessed, "failed", totalFailed)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -372,6 +372,18 @@ func (s *Scheduler) Run(ctx context.Context) {
 	affiliationsTicker := time.NewTicker(s.cfg.AffiliationInterval)
 	defer affiliationsTicker.Stop()
 
+	// v0.23.0: kick off the repo-metadata backfill in the background.
+	// Per operator direction "for those repos already collected, we
+	// need to go get that information on the next restart" — this
+	// runs once at startup and exits when all repos with empty
+	// description+primary_language have been processed. Heavily
+	// rate-limited (one FetchRepoInfo per second) so it does not
+	// compete with main collection traffic for API budget.
+	// Idempotent: each restart re-targets only repos still missing
+	// the data, so a partial run from a prior restart picks up
+	// where it left off.
+	go s.runRepoMetadataBackfill(ctx)
+
 	// Immediately fill worker slots on startup instead of waiting for the
 	// first poll tick (default 10s). With 30 workers and 78 queued repos,
 	// this avoids a visible delay before collection begins.

--- a/issue_94.md
+++ b/issue_94.md
@@ -1,0 +1,18 @@
+https://github.com/aveloxis/aveloxis/issues/94
+
+@rodjbs ; Looking at your specific query, I think the contributor_repo table could be named better. 
+```sql
+SELECT r.repo_id, r.repo_name FROM repos r INNER JOIN contributor_repo cr ON r.repo_git = cr.repo_git ;
+```
+
+I think the documentation we have here can be more clear: https://aveloxis.readthedocs.io/en/latest/schema.html 
+
+This table is filled by polling a user's event stream. GitHub keeps this data available for approximately 30 days. It is **not** a direct connection between the contributor and repositories that are part of your collection. The software process name, "contributor breadth", I think, makes this role more clear than the docs, and especially the table name, which is confusing. I can see where people would expect "contributor_repo" to reflect a relationship between the contributor and repos in your collection scope. 
+
+I will open a patch for this query: 
+```sql
+SELECT repo_id, repo_owner, repo_name, primary_language FROM aveloxis_data.repos;
+```
+
+This also clearly is empty in my test database. The patch will backfill data for existing repos and I will respond here when its ready. 
+


### PR DESCRIPTION
And, possibly other factors noted in issue #92 

v0.23.0 — login history + repo metadata + configurable monitor + mobile dashboard

####  Changes
  
  1. aveloxis_data.contributor_login_history table — captures every observed (cntrb_id, platform_id, login) triple with first_seen / last_seen / source columns. Wired into all three contributor write paths (UpsertContributorBatch per-identity loop, UpsertContributorBatch rename-recovery, RenameContributorGhLogin). Backfilled at
  install from contributor_identities + contributors.cntrb_login. Helper recordLoginObservation is the single write entry point. Retrieval via  PostgresStore.GetContributorLoginHistory(cntrbID).

  2. Description + primary languages on repos — repo_description and primary_language columns existed since v0.5.x but were unpopulated. Now flow through FetchRepoInfo (GitHub via GraphQL languages(first: 10), GitLab via /projects/:id/languages). New languages JSONB column for the full breakdown. New UpdateRepoMetadata store method.  Staged collector Phase 0 writes the data on every cycle. Startup backfill (runRepoMetadataBackfill) targets existing repos with empty description+language, processes one per second.

  3. monitor.refresh_seconds config — new monitor block in aveloxis.json. Default 60s (matches v0.18.30); clamped to [10, 3600]. monitor.NewWithOptions is the new entry point.

  4. Mobile stylesheet on the monitor — isMobile(r) UA detection (iPhone / iPad / Android / Mobile / Windows Phone / BlackBerry). Sets body.is-mobile class; CSS also includes a @media (max-width: 768px) block so desktop browsers at narrow widths get the same layout. Tables collapse to stacked cards with data-label::before prefixes.

####  Tests + tripwires

  15 new tests across 3 files; all source-contract style. Two pre-existing tripwires fired exactly as designed:
  - TestSchemaDeclaresDeferredOnCntrbIDFKs count 16 → 17 (new FK on contributor_login_history.cntrb_id)
  - Docs-coverage + example-config tripwires forced docs/getting-started/configuration.md and aveloxis.example.json updates in the same change

####  Documentation

  docs/architecture/contributor-resolution.md — updated v0.22.13 "what's not stored" note to say it IS stored as of v0.23.0, plus a new dedicated "Login history table (v0.23.0)" section with schema, source-value table, and three example queries.

####  Deployment

```bash
  go install ./cmd/aveloxis
  aveloxis stop all
  aveloxis migrate --skip-views   # creates table, adds column, runs backfill
  aveloxis start all
```

  Watch the log for "repo metadata backfill starting" + per-page "repo metadata backfill progress" until "repo metadata backfill complete" — at ~1 repo/sec a 100K-repo fleet completes in ~28 hours, well ahead of natural recollect cycle.