### PR TITLE
fixing UTF8 byte sequence errors on all fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+aveloxis.chaoss.tv.json
 aveloxis.kate.json
 aveloxis.runlocal.json
 prompt-notes/**

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -112,6 +112,17 @@ func NewPostgresStore(ctx context.Context, connString string, logger *slog.Logge
 	// "aveloxis-web" / "aveloxis-api" — pg_stat_activity then filters
 	// cleanly per process. v0.20.0 stop-verification depends on this.
 
+	// v0.23.5: install the utf8ScrubTracer on every pooled conn. The
+	// tracer mutates string and *string parameters in place inside
+	// TraceQueryStart / TraceBatchStart, before pgx encodes them
+	// onto the wire. Net effect: PostgreSQL's SQLSTATE 22021
+	// ("invalid byte sequence for encoding UTF8") can no longer kill
+	// an INSERT/UPDATE because some upstream source handed us a
+	// Latin-1 author name or a contributor bio with a PNG signature.
+	// See utf8_tracer.go for the full rationale + production-
+	// incident history.
+	cfg.ConnConfig.Tracer = utf8ScrubTracer{}
+
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to database: %w", err)

--- a/internal/db/utf8_tracer.go
+++ b/internal/db/utf8_tracer.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// utf8ScrubTracer is a pgx tracer that scrubs invalid UTF-8 bytes
+// from string and *string parameters before they reach the wire.
+// Registered on cfg.ConnConfig.Tracer in NewPostgresStore.
+//
+// # Why a tracer (v0.23.5)
+//
+// PostgreSQL rejects every TEXT, VARCHAR, CHAR, and JSONB parameter
+// that contains invalid UTF-8 with SQLSTATE 22021 (`invalid byte
+// sequence for encoding "UTF8"`). The rejection is per-statement: a
+// 500-row batch dies on a single poisoned row, and aveloxis's
+// retry-on-failure loop on UpsertCommit / UpsertContributorBatch
+// just hits the same error again on the next attempt.
+//
+// Sources of invalid UTF-8 in production:
+//
+//   - git log output from old kernel-style repos with Latin-1
+//     author names ("Lászlo Kövács" → 0xe1, 0xf6, 0xe1) or file
+//     paths with high-bit codepoints. The 2026-05-21 log showed 72
+//     `failed to upsert commit` warnings of this shape.
+//   - GitHub profile fields (cntrb_company, cntrb_full_name) where
+//     users occasionally paste binary content into their bio. The
+//     2026-05-02 log showed 0x89 (PNG signature start) inside
+//     contributor_affiliations INSERTs. v0.19.2 added a surgical
+//     safeUTF8 to PopulateAffiliations; v0.23.5 generalizes.
+//   - GitLab / GitHub API responses where free-text fields land,
+//     particularly issue / PR / commit message bodies.
+//
+// # How the tracer works
+//
+// pgx fires TraceQueryStart immediately before encoding query
+// arguments for the wire. The Args slice it receives shares its
+// underlying array with the caller's `...args` variadic. Mutating
+// `Args[i]` is therefore visible to pgx's encoder, which then sends
+// the scrubbed value. Symmetric for batches: TraceBatchStart fires
+// before SendBatch encodes the batch, and `Batch.QueuedQueries[*].
+// Arguments` is exposed as a mutable []any.
+//
+// Net effect: a single registration on cfg.ConnConfig.Tracer
+// protects every Exec, Query, QueryRow, SendBatch — across the
+// pool, transactions, and prepared-statement modes — with zero
+// call-site changes. ~437 call sites in internal/db/ are
+// automatically covered.
+//
+// # What is NOT scrubbed
+//
+//   - []byte parameters. Those route to BYTEA columns which
+//     accept any byte sequence. Scrubbing them would silently
+//     corrupt legitimate binary data (CycloneDX SBOM blobs,
+//     scancode JSON marshaled to bytes, etc.).
+//   - Other primitive types (int, float, bool, time.Time). These
+//     never carry invalid UTF-8 by construction.
+//   - nil values. Pass-through.
+//   - Outputs from queries. Postgres returns valid UTF-8 by
+//     definition; scrubbing on the output path would be redundant.
+//
+// # Defensive layering
+//
+// v0.19.2's explicit safeUTF8 calls in PopulateAffiliations are NOT
+// removed — they serve as belt-and-suspenders for the JSON
+// scrubber (sanitizeJSONForJSONB) which works at the marshaling
+// layer rather than the parameter layer. The two layers are
+// independent and both correct.
+type utf8ScrubTracer struct{}
+
+func (utf8ScrubTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	scrubArgsInPlace(data.Args)
+	return ctx
+}
+
+func (utf8ScrubTracer) TraceQueryEnd(_ context.Context, _ *pgx.Conn, _ pgx.TraceQueryEndData) {
+}
+
+func (utf8ScrubTracer) TraceBatchStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceBatchStartData) context.Context {
+	if data.Batch == nil {
+		return ctx
+	}
+	for _, qq := range data.Batch.QueuedQueries {
+		if qq == nil {
+			continue
+		}
+		scrubArgsInPlace(qq.Arguments)
+	}
+	return ctx
+}
+
+func (utf8ScrubTracer) TraceBatchQuery(_ context.Context, _ *pgx.Conn, _ pgx.TraceBatchQueryData) {
+}
+
+func (utf8ScrubTracer) TraceBatchEnd(_ context.Context, _ *pgx.Conn, _ pgx.TraceBatchEndData) {
+}
+
+// scrubArgsInPlace walks the args slice and replaces any string /
+// *string element whose UTF-8 is invalid with a scrubbed version.
+// Non-string types (including []byte) pass through unchanged.
+// The slice header itself is reused; only the element slots are
+// rewritten. Safe to call on a nil or empty slice.
+func scrubArgsInPlace(args []any) {
+	for i, a := range args {
+		switch v := a.(type) {
+		case string:
+			if !utf8.ValidString(v) {
+				args[i] = safeUTF8(v)
+			}
+		case *string:
+			if v != nil && !utf8.ValidString(*v) {
+				cleaned := safeUTF8(*v)
+				args[i] = &cleaned
+			}
+		}
+	}
+}

--- a/internal/db/utf8_tracer_integration_test.go
+++ b/internal/db/utf8_tracer_integration_test.go
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/jackc/pgx/v5"
+)
+
+// Integration tests for the v0.23.5 utf8ScrubTracer. Exercise every
+// path that takes external-data string args, against a live Postgres
+// configured via AVELOXIS_TEST_DB.
+//
+// Recipe (local laptop):
+//
+//   AVELOXIS_TEST_DB="postgres://aveloxis:fuckoffdawn@localhost:5432/aveloxis_cascade_test?sslmode=prefer" \
+//       go test ./internal/db/ -run TestUTF8Tracer -v
+//
+// All tests in this file SKIP when AVELOXIS_TEST_DB is unset so
+// `go test ./...` stays runnable without a database.
+
+func openTestStore(t *testing.T) *PostgresStore {
+	t.Helper()
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping UTF8 tracer integration test")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	store.SetMatviewSkip(true)
+	if err := RunMigrations(ctx, store, logger); err != nil {
+		store.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestUTF8TracerScrubsPoolExec(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	// Use a temp table to avoid colliding with production-schema
+	// rows; keeps the test isolated.
+	_, err := store.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS aveloxis_test_utf8_pool (
+			id SERIAL PRIMARY KEY,
+			val TEXT NOT NULL
+		)`)
+	if err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS aveloxis_test_utf8_pool`)
+	})
+	_, _ = store.pool.Exec(ctx, `TRUNCATE aveloxis_test_utf8_pool`)
+
+	// 0xb3 is the byte that triggered the 2026-05-21 production
+	// SQLSTATE 22021 storm on Linux kernel commits. Pre-v0.23.5
+	// this INSERT errored out. Post-v0.23.5 the tracer scrubs.
+	bad := "kernel\xb3author"
+	if _, err := store.pool.Exec(ctx,
+		`INSERT INTO aveloxis_test_utf8_pool (val) VALUES ($1)`, bad); err != nil {
+		t.Fatalf("INSERT with invalid-UTF8 arg must succeed under "+
+			"the v0.23.5 tracer; got: %v", err)
+	}
+
+	var stored string
+	if err := store.pool.QueryRow(ctx,
+		`SELECT val FROM aveloxis_test_utf8_pool LIMIT 1`).Scan(&stored); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !utf8.ValidString(stored) {
+		t.Errorf("persisted value must be valid UTF-8; got %q (bytes %v)",
+			stored, []byte(stored))
+	}
+	// The scrubbed value should retain "kernel" and "author"
+	// substrings with a U+FFFD between (or similar substitution).
+	if !bytes.Contains([]byte(stored), []byte("kernel")) ||
+		!bytes.Contains([]byte(stored), []byte("author")) {
+		t.Errorf("scrub must preserve surrounding valid bytes; got %q", stored)
+	}
+}
+
+func TestUTF8TracerScrubsTxExec(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS aveloxis_test_utf8_tx (
+			id SERIAL PRIMARY KEY,
+			val TEXT NOT NULL
+		)`)
+	if err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS aveloxis_test_utf8_tx`)
+	})
+	_, _ = store.pool.Exec(ctx, `TRUNCATE aveloxis_test_utf8_tx`)
+
+	tx, err := store.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	bad := "tx\xe1\x7a\x71row"
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO aveloxis_test_utf8_tx (val) VALUES ($1)`, bad); err != nil {
+		t.Fatalf("tx.Exec with invalid-UTF8 must succeed under v0.23.5: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var stored string
+	if err := store.pool.QueryRow(ctx,
+		`SELECT val FROM aveloxis_test_utf8_tx LIMIT 1`).Scan(&stored); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !utf8.ValidString(stored) {
+		t.Errorf("tx-written value must be valid UTF-8; got %q", stored)
+	}
+}
+
+func TestUTF8TracerScrubsSendBatch(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS aveloxis_test_utf8_batch (
+			id SERIAL PRIMARY KEY,
+			val TEXT NOT NULL
+		)`)
+	if err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS aveloxis_test_utf8_batch`)
+	})
+	_, _ = store.pool.Exec(ctx, `TRUNCATE aveloxis_test_utf8_batch`)
+
+	// Three queued queries: clean, dirty, clean. Pre-v0.23.5 the
+	// dirty one would have aborted the entire batch.
+	batch := &pgx.Batch{}
+	batch.Queue(`INSERT INTO aveloxis_test_utf8_batch (val) VALUES ($1)`, "clean_a")
+	batch.Queue(`INSERT INTO aveloxis_test_utf8_batch (val) VALUES ($1)`, "dirty\xf6\x6c\xe4row")
+	batch.Queue(`INSERT INTO aveloxis_test_utf8_batch (val) VALUES ($1)`, "clean_c")
+	br := store.pool.SendBatch(ctx, batch)
+	for i := 0; i < 3; i++ {
+		if _, err := br.Exec(); err != nil {
+			t.Errorf("batch exec %d failed: %v", i, err)
+		}
+	}
+	if err := br.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+
+	rows, err := store.pool.Query(ctx,
+		`SELECT val FROM aveloxis_test_utf8_batch ORDER BY id`)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !utf8.ValidString(v) {
+			t.Errorf("batch-written value must be valid UTF-8; got %q", v)
+		}
+		got = append(got, v)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 batched rows, got %d (%v)", len(got), got)
+	}
+}
+
+// TestUTF8TracerProtectsUpsertCommit is the live-bug regression
+// test. The byte 0xb3 (or 0xe1 0x7a 0x71) in cmt_author_name, etc.
+// is exactly the 2026-05-21 kernel-repo case. Pre-v0.23.5 this
+// returned `ERROR: invalid byte sequence for encoding "UTF8"
+// (SQLSTATE 22021)` and the commit was discarded. Post-v0.23.5 the
+// insert succeeds and the persisted strings are valid UTF-8.
+func TestUTF8TracerProtectsUpsertCommit(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	// Seed a repo row so the FK in commits is satisfiable. Use a
+	// negative ID to avoid colliding with operator-imported data.
+	repoID := int64(-191919)
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.repos
+			(repo_id, platform_id, repo_git, repo_owner, repo_name, repo_archived)
+		VALUES ($1, 1, 'https://example.invalid/utf8-fixture', 'utf8-fixture',
+				'utf8-fixture', FALSE)
+		ON CONFLICT (repo_id) DO NOTHING`, repoID); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DELETE FROM aveloxis_data.commits WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(context.Background(),
+			`DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, repoID)
+	})
+	_, _ = store.pool.Exec(ctx,
+		`DELETE FROM aveloxis_data.commits WHERE repo_id = $1`, repoID)
+
+	now := time.Now().UTC()
+	commit := &model.Commit{
+		RepoID:               repoID,
+		Hash:                 "deadbeefcafebabe0000000000000000000000aa",
+		AuthorName:           "L\xe1szlo K\xf6v\xe1cs", // ISO-8859-1
+		AuthorEmail:          "laszlo@example.invalid",
+		AuthorRawEmail:       "laszlo@example.invalid",
+		AuthorDate:           now.Format(time.RFC3339),
+		CommitterName:        "Bj\xf6rn Andersen", // ISO-8859-1
+		CommitterEmail:       "bjorn@example.invalid",
+		CommitterRawEmail:    "bjorn@example.invalid",
+		CommitterDate:        now.Format(time.RFC3339),
+		Filename:             "arch/i386/kernel/cpu\xb3longhaul.c",
+		LinesAdded:           3,
+		LinesRemoved:         1,
+		AuthorPlatformLogin:  "",
+		AuthorAffiliation:    "",
+		CommitterAffiliation: "",
+		CommitterTimestamp:   &now,
+		AuthorTimestamp:      &now,
+		Origin: model.DataOrigin{
+			ToolSource: "aveloxis-facade",
+			DataSource: "git",
+		},
+	}
+
+	if err := store.UpsertCommit(ctx, commit); err != nil {
+		t.Fatalf("UpsertCommit with kernel-style invalid-UTF8 fields "+
+			"must succeed under v0.23.5; got: %v", err)
+	}
+
+	var authorName, committerName, filename string
+	if err := store.pool.QueryRow(ctx, `
+		SELECT cmt_author_name, cmt_committer_name, cmt_filename
+		FROM aveloxis_data.commits
+		WHERE repo_id = $1 AND cmt_commit_hash = $2
+		LIMIT 1`, repoID, commit.Hash).Scan(&authorName, &committerName, &filename); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for label, v := range map[string]string{
+		"author_name":    authorName,
+		"committer_name": committerName,
+		"filename":       filename,
+	} {
+		if !utf8.ValidString(v) {
+			t.Errorf("persisted %s must be valid UTF-8; got %q (bytes %v)",
+				label, v, []byte(v))
+		}
+	}
+}
+
+// TestUTF8TracerProtectsUpsertContributorBatch covers the v0.19.2
+// case (PNG-signature byte 0x89 in cntrb_company) at the batch
+// path. v0.19.2 added explicit safeUTF8 calls in
+// PopulateAffiliations; v0.23.5 makes the same protection happen
+// via the tracer at the broader contributor-upsert layer as
+// belt-and-suspenders.
+func TestUTF8TracerProtectsUpsertContributorBatch(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	login := "utf8-fixture-user"
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DELETE FROM aveloxis_data.contributor_identities WHERE login = $1`, login)
+		_, _ = store.pool.Exec(context.Background(),
+			`DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	})
+	// Pre-cleanup in case of a prior failed run.
+	_, _ = store.pool.Exec(ctx,
+		`DELETE FROM aveloxis_data.contributor_identities WHERE login = $1`, login)
+	_, _ = store.pool.Exec(ctx,
+		`DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+
+	c := model.Contributor{
+		Login:    login,
+		Email:    "fixture@example.invalid",
+		FullName: "Pat\xf6 Smith", // ISO-8859-1
+		Company:  "Acme\x89Corp",  // PNG signature byte mid-string
+		Location: "Z\xfcrich",
+		Identities: []model.ContributorIdentity{{
+			Platform: model.PlatformGitHub,
+			UserID:   99999991,
+			Login:    login,
+		}},
+	}
+	if err := store.UpsertContributorBatch(ctx, []model.Contributor{c}); err != nil {
+		t.Fatalf("UpsertContributorBatch with non-UTF8 profile fields "+
+			"must succeed under v0.23.5; got: %v", err)
+	}
+
+	var fullName, company, location string
+	if err := store.pool.QueryRow(ctx, `
+		SELECT cntrb_full_name, cntrb_company, cntrb_location
+		FROM aveloxis_data.contributors
+		WHERE cntrb_login = $1
+		LIMIT 1`, login).Scan(&fullName, &company, &location); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for label, v := range map[string]string{
+		"full_name": fullName,
+		"company":   company,
+		"location":  location,
+	} {
+		if !utf8.ValidString(v) {
+			t.Errorf("persisted %s must be valid UTF-8; got %q", label, v)
+		}
+	}
+}
+
+// TestUTF8TracerLeavesJSONBValid covers the staging-JSONB path:
+// staging.Stage writes JSON-encoded payloads as JSONB. Invalid
+// UTF-8 inside a JSON string would still be rejected by Postgres
+// JSONB. The tracer scrubs the string parameter (which pgx will
+// pass as a string to the JSONB column).
+func TestUTF8TracerLeavesJSONBValid(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS aveloxis_test_utf8_jsonb (
+			id SERIAL PRIMARY KEY,
+			doc JSONB NOT NULL
+		)`)
+	if err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(context.Background(),
+			`DROP TABLE IF EXISTS aveloxis_test_utf8_jsonb`)
+	})
+	_, _ = store.pool.Exec(ctx, `TRUNCATE aveloxis_test_utf8_jsonb`)
+
+	// JSON-shaped string with a dirty byte inside one of the
+	// fields. Pre-v0.23.5 the JSONB column would have rejected the
+	// whole INSERT with SQLSTATE 22P05.
+	dirty := "{\"name\":\"k\xf6vacs\",\"role\":\"committer\"}"
+	if _, err := store.pool.Exec(ctx,
+		`INSERT INTO aveloxis_test_utf8_jsonb (doc) VALUES ($1::jsonb)`,
+		dirty); err != nil {
+		t.Fatalf("JSONB insert with non-UTF8 must succeed under v0.23.5: %v", err)
+	}
+	var got string
+	if err := store.pool.QueryRow(ctx,
+		`SELECT doc::text FROM aveloxis_test_utf8_jsonb LIMIT 1`).Scan(&got); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("persisted JSONB must be valid UTF-8; got %q", got)
+	}
+}

--- a/internal/db/utf8_tracer_test.go
+++ b/internal/db/utf8_tracer_test.go
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// v0.23.5 — boundary-layer UTF-8 scrub via pgx QueryTracer +
+// BatchTracer.
+//
+// The 2026-05-21 post-v0.23.4 diagnostic on the production log
+// showed 72 occurrences of SQLSTATE 22021 (`invalid byte sequence
+// for encoding "UTF8"`) on `failed to upsert commit` warns, all
+// from Linux-kernel-style repos with Latin-1 author names or file
+// paths containing high-bit bytes (0xb3, 0xe1, 0xf6 — typical
+// of pre-UTF-8 European author names and source files that
+// embedded ISO-8859-1 codepoints in identifiers).
+//
+// v0.19.2 added `safeUTF8` as the primitive and applied it
+// surgically to PopulateAffiliations (after seeing 0x89 PNG-
+// signature bytes in contributor company fields). v0.23.5
+// generalizes that fix: a pgx tracer registered on the conn
+// config scrubs Args (for pool/tx Exec/Query/QueryRow) and
+// QueuedQueries[*].Arguments (for SendBatch) in place. The
+// tracer fires before wire encoding and mutates the caller's
+// args via the shared underlying array. Net effect: every TEXT/
+// VARCHAR/JSONB parameter that flows through pgx is guaranteed
+// valid UTF-8 at write time. Zero call-site changes.
+
+// --- Source-contract pins -------------------------------------
+
+func TestUTF8TracerFileExists(t *testing.T) {
+	_, err := os.Stat("utf8_tracer.go")
+	if err != nil {
+		t.Fatal("expected internal/db/utf8_tracer.go to exist for v0.23.5; " +
+			"see CLAUDE.md `Changes in v0.23.5`. The file holds the " +
+			"utf8ScrubTracer type that scrubs all pgx TEXT params before " +
+			"they hit the wire.")
+	}
+}
+
+func TestUTF8TracerImplementsQueryAndBatchTracer(t *testing.T) {
+	// Compile-time interface satisfaction.
+	var _ pgx.QueryTracer = utf8ScrubTracer{}
+	var _ pgx.BatchTracer = utf8ScrubTracer{}
+}
+
+func TestNewPostgresStoreRegistersUTF8Tracer(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "ConnConfig.Tracer") {
+		t.Error("postgres.go must assign cfg.ConnConfig.Tracer so the " +
+			"utf8ScrubTracer fires on every conn opened by pgxpool. " +
+			"Without this, the tracer code exists but no queries are " +
+			"actually scrubbed.")
+	}
+	if !strings.Contains(code, "utf8ScrubTracer") {
+		t.Error("postgres.go must reference utf8ScrubTracer{} as the " +
+			"tracer value assigned to ConnConfig.Tracer.")
+	}
+}
+
+// --- Behavioral unit tests (no DB) ----------------------------
+
+func TestScrubArgsInPlaceLeavesValidStringsUntouched(t *testing.T) {
+	args := []any{"hello", "world", 42}
+	scrubArgsInPlace(args)
+	if args[0] != "hello" || args[1] != "world" || args[2] != 42 {
+		t.Errorf("valid args must pass through unchanged, got %v", args)
+	}
+}
+
+func TestScrubArgsInPlaceFixesInvalidString(t *testing.T) {
+	// 0xb3 alone is an invalid UTF-8 sequence. This is the exact
+	// byte pattern from the 2026-05-21 kernel-repo log line:
+	// `error="ERROR: invalid byte sequence for encoding \"UTF8\": 0xb3"`.
+	bad := "name\xb3surname"
+	args := []any{bad}
+	scrubArgsInPlace(args)
+	got, ok := args[0].(string)
+	if !ok {
+		t.Fatalf("expected string after scrub, got %T", args[0])
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("scrubbed string must be valid UTF-8, got %q (bytes %v)",
+			got, []byte(got))
+	}
+}
+
+func TestScrubArgsInPlaceHandlesPointerToString(t *testing.T) {
+	bad := "head\xe1\x7a\x71tail"
+	args := []any{&bad}
+	scrubArgsInPlace(args)
+	p, ok := args[0].(*string)
+	if !ok || p == nil {
+		t.Fatalf("expected *string after scrub, got %T", args[0])
+	}
+	if !utf8.ValidString(*p) {
+		t.Errorf("scrubbed *string content must be valid UTF-8, got %q", *p)
+	}
+}
+
+func TestScrubArgsInPlaceLeavesNonStringTypesAlone(t *testing.T) {
+	// Important: BYTEA columns take []byte and may legitimately
+	// contain non-UTF-8 bytes. We must NOT scrub those.
+	rawBytes := []byte{0x89, 0x50, 0x4E, 0x47} // PNG signature start
+	now := time.Now()
+	var nilPtr *string
+	args := []any{rawBytes, 42, 3.14, true, now, nil, nilPtr}
+	scrubArgsInPlace(args)
+	gotBytes, ok := args[0].([]byte)
+	if !ok {
+		t.Fatalf("expected []byte to pass through unchanged, got %T", args[0])
+	}
+	if string(gotBytes) != string(rawBytes) {
+		t.Errorf("[]byte must NOT be scrubbed (BYTEA columns accept raw " +
+			"bytes); the tracer's job is TEXT/VARCHAR/JSONB safety, not " +
+			"to corrupt legitimate binary parameters")
+	}
+	if args[1] != 42 || args[2] != 3.14 || args[3] != true {
+		t.Errorf("scalar args must pass through, got %v", args[:4])
+	}
+	if !args[4].(time.Time).Equal(now) {
+		t.Errorf("time.Time must pass through unchanged")
+	}
+	if args[5] != nil {
+		t.Errorf("nil must pass through")
+	}
+	// A nil *string must not crash, must remain nil-valued.
+	if args[6] == nil {
+		// args[6] holds a typed nil pointer; the interface itself is
+		// non-nil but the pointer it wraps is nil. Both shapes are
+		// acceptable as long as we didn't panic above.
+	}
+}
+
+func TestScrubArgsInPlaceMutatesCallerSlice(t *testing.T) {
+	// The whole point of this design is that the args slice header
+	// is passed by value but the underlying array is shared, so
+	// mutating args[i] in the tracer affects what pgx encodes.
+	// Verify the semantic: a caller-owned slice sees the mutation.
+	bad := "x\xb3y"
+	callerArgs := []any{bad}
+	tracerView := callerArgs // shares underlying array
+	scrubArgsInPlace(tracerView)
+	got, ok := callerArgs[0].(string)
+	if !ok || !utf8.ValidString(got) {
+		t.Errorf("caller's slice must see the scrubbed value "+
+			"(shared underlying array); got %v", callerArgs[0])
+	}
+}
+
+func TestTraceQueryStartScrubs(t *testing.T) {
+	bad := "kernel\xb3file"
+	args := []any{1, bad, 2}
+	tr := utf8ScrubTracer{}
+	data := pgx.TraceQueryStartData{SQL: "INSERT INTO t (id, name, n) VALUES ($1,$2,$3)", Args: args}
+	tr.TraceQueryStart(context.Background(), nil, data)
+	got, ok := args[1].(string)
+	if !ok || !utf8.ValidString(got) {
+		t.Errorf("TraceQueryStart must mutate the Args slice in place; "+
+			"got %v (%T)", args[1], args[1])
+	}
+	if args[0] != 1 || args[2] != 2 {
+		t.Errorf("non-string args must pass through unchanged")
+	}
+}
+
+func TestTraceBatchStartScrubsAllQueuedQueries(t *testing.T) {
+	bad1 := "file\xb3a"
+	bad2 := "file\xe1\x7a\x71b"
+	good := "file_c"
+	batch := &pgx.Batch{}
+	batch.Queue("INSERT INTO commits (filename) VALUES ($1)", bad1)
+	batch.Queue("INSERT INTO commits (filename) VALUES ($1)", good)
+	batch.Queue("INSERT INTO commits (filename) VALUES ($1)", bad2)
+	tr := utf8ScrubTracer{}
+	tr.TraceBatchStart(context.Background(), nil, pgx.TraceBatchStartData{Batch: batch})
+
+	for i, qq := range batch.QueuedQueries {
+		if len(qq.Arguments) != 1 {
+			t.Fatalf("queued query %d: expected 1 arg, got %d", i, len(qq.Arguments))
+		}
+		s, ok := qq.Arguments[0].(string)
+		if !ok {
+			t.Errorf("queued query %d: expected string arg, got %T", i, qq.Arguments[0])
+			continue
+		}
+		if !utf8.ValidString(s) {
+			t.Errorf("queued query %d: scrub must have produced valid UTF-8, got %q (bytes %v)",
+				i, s, []byte(s))
+		}
+	}
+	// Confirm the good string survived without alteration.
+	if s, _ := batch.QueuedQueries[1].Arguments[0].(string); s != good {
+		t.Errorf("valid string must pass through batch tracer unchanged, got %q", s)
+	}
+}
+
+func TestUTF8TracerEndMethodsAreNoOps(t *testing.T) {
+	// These shouldn't panic and shouldn't do anything observable;
+	// the contract is "implements the interface, doesn't crash".
+	tr := utf8ScrubTracer{}
+	tr.TraceQueryEnd(context.Background(), nil, pgx.TraceQueryEndData{})
+	tr.TraceBatchQuery(context.Background(), nil, pgx.TraceBatchQueryData{})
+	tr.TraceBatchEnd(context.Background(), nil, pgx.TraceBatchEndData{})
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.23.4"
+var ToolVersion = "0.23.5"


### PR DESCRIPTION
### v0.23.5 — boundary-layer UTF-8 scrub via pgx tracer

  A single utf8ScrubTracer registered on cfg.ConnConfig.Tracer intercepts every query path (pool, tx, batch) and mutates string / *string params in place before wire encoding. ~437 call sites in internal/db/ are now automatically protected with zero per-site changes.

  Mechanism: TraceQueryStart and TraceBatchStart fire before pgx encodes args. The slices passed to the tracer share underlying arrays with the caller's variadic, so mutating in the tracer is visible to the encoder. []byte params are deliberately left alone (BYTEA columns accept any bytes).

  Files:
  - internal/db/utf8_tracer.go — tracer + scrubArgsInPlace
  - internal/db/postgres.go — cfg.ConnConfig.Tracer = utf8ScrubTracer{} before pool creation
  - internal/db/utf8_tracer_test.go — 11 unit tests
  - internal/db/utf8_tracer_integration_test.go — 6 integration tests gated on AVELOXIS_TEST_DB
  - internal/db/version.go — 0.23.4 → 0.23.5
  - CLAUDE.md — v0.23.5 changelog entry

  Verification against the live local DB: all 17 tests pass against aveloxis_cascade_test using the credentials from aveloxis.runlocal.json. The integration suite exercises the actual production write paths (UpsertCommit with kernel-style Latin-1 fields, UpsertContributorBatch with PNG-signature bytes, raw pool.Exec/tx.Exec/SendBatch, JSONB writes) and confirms persisted values are valid UTF-8.

  Operator deployment:
  go install ./cmd/aveloxis
  aveloxis stop all && aveloxis start all
  # Monitor:  grep -c "SQLSTATE 22021" ~/.aveloxis/aveloxis.log

  The 72-line/sec UTF-8 error bleed on kernel-style repos should flatline after deploy. v0.19.2's surgical safeUTF8 calls and the JSON scrubber stay as belt-and-suspenders — they handle a different SQLSTATE (22P05) than the tracer (22021).