### PR TITLE
Docs/contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Contributing to Aveloxis
+
+Thanks for being interested in contributing. Aveloxis is a Go reimplementation of the [Augur](https://github.com/chaoss/augur) community-health data pipeline; it collects, stores, and analyzes data from GitHub and GitLab (and any new platform someone wants to add).
+
+This file is a short orientation. The real contributor handbook lives in [`docs/contributing/`](docs/contributing/) — start there.
+
+## Quick start
+
+```bash
+git clone https://github.com/aveloxis/aveloxis
+cd aveloxis
+go build ./...
+go test ./...
+```
+
+That's enough to verify your environment. To run the binary or write code against a real database, follow [`docs/contributing/development-setup.md`](docs/contributing/development-setup.md).
+
+## Where to start reading
+
+- **New to the codebase?** Read [`docs/architecture/overview.md`](docs/architecture/overview.md) and [`CLAUDE.md`](CLAUDE.md) (the latter is dense but it's the canonical record of every architectural decision).
+- **Want to fix a bug?** Pick one from [GitHub issues](https://github.com/aveloxis/aveloxis/issues). Open a discussion if you're unsure about the approach.
+- **Want to add a feature?** Open an issue first to discuss scope. Then follow the relevant chapter in [`docs/contributing/`](docs/contributing/).
+- **Want to add a new data source (e.g. Bugzilla, Gitea, Forgejo)?** Read [`docs/contributing/adding-a-platform.md`](docs/contributing/adding-a-platform.md) — that's the worked example.
+
+## Contributor handbook chapters
+
+The full guide is in [`docs/contributing/`](docs/contributing/):
+
+| Chapter | What it covers |
+|---|---|
+| [README.md](docs/contributing/README.md) | Index + how the project is laid out |
+| [development-setup.md](docs/contributing/development-setup.md) | Local PostgreSQL, `aveloxis.runlocal.json`, first build + test |
+| [code-conventions.md](docs/contributing/code-conventions.md) | SPDX headers, file/package layout, error handling, slog, version bumps, commit style |
+| [testing.md](docs/contributing/testing.md) | TDD discipline, source-contract tests, `AVELOXIS_TEST_DB` integration tier, `data-test` harness |
+| [schema-migrations.md](docs/contributing/schema-migrations.md) | `addColumnIfMissing`, `execMigrationStep`, fail-closed contract, backfill idempotency |
+| [adding-a-platform.md](docs/contributing/adding-a-platform.md) | **Bugzilla case study** — every file to touch, every wire to thread |
+| [adding-a-rest-endpoint.md](docs/contributing/adding-a-rest-endpoint.md) | New REST endpoint in `internal/api` |
+| [adding-a-collection-phase.md](docs/contributing/adding-a-collection-phase.md) | Where new phases plug into the staged pipeline |
+| [adding-a-visualization.md](docs/contributing/adding-a-visualization.md) | New chart/panel in the web GUI |
+
+## Ground rules
+
+These are the non-negotiables. The handbook chapters go deep on the rationale.
+
+1. **Test-driven development.** Write a failing test first, then implement, then verify. No exceptions for "trivial" changes — they're the ones that bite. See [`testing.md`](docs/contributing/testing.md).
+2. **Bump the version on every change.** `internal/db/version.go` is the single source of truth. The version appears in `tool_version` columns across all tables and in SBOMs. See [`code-conventions.md`](docs/contributing/code-conventions.md).
+3. **CLAUDE.md is the canonical record.** Add a changelog entry under `## Current Status` for any user-visible behavior change. Future contributors (and the AI agents that help maintain the project) read this to understand why decisions were made.
+4. **No emojis in code or commit messages** unless explicitly requested by the user/operator. Markdown docs follow the same convention.
+5. **Everything that errors should be logged.** Silent failures cost us hours of operator triage time. See `level=ERROR` patterns in existing code.
+6. **GitHub and GitLab parity where possible.** Every feature targeting one platform should at least be considered for the other; if it isn't possible, document the gap in the README and the relevant docs page. See [`docs/architecture/platform-layer.md`](docs/architecture/platform-layer.md).
+7. **Edge cases get tests.** "I'll add tests later" tests rarely arrive.
+
+## Getting help
+
+- **Bug reports / feature requests:** [GitHub issues](https://github.com/aveloxis/aveloxis/issues).
+- **Architectural questions:** open a discussion in [GitHub Discussions](https://github.com/aveloxis/aveloxis/discussions) or tag an existing issue with `discussion`.
+- **Anything else:** the maintainers are Sean Goggins (University of Missouri) and Derek Howard. Reach via the channels listed in the README.
+
+## License
+
+By contributing, you agree your work is licensed under the MIT license (see [`LICENSE`](LICENSE)).

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Contributing to Aveloxis
+
+This is the contributor handbook. The root [`CONTRIBUTING.md`](../../CONTRIBUTING.md) is a short orientation pointer; the chapters here are where the real material lives.
+
+## What Aveloxis is
+
+A Go reimplementation of [Augur](https://github.com/chaoss/augur), the community-health data collection pipeline used by CHAOSS metrics consumers like [8Knot](https://github.com/oss-aspen/8Knot). Aveloxis collects from GitHub and GitLab APIs, parses git logs, and stores everything in PostgreSQL with full Augur schema parity (108+ tables across two schemas). It adds features Augur lacks: staged collection for 400K+ repo fleets, deterministic contributor IDs, dead-repo sidelining, SBOM generation, OpenSSF Scorecard integration, vulnerability scanning, interactive visualizations, and a web GUI with OAuth.
+
+If you're new to the codebase, read these in order before touching code:
+
+1. [`docs/architecture/overview.md`](../architecture/overview.md) — the architecture in one page
+2. [`docs/architecture/staged-pipeline.md`](../architecture/staged-pipeline.md) — how a single repo's data flows from API to database
+3. [`docs/architecture/platform-layer.md`](../architecture/platform-layer.md) — the GitHub/GitLab abstraction
+4. [`CLAUDE.md`](../../CLAUDE.md) — every architectural decision, ordered newest-first. Dense, but it's the project's canonical memory.
+
+## How the codebase is laid out
+
+```
+aveloxis/
+├── cmd/aveloxis/         # CLI entry point (cobra). All subcommands live here.
+├── internal/
+│   ├── api/              # REST API (port :8383). Charts and external consumers.
+│   ├── collector/        # Per-repo collection pipeline (staged, facade, analysis, scancode, etc.)
+│   ├── config/           # aveloxis.json parsing
+│   ├── db/               # PostgreSQL store. Schema, migrations, upserts, queries.
+│   │   └── schema.sql    # Source of truth for table definitions.
+│   ├── importers/        # Apache/CNCF foundation imports.
+│   ├── mailer/           # Gmail SMTP for transactional emails.
+│   ├── model/            # Platform-agnostic data types shared between GitHub/GitLab.
+│   ├── monitor/          # Monitoring dashboard (port :5555).
+│   ├── platform/         # GitHub + GitLab API abstraction.
+│   │   ├── github/       # GitHub-specific implementation of platform.Client.
+│   │   ├── gitlab/       # GitLab-specific implementation.
+│   │   └── platform.go   # The Client interface and shared types.
+│   ├── scheduler/        # Worker pool, queue processing, periodic tasks.
+│   └── web/              # Web GUI (port :8080). OAuth, groups, visualizations.
+├── docs/                 # ReadTheDocs source (this file lives here).
+└── scripts/              # SPDX header backfill, etc.
+```
+
+Every Go file carries an SPDX header (enforced by a tripwire test in `scripts/`). See [`code-conventions.md`](code-conventions.md).
+
+## Chapters
+
+### Foundation (read before doing anything)
+
+- [`development-setup.md`](development-setup.md) — get a local PostgreSQL, build the binary, run the test suite, set up `aveloxis.runlocal.json`
+- [`code-conventions.md`](code-conventions.md) — SPDX headers, file/package layout, error handling, slog, version bumping, commit style
+- [`testing.md`](testing.md) — TDD discipline, source-contract pattern, integration tier via `AVELOXIS_TEST_DB`, the `data-test` harness for cross-version verification
+
+### Extending Aveloxis
+
+- [`schema-migrations.md`](schema-migrations.md) — adding columns, indexes, backfills; fail-closed contract; integration-test recipe
+- [`adding-a-platform.md`](adding-a-platform.md) — **the big one.** Add Bugzilla / Gitea / Forgejo / SourceHut / whatever else. Concrete walkthrough with code skeletons.
+- [`adding-a-rest-endpoint.md`](adding-a-rest-endpoint.md) — expose new data through the REST API
+- [`adding-a-collection-phase.md`](adding-a-collection-phase.md) — plug a new phase into the staged pipeline (analysis, SBOM, vulnerability scan are all phases)
+- [`adding-a-visualization.md`](adding-a-visualization.md) — new Chart.js panel on the repo detail or comparison page
+
+## What to read for a given task
+
+| You want to... | Start here |
+|---|---|
+| Fix a bug | [`testing.md`](testing.md), then the relevant package's existing tests |
+| Add a column to a table | [`schema-migrations.md`](schema-migrations.md) |
+| Add a new endpoint or chart | The relevant chapter above |
+| Add a whole new data source | [`adding-a-platform.md`](adding-a-platform.md) |
+| Understand why something was done a certain way | [`CLAUDE.md`](../../CLAUDE.md) (search for the relevant version) |
+| Run aveloxis locally | [`development-setup.md`](development-setup.md) |
+
+## The single-most-important rule
+
+**Bump `internal/db/version.go` on every code change.** Feature, bugfix, refactor — every change. The version is the only way operators (and the `data-test` harness) can tell two versions of aveloxis apart. CHANGELOG entries (in `CLAUDE.md`'s `## Current Status` section) reference the version, schemas tag rows with `tool_version = db.ToolVersion`, SBOMs embed it. Forgetting this breaks everything downstream.
+
+See [`code-conventions.md`](code-conventions.md) for the version-bump checklist.

--- a/docs/contributing/adding-a-collection-phase.md
+++ b/docs/contributing/adding-a-collection-phase.md
@@ -1,0 +1,281 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Adding a collection phase
+
+The aveloxis collection pipeline is a sequence of phases, each owning a piece of the per-repo data graph. This chapter explains the phase model and walks through adding a new one.
+
+## The pipeline shape
+
+Per repo, the scheduler runs phases roughly in this order:
+
+```
+1. Prelim         — redirect/dead repo detection (collector/prelim.go)
+2. Staged         — API data → JSONB staging → relational tables (collector/staged.go)
+                     Sub-phases inside staged:
+                       0. Repo metadata (repo_info)
+                       1. Contributors
+                       2. Issues (with labels + assignees)
+                       3. PRs (with labels, assignees, reviewers, reviews, commits, files, meta)
+                       4. Events (issue + PR timelines)
+                       5. Messages (comments)
+                       6. Releases
+3. Facade         — bare git clone + git log walk (collector/facade.go)
+4. Analysis       — dependency scan, libyear, scc complexity (collector/analysis.go)
+4b. Scorecard     — OpenSSF Scorecard (collector/scorecard.go)
+5. Commit Resolution — resolve git authors to platform users (collector/commit_resolver.go)
+6. SBOM           — CycloneDX + SPDX generation (collector/sbom.go)
+7. Vulnerability  — OSV.dev batch API (collector/vulnerability.go)
+```
+
+The scancode phase (license/copyright scanning) runs in a separate dedicated worker pool, NOT inline in this pipeline — see [`docs/architecture/scancode.md`](../architecture/scancode.md) for why.
+
+## When to add a phase vs extend an existing one
+
+**Add a phase when:**
+
+- The work needs to happen at a specific point in the lifecycle (after some phases, before others).
+- It has its own error handling, its own retry / backoff, its own "skip cleanly" semantic.
+- The output goes into its own set of tables (or its own columns) that don't overlap with existing phases.
+
+**Extend an existing phase when:**
+
+- You're adding a column to data the existing phase already collects (a new field on `repo_info`, a new attribute on issues).
+- You're tweaking the SQL or the API call shape.
+- The work happens in the same logical step.
+
+Example of correct phase addition: the v0.21.0 scancode worker pool. It's separate from analysis because it has its own cadence (180-day default vs every-cycle), its own concurrency (decoupled pool vs inline), and its own recovery semantics (PID-based orphan recovery).
+
+Example of correct extension: v0.23.0's repo-metadata backfill (description, primary_language, languages). It augments `FetchRepoInfo` rather than creating a new phase, because the data lives in `repo_info` (already populated by Phase 0).
+
+## Patterns by phase type
+
+### "Per-repo, inline, runs every cycle"
+
+Goes inside the staged pipeline. Add a method to `StagedCollector` that takes the staging writer, owner, repo, since timestamp, and the result-tracking struct. Call it from `collectSequential` or `collectParallel` at the right phase position.
+
+Template:
+
+```go
+// internal/collector/staged.go — add as a new method
+func (sc *StagedCollector) collectThings(ctx context.Context, sw *db.StagingWriter,
+        owner, repo string, since time.Time, result *CollectResult) {
+
+    for thing, err := range sc.client.ListThings(ctx, owner, repo, since) {
+        if err != nil {
+            if isOptionalEndpointSkip(err) {
+                sc.logger.Info("things endpoint unavailable, skipping",
+                    "owner", owner, "repo", repo, "error", err)
+                return  // not fatal — platform doesn't support this
+            }
+            sc.logger.Warn("list things failed",
+                "owner", owner, "repo", repo, "error", err)
+            result.Errors = append(result.Errors, err)
+            return
+        }
+        if err := sw.Stage(ctx, db.EntityThing, db.StagedRow{
+            RepoID: result.RepoID,
+            Data:   mustMarshal(thing),
+        }); err != nil {
+            sc.logger.Warn("stage thing failed",
+                "owner", owner, "repo", repo, "error", err)
+            result.Errors = append(result.Errors, err)
+            return
+        }
+        result.ThingsCount++
+    }
+}
+```
+
+Call from `collectSequential`:
+
+```go
+sc.collectThings(ctx, sw, owner, repo, since, result)
+```
+
+The staging writer batches inserts; you don't need to flush yourself. The downstream `Processor.ProcessRepo` handles relational writes.
+
+If the phase produces a NEW entity type, you'll need to:
+
+1. Add `db.EntityThing` constant.
+2. Add a corresponding row processor in `internal/db/processor.go` that reads staging rows of that type and INSERTs into the relational table.
+3. Add the relational table to `schema.sql` (see [`schema-migrations.md`](schema-migrations.md)).
+
+### "Per-repo, runs after facade (needs git clone)"
+
+Goes in `internal/collector/analysis.go` or alongside it as a sibling file. Pattern:
+
+```go
+// internal/collector/my_analysis.go
+type MyAnalyzer struct {
+    store  *db.PostgresStore
+    logger *slog.Logger
+}
+
+func NewMyAnalyzer(store *db.PostgresStore, logger *slog.Logger) *MyAnalyzer {
+    return &MyAnalyzer{store: store, logger: logger}
+}
+
+func (a *MyAnalyzer) AnalyzeRepo(ctx context.Context, repoID int64, repo *model.Repo, cloneDir string) error {
+    // cloneDir is the path to the bare clone the facade phase produced.
+    // For full-clone analysis, you'll need to do your own `git clone` of cloneDir
+    // into a temp directory.
+
+    // Do the analysis...
+    result := /* ... */
+
+    // Write to the database.
+    return a.store.SaveMyAnalysis(ctx, repoID, result)
+}
+```
+
+Wire in `scheduler.go`'s `runFacadeAndAnalysis` after the existing analysis call.
+
+### "Background, runs on a periodic ticker, fleet-wide"
+
+Like the v0.18.29 `runEnrichment` or v0.19.2 `runSearchResolve` or v0.22.4 long-jobs watchdog. These don't have a per-repo phase position — they run on their own schedule and process whatever rows match a query.
+
+Pattern:
+
+```go
+// internal/scheduler/scheduler.go — add the field + ticker
+
+type Scheduler struct {
+    // ...
+    myThingInterval time.Duration
+}
+
+// In Run(), inside the select loop:
+case <-myThingTicker.C:
+    s.runMyThing(ctx)
+```
+
+```go
+// internal/scheduler/my_thing.go — the actual function
+func (s *Scheduler) runMyThing(ctx context.Context) {
+    candidates, err := s.store.GetThingsNeedingMyThing(ctx, batchSize)
+    if err != nil {
+        s.logger.Warn("get my-thing candidates failed", "error", err)
+        return
+    }
+    for _, c := range candidates {
+        if err := s.doMyThing(ctx, c); err != nil {
+            s.logger.Warn("my-thing failed",
+                "id", c.ID, "error", err)
+            // Stamp last_attempted_at unconditionally so the cooldown gate works
+            // (the v0.18.29 / v0.19.2 / v0.20.17 pattern — see CLAUDE.md).
+            _ = s.store.MarkThingAttempted(ctx, c.ID)
+            continue
+        }
+        _ = s.store.MarkThingDone(ctx, c.ID)
+    }
+}
+```
+
+**The cooldown discipline (mandatory):** if your background task has the failure pattern "I tried X, it failed, I'll try again next cycle, it fails again, repeat forever," add a `last_attempted_at TIMESTAMPTZ` column AND a query gate `WHERE last_attempted_at IS NULL OR last_attempted_at < NOW() - cooldown`. Stamp the column on EVERY attempt — success, failure, even network errors. v0.18.29, v0.19.2, and v0.20.17 are all this pattern. CLAUDE.md has the full rationale; don't reinvent it.
+
+Add config knobs:
+
+```go
+// internal/config/config.go — CollectionConfig
+MyThingIntervalMinutes int `json:"my_thing_interval_minutes"`
+MyThingBatchSize       int `json:"my_thing_batch_size"`
+MyThingCooldownDays    int `json:"my_thing_cooldown_days"`
+```
+
+Wire through `scheduler.Config` and `main.go`. The existing `TestConfigurationDocsCoverEveryJSONField` tripwire will fire CI if you forget to document them in `docs/getting-started/configuration.md`.
+
+### "Decoupled worker pool, not in the main pipeline"
+
+Like scancode (v0.21.0). The pattern:
+
+- Dedicated package: `internal/collector/my_worker.go` and friends.
+- Own claim/release lifecycle via `aveloxis_data.repos` columns (`my_locked_at`, `my_locked_pid`, etc.).
+- Crash recovery via boot_id + PID.
+- Cadence gate: a `my_last_run TIMESTAMPTZ` column queried with `IS NULL OR < NOW() - cadence`.
+- Configurable workers + interval + cadence + shutdown grace.
+
+This is heavy infrastructure. Don't reach for it unless you have evidence the work is the wrong shape for the inline pipeline — typically because it's slow enough (multiple minutes per repo) that it would starve other phases. See `docs/architecture/scancode.md` for the full template.
+
+## The staging writer contract
+
+If your phase produces relational data, route it through `db.StagingWriter`. Why:
+
+- Atomic per-repo replacement semantics (the processor truncates+inserts per repo).
+- Batched INSERT (staging buffers 500 rows, then flushes — much faster than per-row INSERT).
+- Idempotency: re-running the phase doesn't produce duplicates.
+
+Pattern:
+
+```go
+sw := db.NewStagingWriter(store, logger)
+defer sw.Flush(ctx)  // CRITICAL — see v0.16.11
+
+for thing, err := range client.ListThings(ctx, owner, repo, since) {
+    // ...
+    sw.Stage(ctx, db.EntityThing, db.StagedRow{...})
+}
+// processor.ProcessRepo(ctx, repoID) drains staging into relational tables
+```
+
+**The v0.16.11 bug**: `StagingWriter.Stage` buffers internally and only auto-flushes at the 500-row threshold. Four call sites in v0.16.10 forgot to call `Flush` at the end, dropping buffered rows. The fix added explicit `Flush` calls. The pattern test `TestStagingWriterCallersFlushBeforeProcess` enforces it.
+
+**Always call `Flush` before `processor.ProcessRepo`.** No exceptions.
+
+## Error handling discipline
+
+Phases must distinguish:
+
+- **Skippable**: 404, 403, 410, 204, NoContent. The endpoint doesn't apply to this repo (issues disabled, permissions, etc.). Use `isOptionalEndpointSkip(err)` and return early WITHOUT appending to `result.Errors`.
+- **Transient**: 502/503/504, retry-exhaustion, GraphQL transient. Already retried by the HTTPClient layer; if it bubbles out, treat as transient — append to errors so `buildOutcome` can decide whether to force-full-recollect on the next cycle.
+- **Fatal**: schema errors, auth errors, programmer errors. Bubble up; the scheduler logs ERROR and the job fails.
+
+The `platform.ClassifyError(err) ErrorClass` helper handles the routing. Use it.
+
+## Testing phases
+
+Unit tests use a mock platform.Client + an in-memory or scratch `PostgresStore`. The harness pattern:
+
+```go
+func TestCollectThings(t *testing.T) {
+    ctx := context.Background()
+    mockClient := &mockPlatformClient{
+        things: []model.Thing{{ID: 1, Name: "alpha"}, {ID: 2, Name: "beta"}},
+    }
+    sc := NewStagedCollectorWithClient(mockClient, store, logger)
+    result := &CollectResult{RepoID: 42}
+    sw := db.NewStagingWriter(store, logger)
+
+    sc.collectThings(ctx, sw, "owner", "repo", time.Time{}, result)
+
+    sw.Flush(ctx)
+    if result.ThingsCount != 2 {
+        t.Errorf("expected 2 things, got %d", result.ThingsCount)
+    }
+}
+```
+
+For integration tests against a real PostgreSQL via `AVELOXIS_TEST_DB`, see [`testing.md`](testing.md).
+
+## Order-of-operations checklist
+
+When adding a phase:
+
+1. **Decide the phase type** (per-repo inline, background ticker, decoupled worker).
+2. **Decide the data model** — new entity type, new columns on existing, new table?
+3. **Write the platform.Client method** if the data comes from an external API (or extend existing).
+4. **Write the failing test.**
+5. **Implement the phase function** following the relevant template above.
+6. **Wire into the scheduler / staged collector** at the right phase position.
+7. **Add config knobs** with the `Interval / BatchSize / Cooldown` pattern if it's a background task.
+8. **Test, document, version-bump, CLAUDE.md entry.**
+
+## A real example to study
+
+Read `internal/scheduler/repo_metadata_backfill.go` (~140 lines) — the v0.23.0 background phase that backfills `repo_description` and `primary_language` on existing rows. It's the cleanest minimal example of the periodic-ticker pattern: config knob, candidate query, per-row processing with continue-on-error, deterministic exit when the candidate set is exhausted.
+
+Then read `internal/collector/scancode_worker.go` (~800 lines) — the v0.21.0 decoupled-worker pattern. Heavier, but it's the canonical example of a phase that needs its own lifecycle.
+
+Between them, you've seen both ends of the phase-design spectrum.

--- a/docs/contributing/adding-a-platform.md
+++ b/docs/contributing/adding-a-platform.md
@@ -1,0 +1,872 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Adding a new platform
+
+This chapter walks through adding a new data source to Aveloxis. It uses **Bugzilla** as the worked example because Bugzilla forces honesty about what does and doesn't fit Aveloxis's existing platform model — it's an issue tracker with no git component, no pull requests, no releases. If you can add Bugzilla, you can add Gitea, Forgejo, SourceHut, Jira, Phabricator, or anything else.
+
+The chapter is long because the work is real. Read it once end-to-end before touching code, then use it as a checklist.
+
+## What "a platform" means in Aveloxis
+
+A platform is a data source that produces structured records about software development activity. Aveloxis already supports three:
+
+| `Platform` enum | ID | What it produces |
+|---|---|---|
+| `PlatformGitHub` | 1 | Repos, issues, PRs, reviews, comments, contributors, releases, commits (via git) |
+| `PlatformGitLab` | 2 | Repos, issues, merge requests, reviews, comments, contributors, releases, commits (via git) |
+| `PlatformGenericGit` | 3 | Git-only — facade walks commits, no API collection |
+
+The existing `platform.Client` interface (defined in `internal/platform/platform.go`) is heavily shaped around "git forge with REST/GraphQL API." It assumes the platform has issues, PRs, contributors, etc. A platform that's missing some of these (Bugzilla has no PRs; Generic Git has no API) must:
+
+1. Implement the interface anyway.
+2. Return empty iterators / nil for the methods that don't apply.
+3. Make sure the scheduler's pipeline skips the phases that depend on those methods returning useful data.
+
+The third point is where the architectural design call lives. We'll get to it.
+
+## Bugzilla — the worked example
+
+[Bugzilla](https://www.bugzilla.org/) is the bug tracker that birthed the open-source bug-tracker genre (1998). It's still actively used by Mozilla, Red Hat, Apache, and a long tail of older projects. Its data model:
+
+| Bugzilla concept | Closest Aveloxis concept | Notes |
+|---|---|---|
+| Product | Repo (or RepoGroup) | A Bugzilla product = a logical project. Like a GitHub repo but no git. |
+| Component | Sub-repo (no clean fit) | A product's sub-area. Aveloxis has no native concept. |
+| Bug | Issue | Maps cleanly. Bug status (NEW/ASSIGNED/RESOLVED) → issue state. |
+| Comment | Message | Maps cleanly. |
+| Bug history event | IssueEvent | Bugzilla logs every field change; map to `issue_events`. |
+| User | Contributor | Bugzilla user_id → contributors. Email primary. |
+| Keyword | IssueLabel | Bugzilla calls them keywords; map to labels. |
+| Assignee | IssueAssignee | Singular in Bugzilla (one assignee per bug); map to a one-element list. |
+| Attachment | (no fit) | Skipped; Aveloxis doesn't store attachments. |
+| Tracking flag | (no fit) | Skipped. |
+| Milestone | Release (loose fit) | Could map; the cleaner choice is "skip releases for Bugzilla." |
+
+**What Bugzilla does NOT have:** git repositories, pull requests, file changes, commits, branches, releases (in the GitHub sense), SBOMs, vulnerabilities (dependency-derived), scancode results, OpenSSF Scorecard.
+
+This means a Bugzilla collector implements roughly 40% of `platform.Client` meaningfully and returns empty results for the rest. That's fine — the scheduler must gate the dependent phases.
+
+## API choice: REST vs XML-RPC
+
+Bugzilla exposes two APIs:
+
+- **XML-RPC** (`/xmlrpc.cgi`) — supported by every Bugzilla 3.4+. The old standard.
+- **REST** (`/rest/bug`, `/rest/user`, etc.) — supported by Bugzilla 5.0+ (2015). JSON, modern.
+
+Go has solid `encoding/xml` but no clean XML-RPC client; you'd want the REST endpoint. The walkthrough below assumes Bugzilla 5.0+. For older Bugzilla instances, you'd need to add XML-RPC encoding/decoding — out of scope here.
+
+Auth: API keys (Bugzilla 5.0+ supports them) or username+password. The Bugzilla key goes in the `X-BUGZILLA-API-KEY` header.
+
+## The end-to-end inventory: what you'll touch
+
+This is the complete list of files a new platform needs. Some are mandatory; some are optional depending on what the platform supports.
+
+### Mandatory
+
+1. **`internal/model/repo.go`** — add `PlatformBugzilla Platform = 4` to the enum + update the `String()` switch + decide on capability predicates (`IsGitOnly` etc.).
+2. **`internal/db/schema.sql`** — add `(4, 'Bugzilla')` to the `aveloxis_data.platforms` seed INSERT.
+3. **`internal/platform/bugzilla/`** — new package implementing `platform.Client`. At minimum:
+   - `client.go` — the `Client` struct, constructor, all interface methods (most return empty iterators).
+   - `repos.go` — `FetchRepoInfo` and `FetchCloneStats` (stubbed; Bugzilla products don't have clone stats).
+   - `issues.go` — `ListIssues`, `ListIssueLabels`, `ListIssueAssignees`, `FetchIssueByNumber`, plus the unified `ListIssuesAndPRs`.
+   - `messages.go` — comment-related methods.
+   - `events.go` — `ListIssueEvents` from bug history.
+   - `users.go` — `ListContributors`, `EnrichContributor`, `SearchUserByEmail`.
+   - `urlparse.go` — `ParseRepoURL` (parses a Bugzilla product URL).
+   - `errors.go` — mapping Bugzilla error codes to `platform.Class*` classifications.
+4. **`internal/scheduler/scheduler.go`** — add `case model.PlatformBugzilla:` to the `selectClient` switch (~line 899); add the relevant capability gate around facade/analysis/SBOM phases (~line 756).
+5. **`cmd/aveloxis/main.go`** — load Bugzilla API keys into a `bugzillaKeys` `*platform.KeyPool`, construct the `bugzilla.Client`, pass it to the scheduler config.
+6. **`internal/db/keys.go`** — already supports arbitrary platform strings via `loadKeysFromTable(table, platform)`. Pass `"bugzilla"` as the platform string. No code change needed unless you want explicit constants.
+7. **`internal/config/config.go`** — add a `BugzillaConfig` block to `Config` (base URL, optionally a list of self-hosted Bugzilla hosts).
+8. **`internal/db/version.go`** — bump.
+9. **`CLAUDE.md`** — `### Changes in vX.Y.0` section documenting the new platform.
+
+### Likely
+
+10. **`internal/web/server.go`** — bulk-paste-URL parsing. If you want operators to be able to paste a Bugzilla product URL into the web GUI and have it routed correctly, the URL parser dispatch needs to recognize Bugzilla URLs.
+11. **`cmd/aveloxis/main.go`** — `add-repo` command needs URL parsing that recognizes Bugzilla.
+12. **`internal/collector/prelim.go`** — Bugzilla products don't 301-redirect on rename; you may need to add a Bugzilla-specific liveness check OR accept that prelim is a no-op for Bugzilla. The latter is fine.
+
+### Optional
+
+13. **OAuth login for the web GUI.** If you want operators to be able to sign in via Bugzilla (most Bugzilla instances don't expose OAuth, so this is rarely useful — but if your target instance does, follow the GitHub/GitLab pattern in `handleGitHubLogin` / `handleGitHubCallback`).
+14. **Source-contract tests** for each piece.
+15. **Integration tests** that exercise a mocked Bugzilla via `httptest.NewServer`.
+
+That's 9 mandatory files, 3 likely, 3 optional. Allocate ~2–3 days for the mandatory work if you've never done it before, ~1 day if you have.
+
+## The capability design call
+
+Aveloxis's existing capability predicate is:
+
+```go
+// internal/model/repo.go
+func (p Platform) IsGitOnly() bool {
+    return p == PlatformGenericGit
+}
+```
+
+The scheduler uses it to gate API collection:
+
+```go
+// internal/scheduler/scheduler.go (~line 756)
+if !repo.Platform.IsGitOnly() {
+    // staged collection (API)
+    client, err := s.selectClient(repo.Platform)
+    // ...
+}
+```
+
+And the facade phase runs unconditionally (every platform gets facade), then the analysis phase runs on every platform with a git clone.
+
+For Bugzilla, you need the inverse gate: "this platform has API data, but no git side." The cleanest extension is a parallel predicate:
+
+```go
+// internal/model/repo.go
+// HasGit returns true if this platform has a git repository to clone and walk.
+// False for API-only platforms like Bugzilla, Jira, Phabricator.
+func (p Platform) HasGit() bool {
+    switch p {
+    case PlatformGitHub, PlatformGitLab, PlatformGenericGit:
+        return true
+    case PlatformBugzilla:
+        return false
+    default:
+        return false  // unknown platforms are safest treated as API-only
+    }
+}
+```
+
+Then the scheduler gates facade + analysis + SBOM + scancode + scorecard + vulnerability scanning behind `if repo.Platform.HasGit()`. Add this gate AROUND each phase's call site. About 6 sites in `scheduler.go` and `collector/collector.go`.
+
+The existing `IsGitOnly` stays; it's specifically "this platform ONLY has git, no API." Bugzilla is the mirror: API only, no git.
+
+If you anticipate more platforms with mixed capabilities (a platform that has issues but no PRs, say), consider extending `Platform` to a `Capabilities()` method returning a struct. For just Bugzilla, the parallel-predicate approach is fine — don't refactor for a hypothetical future.
+
+## Step-by-step walkthrough
+
+### Step 1 — declare the platform
+
+```go
+// internal/model/repo.go
+const (
+    PlatformGitHub     Platform = 1
+    PlatformGitLab     Platform = 2
+    PlatformGenericGit Platform = 3
+    PlatformBugzilla   Platform = 4   // new
+)
+
+func (p Platform) String() string {
+    switch p {
+    case PlatformGitHub:
+        return "GitHub"
+    case PlatformGitLab:
+        return "GitLab"
+    case PlatformGenericGit:
+        return "Git"
+    case PlatformBugzilla:
+        return "Bugzilla"
+    default:
+        return "Unknown"
+    }
+}
+
+// HasGit returns true if this platform has a git repository.
+// False for API-only platforms (Bugzilla, future Jira, etc.).
+func (p Platform) HasGit() bool {
+    switch p {
+    case PlatformGitHub, PlatformGitLab, PlatformGenericGit:
+        return true
+    default:
+        return false
+    }
+}
+```
+
+### Step 2 — seed the database
+
+```sql
+-- internal/db/schema.sql
+INSERT INTO aveloxis_data.platforms (platform_id, platform_name)
+VALUES (1, 'GitHub'), (2, 'GitLab'), (3, 'Git'), (4, 'Bugzilla')
+ON CONFLICT DO NOTHING;
+```
+
+The migration code applies this on every `aveloxis migrate` because of `ON CONFLICT DO NOTHING`. Operators with existing databases get the row inserted on their next migrate.
+
+If you want to be belt-and-suspenders explicit, add an `execMigrationStep`:
+
+```go
+// internal/db/migrate.go — inside RunMigrations
+execMigrationStep(ctx, pg, logger, &errs,
+    "v0.24.0 seed Bugzilla platform row",
+    `INSERT INTO aveloxis_data.platforms (platform_id, platform_name)
+     VALUES (4, 'Bugzilla') ON CONFLICT DO NOTHING`)
+```
+
+Idempotent via `ON CONFLICT DO NOTHING`.
+
+### Step 3 — package skeleton
+
+```
+internal/platform/bugzilla/
+├── client.go           # Client struct + constructor + Platform() + interface satisfaction
+├── repos.go            # FetchRepoInfo (Bugzilla product metadata)
+├── issues.go           # ListIssues, ListIssueLabels, ListIssueAssignees, FetchIssueByNumber, ListIssuesAndPRs
+├── messages.go         # ListIssueComments + the per-issue variants
+├── events.go           # ListIssueEvents from Bugzilla bug history
+├── prs_noop.go         # No-op implementations of every PR-related method
+├── releases_noop.go    # No-op ListReleases
+├── users.go            # ListContributors, EnrichContributor, SearchUserByEmail
+├── urlparse.go         # ParseRepoURL("https://bugzilla.example.com/show_bug.cgi?id=X" or product URL)
+├── errors.go           # ClassifyError mapping for Bugzilla-specific responses
+├── client_test.go      # Source-contract tests pinning interface satisfaction
+└── issues_test.go      # httptest-driven behavioral tests
+```
+
+### Step 4 — Client struct + interface satisfaction
+
+```go
+// internal/platform/bugzilla/client.go
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Package bugzilla implements platform.Client for Bugzilla bug tracker
+// instances. Targets Bugzilla 5.0+ REST API.
+//
+// Capabilities supported:
+//   - Bugs (-> issues), bug history (-> issue events), comments (-> messages),
+//     users (-> contributors), keywords (-> issue labels), assignees.
+//
+// Capabilities NOT supported (return empty / nil):
+//   - Pull requests, releases, file changes, contributor identity from git,
+//     OAuth login. Bugzilla has none of these.
+//
+// The scheduler skips facade, analysis, scancode, SBOM, vulnerability
+// scanning, and scorecard for repos with PlatformBugzilla, gated by
+// model.Platform.HasGit() == false.
+package bugzilla
+
+import (
+    "context"
+    "iter"
+    "log/slog"
+    "time"
+
+    "github.com/aveloxis/aveloxis/internal/model"
+    "github.com/aveloxis/aveloxis/internal/platform"
+)
+
+// Client implements platform.Client for Bugzilla.
+type Client struct {
+    baseURL string                // e.g. "https://bugzilla.mozilla.org"
+    keys    *platform.KeyPool     // API keys (Bugzilla 5.0+); use nil for unauthenticated read-only access
+    http    *platform.HTTPClient
+    logger  *slog.Logger
+}
+
+// New constructs a Bugzilla client. baseURL is the Bugzilla instance root
+// (no trailing slash). If keys is nil, requests are unauthenticated —
+// works for public bugs on public instances, rate-limited harshly.
+func New(baseURL string, keys *platform.KeyPool, logger *slog.Logger) *Client {
+    return &Client{
+        baseURL: baseURL,
+        keys:    keys,
+        http:    platform.NewHTTPClient(keys, logger, platform.AuthBugzilla),
+        logger:  logger,
+    }
+}
+
+func (c *Client) Platform() model.Platform {
+    return model.PlatformBugzilla
+}
+
+// OnPermanentRedirect is a no-op for Bugzilla — Bugzilla products don't
+// 301-redirect on rename; admins update DNS at the host level if needed.
+// The scheduler installs the hook unconditionally on every platform.Client;
+// we accept the call and ignore.
+func (c *Client) OnPermanentRedirect(_ func(from, to string)) {}
+
+// Compile-time assertion that *Client satisfies platform.Client.
+var _ platform.Client = (*Client)(nil)
+```
+
+### Step 5 — auth style
+
+The existing `platform.AuthStyle` enum is GitHub-only and GitLab-only. Add a Bugzilla variant:
+
+```go
+// internal/platform/auth.go (or wherever AuthStyle lives)
+type AuthStyle int
+const (
+    AuthGitHub AuthStyle = iota
+    AuthGitLab
+    AuthBugzilla   // sends X-BUGZILLA-API-KEY: <key>
+)
+```
+
+And extend the HTTPClient's request preparation:
+
+```go
+// internal/platform/httpclient.go — wherever the auth header is set
+switch c.authStyle {
+case AuthGitHub:
+    req.Header.Set("Authorization", "token "+key)
+case AuthGitLab:
+    req.Header.Set("PRIVATE-TOKEN", key)
+case AuthBugzilla:
+    req.Header.Set("X-BUGZILLA-API-KEY", key)
+}
+```
+
+### Step 6 — URL parsing
+
+```go
+// internal/platform/bugzilla/urlparse.go
+import "fmt"
+import "net/url"
+import "strings"
+
+// ParseRepoURL converts a Bugzilla product URL into ("", productName, nil).
+// Bugzilla has no owner concept at the product level — the instance is
+// the owner.
+//
+//   "https://bugzilla.mozilla.org/buglist.cgi?product=Firefox" -> ("", "Firefox")
+//   "https://bugzilla.mozilla.org/describecomponents.cgi?product=Toolkit" -> ("", "Toolkit")
+func (c *Client) ParseRepoURL(rawURL string) (owner, repo string, err error) {
+    u, err := url.Parse(rawURL)
+    if err != nil {
+        return "", "", fmt.Errorf("parsing URL: %w", err)
+    }
+    q := u.Query()
+    product := q.Get("product")
+    if product == "" {
+        return "", "", fmt.Errorf("URL has no product parameter: %s", rawURL)
+    }
+    // owner is empty for Bugzilla; we use just the product name.
+    return "", strings.TrimSpace(product), nil
+}
+```
+
+The scheduler dispatches on URL → platform; you'll need to wire that in `internal/web/server.go`'s URL-router and `cmd/aveloxis/main.go`'s `add-repo` command. Pattern:
+
+```go
+// internal/web/server.go (and add-repo) — URL dispatch
+func detectPlatform(url string) model.Platform {
+    switch {
+    case strings.Contains(url, "github.com"):
+        return model.PlatformGitHub
+    case strings.Contains(url, "gitlab.com"):
+        return model.PlatformGitLab
+    case strings.Contains(url, "bugzilla"):  // very loose; tighten for production
+        return model.PlatformBugzilla
+    default:
+        return model.PlatformGenericGit
+    }
+}
+```
+
+In practice, operators will configure a list of Bugzilla host patterns in `aveloxis.json` (similar to `gitlab_hosts`) so the dispatch is deterministic.
+
+### Step 7 — implement the meaningful methods
+
+The methods that DO apply to Bugzilla:
+
+#### `FetchRepoInfo` — Bugzilla product metadata
+
+```go
+// internal/platform/bugzilla/repos.go
+func (c *Client) FetchRepoInfo(ctx context.Context, _, product string) (*model.RepoInfo, error) {
+    // GET /rest/product?names=<product>&include_fields=name,description,is_active,bug_count,...
+    var resp struct {
+        Products []struct {
+            Name        string `json:"name"`
+            Description string `json:"description"`
+            IsActive    bool   `json:"is_active"`
+            // Bug count needs a separate /rest/bug?product=X&count_only=true call.
+        } `json:"products"`
+    }
+    url := fmt.Sprintf("%s/rest/product?names=%s&include_fields=name,description,is_active",
+        c.baseURL, url.QueryEscape(product))
+    if err := c.http.GetJSON(ctx, url, &resp); err != nil {
+        return nil, fmt.Errorf("fetch product: %w", err)
+    }
+    if len(resp.Products) == 0 {
+        return nil, platform.ErrNotFound
+    }
+    p := resp.Products[0]
+
+    // Fetch open bug count via a separate /rest/bug count query.
+    bugCount, _ := c.fetchOpenBugCount(ctx, product)
+
+    return &model.RepoInfo{
+        Name:        p.Name,
+        Description: p.Description,
+        Archived:    !p.IsActive,
+        IssuesCount: bugCount,
+        // Bugzilla doesn't expose stars/watchers/forks/contributors-count.
+        // Leave at zero; the README documents the gap.
+    }, nil
+}
+```
+
+#### `ListIssues` — bugs as issues
+
+```go
+// internal/platform/bugzilla/issues.go
+func (c *Client) ListIssues(ctx context.Context, _, product string, since time.Time) iter.Seq2[model.Issue, error] {
+    return func(yield func(model.Issue, error) bool) {
+        // GET /rest/bug?product=<product>&last_change_time=<since>&include_fields=...
+        offset := 0
+        for {
+            params := url.Values{}
+            params.Set("product", product)
+            params.Set("limit", "500")
+            params.Set("offset", strconv.Itoa(offset))
+            if !since.IsZero() {
+                params.Set("last_change_time", since.Format(time.RFC3339))
+            }
+            params.Set("include_fields", "id,summary,status,resolution,assigned_to,reporter,creation_time,last_change_time,keywords")
+
+            var resp struct {
+                Bugs []bugzillaBug `json:"bugs"`
+            }
+            apiURL := fmt.Sprintf("%s/rest/bug?%s", c.baseURL, params.Encode())
+            if err := c.http.GetJSON(ctx, apiURL, &resp); err != nil {
+                yield(model.Issue{}, fmt.Errorf("list bugs at offset %d: %w", offset, err))
+                return
+            }
+            if len(resp.Bugs) == 0 {
+                return  // pagination complete
+            }
+            for _, b := range resp.Bugs {
+                if !yield(b.toIssue(product), nil) {
+                    return
+                }
+            }
+            if len(resp.Bugs) < 500 {
+                return
+            }
+            offset += 500
+        }
+    }
+}
+
+type bugzillaBug struct {
+    ID               int       `json:"id"`
+    Summary          string    `json:"summary"`
+    Status           string    `json:"status"`
+    Resolution       string    `json:"resolution"`
+    AssignedTo       string    `json:"assigned_to"`
+    Reporter         string    `json:"reporter"`
+    CreationTime     time.Time `json:"creation_time"`
+    LastChangeTime   time.Time `json:"last_change_time"`
+    Keywords         []string  `json:"keywords"`
+}
+
+func (b bugzillaBug) toIssue(product string) model.Issue {
+    state := "open"
+    if b.Status == "RESOLVED" || b.Status == "VERIFIED" || b.Status == "CLOSED" {
+        state = "closed"
+    }
+    return model.Issue{
+        Number:     b.ID,
+        Title:      b.Summary,
+        State:      state,
+        ReporterLogin: b.Reporter,
+        // ... rest of the mapping
+        CreatedAt:  b.CreationTime,
+        UpdatedAt:  b.LastChangeTime,
+    }
+}
+```
+
+Patterns to follow:
+
+- Streaming via `iter.Seq2[T, error]`. Yield one item at a time so the staged collector can flush in batches without buffering the whole result set.
+- Pagination via `offset` + fixed `limit`. Bugzilla's REST API supports it natively. Stop when the response is shorter than the limit.
+- `since` filter via `last_change_time`. Pass `time.Time` formatted as RFC3339.
+- Map Bugzilla statuses to Aveloxis's `open`/`closed` state. `RESOLVED`, `VERIFIED`, `CLOSED` are closed; everything else is open.
+- Error wrapping with context (offset number) so failures are actionable.
+
+#### `ListIssuesAndPRs` — the unified phase-2 enumerator
+
+```go
+func (c *Client) ListIssuesAndPRs(ctx context.Context, owner, product string, since time.Time) (*platform.IssueAndPRBatch, error) {
+    batch := &platform.IssueAndPRBatch{
+        Issues:         []model.Issue{},
+        PullRequests:   []model.PullRequest{},  // always empty for Bugzilla
+        IssueComments:  []platform.MessageWithRef{},  // populate if you choose inline-comment mode
+        IssueLabels:    nil,  // skip the per-issue label fetch optimization
+        IssueAssignees: nil,
+    }
+    for issue, err := range c.ListIssues(ctx, owner, product, since) {
+        if err != nil {
+            return batch, err  // return partial + error so the staged collector can stage what we got
+        }
+        batch.Issues = append(batch.Issues, issue)
+    }
+    return batch, nil
+}
+```
+
+Returning the batch with an error lets the staged collector stage partial results (the v0.20.9 pattern — see [`docs/contributing/adding-a-collection-phase.md`](adding-a-collection-phase.md)).
+
+#### `ListIssueComments` — Bugzilla bug comments
+
+Bugzilla's REST API for comments: `GET /rest/bug/comment?ids=<bug_id>&new_since=<since>`. There's no fleet-wide "all comments since X" endpoint — you have to enumerate bugs first.
+
+The pattern: implement `ListCommentsForIssue` (per-issue), and have `ListIssueComments` (fleet-wide) iterate over `ListIssues` and yield comments per bug. Less efficient than GitHub's repo-wide `/issues/comments` endpoint, but Bugzilla has no equivalent.
+
+#### `ListContributors` — Bugzilla users
+
+```go
+func (c *Client) ListContributors(ctx context.Context, _, product string) iter.Seq2[model.Contributor, error] {
+    return func(yield func(model.Contributor, error) bool) {
+        // Bugzilla has no "list users who touched this product" endpoint.
+        // The pragmatic approach: enumerate the most recent N bugs, harvest
+        // unique reporter + assigned_to fields, then call /rest/user?names=
+        // for each to fetch profile data.
+        seen := make(map[string]bool)
+        for issue, err := range c.ListIssues(ctx, "", product, time.Time{}) {
+            if err != nil {
+                yield(model.Contributor{}, err)
+                return
+            }
+            for _, login := range []string{issue.ReporterLogin, issue.AssigneeLogin} {
+                if login == "" || seen[login] {
+                    continue
+                }
+                seen[login] = true
+                contrib, enrichErr := c.EnrichContributor(ctx, login)
+                if enrichErr != nil {
+                    continue  // skip; not fatal
+                }
+                if !yield(*contrib, nil) {
+                    return
+                }
+            }
+        }
+    }
+}
+
+func (c *Client) EnrichContributor(ctx context.Context, login string) (*model.Contributor, error) {
+    var resp struct {
+        Users []struct {
+            ID       int64  `json:"id"`
+            Name     string `json:"name"`
+            Email    string `json:"email"`
+            RealName string `json:"real_name"`
+        } `json:"users"`
+    }
+    apiURL := fmt.Sprintf("%s/rest/user?names=%s", c.baseURL, url.QueryEscape(login))
+    if err := c.http.GetJSON(ctx, apiURL, &resp); err != nil {
+        return nil, fmt.Errorf("enrich user: %w", err)
+    }
+    if len(resp.Users) == 0 {
+        return nil, platform.ErrNotFound
+    }
+    u := resp.Users[0]
+    return &model.Contributor{
+        Login:    u.Name,
+        Email:    u.Email,
+        FullName: u.RealName,
+        Identities: []model.ContributorIdentity{{
+            Platform: model.PlatformBugzilla,
+            UserID:   u.ID,
+            Login:    u.Name,
+            Email:    u.Email,
+        }},
+    }, nil
+}
+```
+
+The deterministic UUID: `PlatformUUID(int(model.PlatformBugzilla), u.ID)` works as-is because the helper accepts any platform ID byte. No code change needed.
+
+#### `SearchUserByEmail` — Bugzilla user lookup
+
+```go
+func (c *Client) SearchUserByEmail(ctx context.Context, email string) (login string, userID int64, err error) {
+    var resp struct {
+        Users []struct {
+            ID    int64  `json:"id"`
+            Name  string `json:"name"`
+            Email string `json:"email"`
+        } `json:"users"`
+    }
+    apiURL := fmt.Sprintf("%s/rest/user?match=%s", c.baseURL, url.QueryEscape(email))
+    if err := c.http.GetJSON(ctx, apiURL, &resp); err != nil {
+        return "", 0, err
+    }
+    if len(resp.Users) == 0 {
+        return "", 0, nil  // not found is not an error — the contract is ("", 0, nil)
+    }
+    // Find the user whose email matches exactly (Bugzilla's match= is a substring match).
+    for _, u := range resp.Users {
+        if strings.EqualFold(u.Email, email) {
+            return u.Name, u.ID, nil
+        }
+    }
+    return "", 0, nil
+}
+```
+
+### Step 8 — implement the no-op methods
+
+Every PR / release / file / review method returns an empty iterator:
+
+```go
+// internal/platform/bugzilla/prs_noop.go
+func (c *Client) ListPullRequests(_ context.Context, _, _ string, _ time.Time) iter.Seq2[model.PullRequest, error] {
+    return func(yield func(model.PullRequest, error) bool) { /* empty */ }
+}
+
+func (c *Client) ListPRLabels(_ context.Context, _, _ string, _ int) iter.Seq2[model.PullRequestLabel, error] {
+    return func(yield func(model.PullRequestLabel, error) bool) { /* empty */ }
+}
+
+// ... all other PR methods follow the same pattern: empty iter.Seq2 ...
+
+func (c *Client) FetchPRMeta(_ context.Context, _, _ string, _ int) (head, base *model.PullRequestMeta, err error) {
+    return nil, nil, platform.ErrNotFound  // Bugzilla has no PRs at all
+}
+
+func (c *Client) FetchPRRepos(_ context.Context, _, _ string, _ int) (headRepo, baseRepo *model.PullRequestRepo, err error) {
+    return nil, nil, platform.ErrNotFound
+}
+
+func (c *Client) FetchPRByNumber(_ context.Context, _, _ string, _ int) (*model.PullRequest, error) {
+    return nil, platform.ErrNotFound
+}
+
+func (c *Client) FetchPRBatch(_ context.Context, _, _ string, _ []int) ([]platform.StagedPR, error) {
+    return []platform.StagedPR{}, nil  // empty success — staged collector will see no PRs to stage
+}
+```
+
+```go
+// internal/platform/bugzilla/releases_noop.go
+func (c *Client) ListReleases(_ context.Context, _, _ string) iter.Seq2[model.Release, error] {
+    return func(yield func(model.Release, error) bool) { /* empty */ }
+}
+
+func (c *Client) FetchCloneStats(_ context.Context, _, _ string) ([]model.RepoClone, error) {
+    return nil, platform.ErrNotFound  // Bugzilla has no clone stats
+}
+```
+
+### Step 9 — wire into the scheduler
+
+```go
+// internal/scheduler/scheduler.go around line 899
+func (s *Scheduler) selectClient(p model.Platform) (platform.Client, error) {
+    switch p {
+    case model.PlatformGitHub:
+        return s.ghClient, nil
+    case model.PlatformGitLab:
+        return s.glClient, nil
+    case model.PlatformBugzilla:
+        return s.bzClient, nil
+    default:
+        return nil, fmt.Errorf("unknown platform: %d", p)
+    }
+}
+```
+
+Add a `bzClient platform.Client` field to the `Scheduler` struct. Update the constructor `NewWithKeys` to accept it.
+
+Around line 756, the gate that controls "API collection vs git-only":
+
+```go
+if !repo.Platform.IsGitOnly() {
+    client, clientErr := s.selectClient(repo.Platform)
+    // ... existing code does staged collection
+}
+```
+
+This already works for Bugzilla — `IsGitOnly()` returns false for Bugzilla, so the API collection branch runs.
+
+The NEW gate is around facade / analysis / SBOM / scancode / scorecard. Find each call site and wrap:
+
+```go
+if repo.Platform.HasGit() {
+    // facade phase
+    facadeResult, facadeErr := s.runFacadeAndAnalysis(ctx, ...)
+    // ...
+}
+```
+
+Audit `internal/scheduler/scheduler.go` for `runFacadeAndAnalysis`, `analysisCollector.AnalyzeRepo`, scorecard invocation, SBOM generation, vulnerability scanning, scancode worker pool entries. Wrap each in the `HasGit()` gate.
+
+### Step 10 — wire into `main.go`
+
+```go
+// cmd/aveloxis/main.go — runServe and the keys loader
+
+func loadKeys(ctx context.Context, cfg *config.Config, store *db.PostgresStore, useAugurKeys bool, logger *slog.Logger) (
+    ghKeys, glKeys, bzKeys *platform.KeyPool, err error,
+) {
+    // ... existing ghKeys + glKeys loading
+
+    bzKeysData, err := store.LoadAPIKeys(ctx, "bugzilla", useAugurKeys)
+    if err != nil {
+        logger.Warn("loading Bugzilla keys", "error", err)
+    }
+    bzKeys = platform.NewKeyPool(bzKeysData, ...)
+
+    return ghKeys, glKeys, bzKeys, nil
+}
+```
+
+Then:
+
+```go
+ghKeys, glKeys, bzKeys, err := loadKeys(ctx, cfg, store, useAugurKeys, logger)
+ghClient := github.New(cfg.GitHub.BaseURL, ghKeys, logger)
+glClient := gitlab.New(cfg.GitLab.BaseURL, glKeys, logger)
+bzClient := bugzilla.New(cfg.Bugzilla.BaseURL, bzKeys, logger)
+
+sched := scheduler.NewWithKeys(store, ghClient, glClient, bzClient, ghKeys, logger, scheduler.Config{...})
+```
+
+Update `scheduler.NewWithKeys` to accept the bzClient param.
+
+### Step 11 — config
+
+```go
+// internal/config/config.go
+type Config struct {
+    Database   DatabaseConfig    `json:"database"`
+    GitHub     GitHubConfig      `json:"github"`
+    GitLab     GitLabConfig      `json:"gitlab"`
+    Bugzilla   BugzillaConfig    `json:"bugzilla"`   // new
+    // ...
+}
+
+type BugzillaConfig struct {
+    BaseURL       string   `json:"base_url"`        // e.g. "https://bugzilla.mozilla.org"
+    APIKeys       []string `json:"api_keys,omitempty"`
+    BugzillaHosts []string `json:"bugzilla_hosts,omitempty"`  // for multi-instance dispatch
+}
+```
+
+`aveloxis.example.json` gains a `bugzilla` block. The existing `TestExampleConfigIncludesEveryJSONField` tripwire will fire CI if you forget.
+
+Document the field in `docs/getting-started/configuration.md`.
+
+### Step 12 — tests
+
+Source-contract:
+
+```go
+// internal/platform/bugzilla/client_test.go
+func TestBugzillaClientSatisfiesPlatformInterface(t *testing.T) {
+    var _ platform.Client = (*Client)(nil)  // compile-time check
+}
+
+func TestBugzillaClientPlatformReturnsBugzilla(t *testing.T) {
+    c := New("https://example.invalid", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+    if c.Platform() != model.PlatformBugzilla {
+        t.Errorf("expected PlatformBugzilla, got %v", c.Platform())
+    }
+}
+```
+
+Behavioral, via `httptest.NewServer`:
+
+```go
+func TestBugzillaListIssues(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if strings.HasPrefix(r.URL.Path, "/rest/bug") {
+            w.Header().Set("Content-Type", "application/json")
+            w.Write([]byte(`{
+                "bugs": [
+                    {"id": 12345, "summary": "Test bug", "status": "NEW", "reporter": "alice@example.invalid"},
+                    {"id": 12346, "summary": "Resolved bug", "status": "RESOLVED", "reporter": "bob@example.invalid"}
+                ]
+            }`))
+            return
+        }
+        http.NotFound(w, r)
+    }))
+    defer srv.Close()
+
+    c := New(srv.URL, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+    var issues []model.Issue
+    for issue, err := range c.ListIssues(context.Background(), "", "Firefox", time.Time{}) {
+        if err != nil { t.Fatal(err) }
+        issues = append(issues, issue)
+    }
+    if len(issues) != 2 {
+        t.Errorf("expected 2 issues, got %d", len(issues))
+    }
+    if issues[0].State != "open" {
+        t.Errorf("NEW bug should map to open state, got %q", issues[0].State)
+    }
+    if issues[1].State != "closed" {
+        t.Errorf("RESOLVED bug should map to closed state, got %q", issues[1].State)
+    }
+}
+```
+
+### Step 13 — version bump, CLAUDE.md entry
+
+```go
+// internal/db/version.go
+var ToolVersion = "0.24.0"  // minor bump for new platform
+```
+
+Add a `### Changes in v0.24.0 — Bugzilla platform support` section to `CLAUDE.md` documenting:
+
+- What's collected (bugs, comments, users, events, keywords as labels).
+- What's NOT collected (PRs, releases, files, commits, SBOMs, vulnerabilities — Bugzilla has none of these).
+- The capability-gate pattern (`HasGit()`) introduced for it.
+- How operators configure it (`aveloxis.json` `bugzilla` block, `aveloxis add-key <token> --platform bugzilla`).
+- Anything operators should know (rate limits, auth requirements, parity gaps).
+
+## What you'll discover during implementation
+
+Some things the walkthrough doesn't cover that you'll bump into:
+
+1. **`SetMatviewSkip` interaction.** The dm_repo_* aggregates JOIN on commits, which Bugzilla doesn't have. Those views will still build but return zero rows for Bugzilla repos. Fine — they just don't apply.
+
+2. **`repo_info` columns** that don't apply to Bugzilla (star_count, fork_count, watcher_count, clone_count, default_branch). Leave them at zero / empty. Don't fabricate values. Document the parity gap in the architecture docs (mirroring how `docs/architecture/contributor-resolution.md` documents the GitHub/GitLab gaps).
+
+3. **`contributor_identities` rows** for Bugzilla users have an `email` field but no `name` (Bugzilla returns `real_name`), no `avatar_url`, no GraphQL `node_id`, etc. Leave those empty. The `contributors_aliases` mechanism for commit-email resolution doesn't apply (no commits).
+
+4. **`monitor` dashboard** filters by platform. The existing UI doesn't know what to render for Bugzilla. You'll want to update `internal/monitor/monitor.go` and the template to handle the case (or display Bugzilla repos in the same table with the "Commits" column empty).
+
+5. **Web GUI repo detail page.** The Chart.js panels for "Weekly commits" / "Weekly PRs" don't apply. Decide: hide them for Bugzilla repos, or show "no data."
+
+6. **Gap fill and open-item refresh.** These exist for issues + PRs. For Bugzilla, PR refresh is a no-op (no PRs). Issue gap fill should work if `ListIssues` accepts a `since=zero` to fetch everything. Verify.
+
+## Don'ts
+
+- **Don't fabricate fields.** If Bugzilla doesn't have stars, leave `star_count` at zero. Don't substitute bug_count or anything else.
+- **Don't extend `platform.Client` for Bugzilla-specific concepts** (attachments, tracking flags). Either map to existing concepts or leave un-collected. Adding interface methods that only one platform implements ramps up complexity for everyone.
+- **Don't add a `case PlatformBugzilla` to every existing platform switch** if a default works. Several call sites use `selectClient(repo.Platform)` which already routes by platform; you don't need parallel switches everywhere.
+- **Don't skip tests.** The walkthrough above has source-contract + behavioral test examples for a reason. Without tests, refactors will break Bugzilla silently because the test suite won't exercise the non-default code paths.
+
+## A reasonable order of operations
+
+1. Read this chapter end-to-end. Skim the existing `internal/platform/github/` and `internal/platform/gitlab/` packages.
+2. Add the enum entry + DB seed (steps 1–2). 1 hour. Commit.
+3. Scaffold the package with no-op methods + interface satisfaction tests (steps 3–4, 7's no-ops). 2–4 hours. Tests should compile + pass.
+4. Implement `ListIssues` + `FetchRepoInfo` + URL parsing (steps 6–7). 1 day. Add behavioral tests via httptest.
+5. Implement contributors + comments + events (step 7). 1 day.
+6. Wire into scheduler + main.go + config (steps 9–11). Half day.
+7. End-to-end test against a real (or local-Docker'd) Bugzilla. 1 day.
+8. Write CLAUDE.md entry + bump version + open PR.
+
+Total: ~1 week for someone familiar with Go and Aveloxis. Longer if you're new to either.
+
+## Final note
+
+The existing platform layer is the second iteration of this design — the first attempt (early 2024) tried to share too much between GitHub and GitLab and resulted in a leaky abstraction. The current shape works because each platform owns its package with its own types, sharing only the model and the platform.Client interface. Resist the urge to refactor toward "shared collectors" until you have THREE platforms in production — then you'll know what's actually shareable.
+
+For Bugzilla specifically, the package will look mostly distinct from github/ and gitlab/, which is fine. Distinct packages stay readable; over-shared code becomes a maintenance burden when one platform's API changes.
+
+Good luck. File issues if any of this is unclear.

--- a/docs/contributing/adding-a-rest-endpoint.md
+++ b/docs/contributing/adding-a-rest-endpoint.md
@@ -1,0 +1,286 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Adding a REST endpoint
+
+The aveloxis REST API runs as a separate process on `:8383` and is consumed by the web GUI's Chart.js panels and any external client. Adding an endpoint is a thin task — most of the work is shaping the query and the response.
+
+## Where the API lives
+
+```
+internal/api/
+├── server.go              # Mux + route registration + handler signatures
+├── metrics.go             # /api/v1/repos/{id}/stats and similar count endpoints
+├── server_test.go         # End-to-end handler tests via httptest
+├── cors_test.go           # CORS preflight + Access-Control-* header pins
+├── metrics_test.go        # Per-handler behavioral tests
+├── scancode_files_test.go
+└── scancode_freshness_test.go
+```
+
+The server uses Go 1.22+ ServeMux pattern matching (`{repoID}` path params). It's intentionally plain — no router library, no middleware stack beyond CORS.
+
+## Existing endpoints (as of v0.23.5)
+
+```
+GET /api/v1/health
+GET /api/v1/repos/{repoID}/stats
+GET /api/v1/repos/stats?ids=1,2,3            (batch)
+GET /api/v1/repos/{repoID}/sbom?format=...
+GET /api/v1/repos/{repoID}/timeseries?since=...
+GET /api/v1/repos/{repoID}/licenses
+GET /api/v1/repos/{repoID}/scancode-licenses
+GET /api/v1/repos/{repoID}/scancode-files
+GET /api/v1/repos/search?q=...
+```
+
+The pattern: path-versioned (`/api/v1/`), resource-noun, optional path params + query params.
+
+## Walkthrough: add `GET /api/v1/repos/{repoID}/contributors`
+
+We'll add an endpoint that returns the top-N contributors for a repo, ranked by commit count. This is a representative example.
+
+### Step 1 — write the failing test
+
+```go
+// internal/api/contributors_test.go
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestRepoContributorsHandler(t *testing.T) {
+    srv := newTestServer(t)
+    defer srv.Close()
+
+    resp, err := http.Get(srv.URL + "/api/v1/repos/1/contributors?limit=5")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("expected 200, got %d", resp.StatusCode)
+    }
+
+    var body struct {
+        Contributors []struct {
+            Login    string `json:"login"`
+            Commits  int    `json:"commits"`
+            Email    string `json:"email"`
+        } `json:"contributors"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    // Test fixtures set up by newTestServer should produce specific
+    // contributors — assert on them.
+}
+
+func TestRepoContributorsHandlerRejectsInvalidRepoID(t *testing.T) {
+    srv := newTestServer(t)
+    defer srv.Close()
+    resp, _ := http.Get(srv.URL + "/api/v1/repos/notanumber/contributors")
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400 for non-numeric repoID, got %d", resp.StatusCode)
+    }
+}
+
+func TestRepoContributorsHandlerLimitDefaults(t *testing.T) {
+    srv := newTestServer(t)
+    defer srv.Close()
+    resp, _ := http.Get(srv.URL + "/api/v1/repos/1/contributors")  // no limit
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("expected default limit to succeed, got %d", resp.StatusCode)
+    }
+}
+```
+
+Run it — it'll fail because the route doesn't exist.
+
+### Step 2 — add the store method
+
+The handler should be a thin shell. Put the SQL in `internal/db/`:
+
+```go
+// internal/db/repo_contributors.go
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+    "context"
+    "fmt"
+)
+
+// RepoContributor is the per-row return type for GetRepoContributors.
+type RepoContributor struct {
+    Login   string `json:"login"`
+    Email   string `json:"email"`
+    Commits int    `json:"commits"`
+}
+
+// GetRepoContributors returns up to `limit` contributors ranked by
+// commit count for the given repo. Returns an empty slice (no error)
+// when the repo has no commits yet.
+func (s *PostgresStore) GetRepoContributors(ctx context.Context, repoID int64, limit int) ([]RepoContributor, error) {
+    if limit <= 0 {
+        limit = 25  // default
+    }
+    if limit > 500 {
+        limit = 500  // cap
+    }
+    rows, err := s.pool.Query(ctx, `
+        SELECT
+            c.gh_login,
+            COALESCE(c.cntrb_canonical, c.cntrb_email, '') AS email,
+            COUNT(DISTINCT cm.cmt_commit_hash) AS commits
+        FROM aveloxis_data.commits cm
+        JOIN aveloxis_data.contributors c ON cm.cmt_ght_author_id = c.cntrb_id
+        WHERE cm.repo_id = $1 AND COALESCE(c.cntrb_deleted, 0) = 0
+        GROUP BY c.cntrb_id, c.gh_login, c.cntrb_canonical, c.cntrb_email
+        ORDER BY commits DESC, c.gh_login ASC
+        LIMIT $2`, repoID, limit)
+    if err != nil {
+        return nil, fmt.Errorf("query repo contributors: %w", err)
+    }
+    defer rows.Close()
+
+    var out []RepoContributor
+    for rows.Next() {
+        var rc RepoContributor
+        if err := rows.Scan(&rc.Login, &rc.Email, &rc.Commits); err != nil {
+            return nil, fmt.Errorf("scan: %w", err)
+        }
+        out = append(out, rc)
+    }
+    return out, rows.Err()
+}
+```
+
+### Step 3 — add the handler
+
+```go
+// internal/api/contributors.go
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+    "encoding/json"
+    "net/http"
+    "strconv"
+)
+
+func (s *Server) handleRepoContributors(w http.ResponseWriter, r *http.Request) {
+    repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+    if err != nil {
+        http.Error(w, "invalid repoID", http.StatusBadRequest)
+        return
+    }
+
+    limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+    contributors, err := s.store.GetRepoContributors(r.Context(), repoID, limit)
+    if err != nil {
+        s.logger.Warn("GetRepoContributors failed",
+            "repo_id", repoID, "error", err)
+        http.Error(w, "internal error", http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(map[string]any{
+        "repo_id":      repoID,
+        "contributors": contributors,
+    })
+}
+```
+
+### Step 4 — register the route
+
+```go
+// internal/api/server.go — inside NewServer / registerRoutes
+s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributors", s.handleRepoContributors)
+```
+
+### Step 5 — run the tests
+
+```bash
+go test ./internal/api/ -run TestRepoContributors -v
+```
+
+Iterate until green.
+
+### Step 6 — bump version, document
+
+Bump `internal/db/version.go`. Add a changelog entry in `CLAUDE.md`. Update `docs/guide/api.md` with the new endpoint signature and response shape.
+
+## Patterns to follow
+
+### Path parameters via `r.PathValue("name")`
+
+Go 1.22+ ServeMux pattern matching. Mux registration uses `{name}` placeholders; the handler reads via `r.PathValue("name")`. Always parse + validate immediately and return 400 on parse failure.
+
+### Query params via `r.URL.Query().Get`
+
+Don't bind query params via reflection / a library. Read them directly. Validate. Apply defaults and caps.
+
+### Errors
+
+- 400 for client errors (invalid input).
+- 404 for resources that don't exist (use the existing patterns; look at `handleRepoStats` for the pattern of distinguishing "repo not found" from "repo has no data yet").
+- 500 for server-side errors. Log the actual error; return a generic message to the client.
+
+Never leak SQL errors or stack traces to the client.
+
+### Response shape
+
+JSON. Wrap collections in a named field:
+
+```json
+{"contributors": [...], "repo_id": 123}
+```
+
+Not just `[...]` — that locks you in if you ever need to add pagination metadata.
+
+For paginated endpoints, follow the existing `ListQueuePage` shape:
+
+```json
+{"items": [...], "total": 1234, "page": 1, "page_size": 100}
+```
+
+### CORS
+
+The existing server.go enables CORS via middleware. Don't disable it. The web GUI's Chart.js fetches go through CORS — without it, charts silently fail.
+
+### Caching
+
+If the underlying query is expensive (full table scan, complex aggregate), consider adding a process-level cache like `internal/monitor/queue_stats_cache.go`. 60-second TTL + stale-on-error is the established pattern. See v0.18.30 for the rationale.
+
+### Logging
+
+`s.logger.Warn` on errors. Include repo_id and any other context. NEVER log the API key or session token — those don't appear on REST endpoints anyway since the API is currently unauthenticated, but be careful if you add auth.
+
+## What NOT to do
+
+- **Don't add middleware libraries.** Stdlib net/http is sufficient. Aveloxis has resisted gin/echo/chi for years and isn't adding them now.
+- **Don't write SQL in the handler.** Put it in `internal/db/`. Handlers are thin shells.
+- **Don't change response shape of existing endpoints.** The web GUI templates and external consumers pin them. Add new endpoints; don't repurpose old ones.
+- **Don't add authentication ad hoc.** The current REST API is intentionally unauthenticated (read-only, local-network). If you need auth, design it across all endpoints with the maintainers; don't slip it into one handler.
+
+## Wiring to the web GUI
+
+If your endpoint feeds a chart or panel, that's a separate task — see [`adding-a-visualization.md`](adding-a-visualization.md).
+
+The web GUI consumes the REST API via `fetch()` in the templates. The base URL is hardcoded to `http://localhost:8383` in the templates currently (one of the known-issues items in the CLAUDE.md status section). When you add an endpoint, you'll likely also update a template under `internal/web/templates.go` to call it.

--- a/docs/contributing/adding-a-visualization.md
+++ b/docs/contributing/adding-a-visualization.md
@@ -1,0 +1,267 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Adding a visualization
+
+The aveloxis web GUI uses [Chart.js](https://www.chartjs.org/) (loaded from CDN, no build step). Visualizations live inline in `internal/web/templates.go` as Go template strings with embedded `<script>` blocks.
+
+This chapter walks through adding a new chart to either the repo detail page or the comparison page.
+
+## How visualizations work today
+
+Two pages currently host charts:
+
+- **Repo detail page** (`/groups/{gid}/repos/{rid}`): four overlaid line charts (commits, PRs opened, PRs merged, issues), all weekly time-series.
+- **Comparison page** (`/compare?repos=1,2,3`): same four chart series, but for up to 5 repos overlaid, with three display modes (Raw / 100% normalized / Z-Score).
+
+Both pull data from the REST API on `:8383`. If the API isn't running, the page renders a "REST API not available" fallback.
+
+The pattern, end to end:
+
+```
+1. Browser loads HTML rendered by internal/web/templates.go
+2. <script> block fires fetch("http://localhost:8383/api/v1/repos/<id>/timeseries?...")
+3. JSON response parsed → Chart.js renders into a <canvas>
+```
+
+There's no Vue, no React, no client-side state management. Plain JS, plain templates. Resist adding a framework.
+
+## Walkthrough: add a "contributor activity" chart
+
+We'll add a chart showing weekly contributor count to the repo detail page. The REST endpoint is hypothetical — see [`adding-a-rest-endpoint.md`](adding-a-rest-endpoint.md) for the API half.
+
+### Step 1 — make sure the data is available
+
+Add a REST endpoint that returns the weekly contributor count time-series:
+
+```
+GET /api/v1/repos/{repoID}/contributor-timeseries?since=2025-01-01
+→ {
+  "repo_id": 1,
+  "weekly_counts": [
+    {"week": "2025-W01", "active_contributors": 5},
+    {"week": "2025-W02", "active_contributors": 7},
+    ...
+  ]
+}
+```
+
+Implement the endpoint following [`adding-a-rest-endpoint.md`](adding-a-rest-endpoint.md). The store-side SQL aggregates `commits` by `date_trunc('week', cmt_author_timestamp)` and `cmt_ght_author_id`.
+
+### Step 2 — find the right template
+
+`internal/web/templates.go` defines all templates as a big set of `{{define}}` blocks. The repo detail template is named `repoDetail` (or similar — search for the URL path or for `chart-commits` to find it). The relevant section looks like:
+
+```go
+const repoDetailTemplate = `
+{{define "repoDetail"}}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{.Repo.Owner}}/{{.Repo.Name}}</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <style> /* ... */ </style>
+</head>
+<body>
+  <h1>{{.Repo.Owner}}/{{.Repo.Name}}</h1>
+
+  <div class="chart-row">
+    <canvas id="chart-commits"></canvas>
+    <canvas id="chart-prs-opened"></canvas>
+  </div>
+  <div class="chart-row">
+    <canvas id="chart-prs-merged"></canvas>
+    <canvas id="chart-issues"></canvas>
+  </div>
+
+  <script>
+    const COLORS = {
+      commits: '#1f77b4',
+      prsOpened: '#2ca02c',
+      prsMerged: '#9467bd',
+      issues: '#d62728',
+    };
+
+    function makeChart(canvasId, label, color, data) {
+      // ... existing factory
+    }
+
+    fetch('http://localhost:8383/api/v1/repos/{{.Repo.ID}}/timeseries?since=2024-01-01')
+      .then(r => r.json())
+      .then(ts => {
+        makeChart('chart-commits', 'Commits / week', COLORS.commits, ts.commits || []);
+        makeChart('chart-prs-opened', 'PRs Opened / week', COLORS.prsOpened, ts.prs_opened || []);
+        makeChart('chart-prs-merged', 'PRs Merged / week', COLORS.prsMerged, ts.prs_merged || []);
+        makeChart('chart-issues', 'Issues / week', COLORS.issues, ts.issues || []);
+      })
+      .catch(err => console.error('chart load failed', err));
+  </script>
+</body>
+</html>
+{{end}}
+`
+```
+
+### Step 3 — add the canvas + the fetch
+
+```go
+// Add to the chart-row divs:
+<div class="chart-row">
+  <canvas id="chart-contributors"></canvas>
+</div>
+
+// Add to COLORS:
+const COLORS = {
+  commits: '#1f77b4',
+  prsOpened: '#2ca02c',
+  prsMerged: '#9467bd',
+  issues: '#d62728',
+  contributors: '#ff7f0e',  // new (matplotlib tab:orange)
+};
+
+// Add a second fetch (parallel to the existing one is fine — both fire when the page loads):
+fetch('http://localhost:8383/api/v1/repos/{{.Repo.ID}}/contributor-timeseries?since=2024-01-01')
+  .then(r => r.json())
+  .then(ts => {
+    makeChart('chart-contributors', 'Active contributors / week',
+              COLORS.contributors, ts.weekly_counts || []);
+  })
+  .catch(err => console.error('contributor chart load failed', err));
+```
+
+The `makeChart` factory expects an array of `{x: 'YYYY-WW', y: N}` objects — make sure your API response shape matches OR adapt the factory.
+
+### Step 4 — handle the data-shape mismatch
+
+The existing `makeChart` factory probably expects a specific shape. Read its implementation:
+
+```js
+function makeChart(canvasId, label, color, data) {
+  new Chart(document.getElementById(canvasId), {
+    type: 'line',
+    data: {
+      labels: data.map(d => d.week),    // expects {week: '2025-W01', ...}
+      datasets: [{
+        label: label,
+        data: data.map(d => d.count),   // expects {count: N}
+        borderColor: color,
+        // ...
+      }],
+    },
+    options: { /* ... */ },
+  });
+}
+```
+
+If your API returns `active_contributors` instead of `count`, either:
+
+- **Adapt the response shape** in your REST endpoint to use `count`. Cleanest.
+- **Map at fetch time**: `.then(ts => makeChart(..., ts.weekly_counts.map(d => ({week: d.week, count: d.active_contributors}))))`. Smaller change but the mapping clutters the template.
+
+Preference: API returns the shape the factory expects. The factory is consumed by every chart; matching it keeps the templates simple.
+
+## Patterns to follow
+
+### Color palette
+
+The existing charts use matplotlib's "tab10" palette:
+
+| Series | Hex | matplotlib name |
+|---|---|---|
+| Commits | `#1f77b4` | tab:blue |
+| PRs opened | `#2ca02c` | tab:green |
+| PRs merged | `#9467bd` | tab:purple |
+| Issues | `#d62728` | tab:red |
+| Contributors (new) | `#ff7f0e` | tab:orange |
+
+Stay in the palette. Avoid colors that don't differ enough for colorblind users.
+
+### Chart options
+
+Use the existing `makeChart` defaults unless you have a specific reason to deviate. Common deviations:
+
+- `type: 'bar'` instead of `'line'` for categorical comparisons.
+- `stacked: true` on the y-axis for cumulative views.
+- `scales.y.beginAtZero: true` for counts (don't truncate; it lies about magnitude).
+
+### Comparison page differences
+
+If your chart should also appear on `/compare`, that template is separate. The comparison page wraps `makeChart` with a `renderComparisonChart` that handles multiple data series + the mode toggle (Raw / 100% / Z-Score). Search for `renderComparisonChart` in the template file.
+
+The contract: each repo's data is a separate dataset in the same chart. The mode toggle is a UI control above the charts that re-renders with normalized values. Implement the normalization in JS.
+
+### Time zones
+
+API responses use ISO week numbers (`YYYY-WW`) — already timezone-agnostic. Don't return raw timestamps that the browser interprets in local time; the charts get misaligned across users in different zones.
+
+### Empty data
+
+A repo with no data yet (newly added, collection in progress) should render an empty chart with a message, not a blank canvas. The existing pattern:
+
+```js
+if (!data || data.length === 0) {
+  document.getElementById(canvasId).parentElement.innerHTML =
+    '<div class="chart-empty">No data yet — collection may still be in progress</div>';
+  return;
+}
+```
+
+Add `.chart-empty` CSS for the styling.
+
+## What NOT to do
+
+- **Don't add a frontend framework.** No React, no Vue, no Svelte, no Alpine. The current setup builds in milliseconds and has zero deploy complexity. Resist.
+- **Don't move chart code to a separate JS file.** The inline `<script>` blocks are easy to find, easy to debug. Go templates can include the script as a separate `{{define}}` if it grows, but not as an external file (that'd require a static file server, which is more deploy complexity).
+- **Don't hardcode the API base URL** in new code. The existing templates have `http://localhost:8383` hardcoded — that's a known limitation tracked in `CLAUDE.md`. Pass the base URL via the template data context if you can, OR follow the existing pattern and accept the limitation (and add a comment noting it for future cleanup).
+- **Don't skip the "no data" empty state.** A blank canvas is a worse UX than an explicit message.
+- **Don't load Chart.js per chart.** It's already loaded once at the top of each template; just reuse.
+- **Don't use third-party plugins for Chart.js** without explicit maintainer approval. Each plugin is another CDN dependency, another security surface, another version-pin to maintain.
+
+## Testing visualizations
+
+Go template tests verify the template renders cleanly with sample data:
+
+```go
+func TestRepoDetailTemplateRenders(t *testing.T) {
+    srv := newTestWebServer(t)
+    req := httptest.NewRequest(http.MethodGet, "/groups/1/repos/1", nil)
+    req = req.WithContext(authedContext(t, srv))  // session helper
+    rec := httptest.NewRecorder()
+    srv.ServeHTTP(rec, req)
+
+    if rec.Code != http.StatusOK {
+        t.Errorf("expected 200, got %d", rec.Code)
+    }
+    body := rec.Body.String()
+    if !strings.Contains(body, `id="chart-contributors"`) {
+        t.Error("expected chart-contributors canvas to be present")
+    }
+    if !strings.Contains(body, `/contributor-timeseries`) {
+        t.Error("expected fetch to /contributor-timeseries endpoint")
+    }
+}
+```
+
+But you CANNOT meaningfully unit-test JS chart rendering. For that:
+
+1. Manual browser testing during development. Open `http://localhost:8082` and check the chart renders.
+2. Console errors check (`console.error('chart load failed', ...)`) — keep these in production code; they surface in browser DevTools.
+3. If the chart breaks, browser DevTools' Network tab shows the failed fetch.
+
+Per CLAUDE.md: **for UI/frontend changes, use the feature in a browser before reporting the task as complete.** Type checking and test suites verify code correctness, not feature correctness.
+
+## Updating the comparison page
+
+If your chart should also appear in `/compare`:
+
+1. Find the comparison template (search for `renderComparisonChart`).
+2. Add a `<canvas id="cmp-contributors"></canvas>` next to the existing comparison canvases.
+3. Add a `renderComparisonChart('cmp-contributors', 'Active contributors / week', 'weekly_counts');` call alongside the existing ones.
+4. Make sure your REST API endpoint accepts the comparison page's repos-list pattern (`ids=1,2,3`).
+5. Test in a browser with 2+ repos.
+
+## Documentation
+
+Update `docs/guide/visualizations.md` with the new chart's name, axis labels, what it shows, what data it pulls from, and known limitations (e.g. "only shows weeks with at least one commit").

--- a/docs/contributing/code-conventions.md
+++ b/docs/contributing/code-conventions.md
@@ -1,0 +1,245 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Code conventions
+
+How aveloxis code is organized, what idioms to follow, and what to avoid. Most of these are durable patterns from production incidents — if a rule seems arbitrary, search [`CLAUDE.md`](../../CLAUDE.md) for the context.
+
+## SPDX headers (mandatory)
+
+Every Go file starts with:
+
+```go
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package foo
+```
+
+A tripwire test (`scripts/spdx_coverage_test.go`) walks the repo and fails CI if any `.go` file is missing these two lines. The script `scripts/add_spdx.sh` backfills headers idempotently.
+
+Build-tag-prefixed files (`//go:build ...`) — none currently in the repo — would need special handling; ask before adding one.
+
+## Package layout
+
+Within `internal/`:
+
+- One package per directory (Go convention).
+- Filenames describe the artifact: `staging.go` defines staging types, `staging_writer.go` defines the writer, `staging_test.go` is its unit test.
+- Test files (`*_test.go`) live next to the code they test.
+- Integration tests (require a real database) are suffixed `_integration_test.go` and gated on `AVELOXIS_TEST_DB`. See [`testing.md`](testing.md).
+- Per-version migration / fix code is named by feature (e.g. `cntrb_id_cascade.go`, `utf8_tracer.go`), not by version number.
+
+## Imports
+
+Standard Go three-group format. `goimports` enforces it; the maintainers run it on save:
+
+```go
+import (
+    "context"
+    "fmt"
+    "log/slog"
+
+    "github.com/jackc/pgx/v5"
+    "github.com/google/uuid"
+
+    "github.com/aveloxis/aveloxis/internal/db"
+    "github.com/aveloxis/aveloxis/internal/model"
+)
+```
+
+Groups: stdlib, third-party, project-local.
+
+## Naming
+
+- **Exported names**: `PascalCase`. Aveloxis follows Go's standard.
+- **Unexported names**: `camelCase`.
+- **Constants**: `PascalCase` when exported, otherwise `camelCase`. NOT `SCREAMING_SNAKE_CASE`.
+- **Acronyms**: idiomatic Go (`URL`, `HTTP`, `ID`, `UUID`, `SBOM`, `PR`). Match the surrounding code if in doubt.
+- **Test names**: `TestXxx` (Go's required prefix) describing what's pinned. Long, specific test names beat short cryptic ones. Pattern: `TestComponent_Behavior_Condition`. Example: `TestUpsertCommit_SucceedsWith_InvalidUTF8_UnderV023_5Tracer`.
+
+## Error handling
+
+### The contract
+
+- Return errors via `error` return value. Don't panic in library code.
+- Wrap with context using `fmt.Errorf("operation: %w", err)`.
+- Log AT THE BOUNDARY where you decide what to do with the error, not deep inside library code (that produces double-logging).
+- Use sentinel errors for cases callers branch on: `platform.ErrNotFound`, `platform.ErrGone`, `platform.ErrNoContent`, `platform.ErrForbidden`, `platform.ErrAllKeysInvalidated`, `platform.ErrPaginationLimitExceeded`, `platform.ErrTransient`. Compare with `errors.Is`.
+- For classification across many error shapes, use `platform.ClassifyError(err) ErrorClass`. New error shapes should classify through this single helper — never add ad-hoc retry logic to a call site.
+
+### The CLAUDE.md rule (mandatory)
+
+> **Everything that errors should be logged.**
+
+If you swallow an error with `_, _ = pg.Exec(...)`, you'll regret it in production. v0.19.4 is a permanent reminder: `addColumnIfMissing` used to swallow ALTER TABLE errors, and a typo in v0.21.0 went unnoticed for weeks because of it. The fix was to thread an error collector and `errors.Join` at the end. See [`schema-migrations.md`](schema-migrations.md).
+
+### Idioms
+
+```go
+// Good: contextual wrap + slog at the boundary
+if err := store.UpsertCommit(ctx, c); err != nil {
+    s.logger.Warn("failed to upsert commit",
+        "hash", c.Hash, "file", c.Filename, "error", err)
+    return fmt.Errorf("upserting commit %s: %w", c.Hash, err)
+}
+
+// Bad: silent failure
+_, _ = store.UpsertCommit(ctx, c)
+```
+
+## Logging (slog)
+
+Aveloxis uses `log/slog` (stdlib). The pattern:
+
+```go
+s.logger.Info("collection complete",
+    "repo_id", repoID,
+    "issues", result.Issues,
+    "prs", result.PullRequests,
+    "duration_seconds", duration.Seconds(),
+)
+```
+
+Rules:
+
+- **Structured keys, not formatted strings.** Operators grep on key=value, not free-text.
+- **Verb-noun message.** `"collection complete"`, `"failed to upsert commit"`, `"running ScanCode"`. Lowercase except for proper nouns (ScanCode, GitHub, etc.).
+- **Log level discipline:**
+  - `DEBUG`: noisy per-row work. Off by default.
+  - `INFO`: per-cycle / per-repo lifecycle events.
+  - `WARN`: degraded state that's recoverable.
+  - `ERROR`: data integrity at risk or operator action needed. The v0.20.15 startup schema-mismatch warning is an ERROR — operators ignored a WARN once and lost a week of collection.
+- **Context first, error last.** `"error", err` always appears as the final argument so it's easy to spot in a log scan.
+- **Don't log secrets.** API keys, OAuth tokens, session cookies. The mailer's `gmail_app_password` is the canonical example of what NOT to log.
+
+## Version bumping (mandatory)
+
+**Every code change bumps `internal/db/version.go`.** No exceptions.
+
+```go
+// internal/db/version.go
+var ToolVersion = "0.23.5"   // bump this
+```
+
+The version flows to:
+
+- `tool_version` columns on most tables (set via `setToolVersionDefaults` at migration time).
+- `aveloxis version` CLI output.
+- SBOMs (CycloneDX + SPDX metadata).
+- The `data-test` harness uses it to distinguish released vs working-tree binaries.
+
+### When to bump
+
+- **Patch (0.X.Y → 0.X.(Y+1))**: bugfix, refactor, performance fix, doc-only change.
+- **Minor (0.X.0 → 0.(X+1).0)**: new feature, new schema column, new config knob, new CLI subcommand. Worth a minor bump because operators need to know to re-run `migrate` or update their `aveloxis.json`.
+- **Major (0.X.0 → 1.X.0)**: breaking change to the schema, the REST API, or the platform.Client interface. Aveloxis is still 0.x.
+
+### When NOT to bump
+
+- Documentation-only changes (e.g. fixing a typo in `docs/`) — bump if you want to track them; the maintainers tend to skip the bump in pure-docs PRs.
+- Whitespace / gofmt-only changes.
+
+When in doubt, bump.
+
+## Commit messages
+
+Imperative present tense ("Add ...", "Fix ...", "Refactor ..."), 50-character title, blank line, body wrapped at 72 chars. Reference the version in the body when the change bumps it:
+
+```
+Add utf8ScrubTracer for boundary-layer UTF-8 safety
+
+v0.23.5. Centralizes the v0.19.2 surgical safeUTF8 fix as a pgx
+QueryTracer + BatchTracer registered on cfg.ConnConfig.Tracer.
+Scrubs string and *string parameters in place before wire
+encoding; ~437 call sites in internal/db/ are now automatically
+protected with zero per-site changes.
+
+Tests: 11 unit + 6 integration tests gated on AVELOXIS_TEST_DB.
+The integration suite reproduces the 2026-05-21 kernel-repo bug
+(SQLSTATE 22021 from Latin-1 author names) and asserts the fix.
+
+Closes #N
+```
+
+Body should explain **why**, not just **what**. The diff already shows what changed.
+
+## CLAUDE.md is the canonical record
+
+When your change has user-visible behavior, add a `### Changes in vX.Y.Z` section under `## Current Status` in `CLAUDE.md`. Future contributors AND the AI agents that help maintain the project read this to understand decisions.
+
+Format established by existing entries:
+
+- Lead with the version + one-line summary.
+- "The diagnostic" or "The bug" subsection if applicable, with concrete log lines or query output.
+- "The fix" subsection describing the approach.
+- "Files changed" enumeration.
+- "Tests" enumeration with N new tests.
+- "Operator deployment" with the exact commands.
+- "What this does NOT change" guard against scope confusion.
+
+Don't be afraid of length. Operators (and the project's memory) value detail.
+
+## Don't add features beyond what the task requires
+
+From `CLAUDE.md`:
+
+> Don't add features, refactor, or introduce abstractions beyond what the task requires. A bug fix doesn't need surrounding cleanup; a one-shot operation doesn't need a helper. Don't design for hypothetical future requirements. Three similar lines is better than a premature abstraction.
+
+Real examples of this rule biting in production:
+
+- The v0.20.2 logical-merge work explicitly REJECTED a 16-table FK rewrite migration. The architecture's worth of "future flexibility" wasn't worth the blast radius.
+- v0.23.4 explicitly does NOT remove `--quiet` from the scancode invocation. Removing it would add operator log clutter for the sake of "cleaner output." The salvage path makes the per-file errors structured instead.
+
+If you find yourself writing "this will be useful later", delete it.
+
+## Don't write comments that restate the code
+
+```go
+// Bad: redundant with the function name
+// MarkScancodeComplete marks scancode as complete.
+func MarkScancodeComplete(ctx context.Context, repoID int64) error {
+
+// Good: explains the non-obvious why
+// MarkScancodeComplete resets scancode_failed_attempts to 0 and
+// scancode_last_failed_at to NULL on success — a repo that recovers
+// after a few failures doesn't carry the high attempt count into
+// the next failure cycle. (v0.21.4)
+func MarkScancodeComplete(ctx context.Context, repoID int64) error {
+```
+
+If removing the comment wouldn't confuse a future reader, don't write it.
+
+## Don't write to files in ways that surprise
+
+Always read before writing. The `Write` and `Edit` tooling in the project's AI workflow enforces this; humans should too. A file you "know" is empty might have been touched by a build tool, a pre-commit hook, or another contributor's in-progress branch.
+
+## CLI command style
+
+Subcommands go in `cmd/aveloxis/`. Use cobra. The command name is the file name minus `_cmd.go`:
+
+```
+cmd/aveloxis/migrate_cmd.go         → aveloxis migrate
+cmd/aveloxis/data_test_cmd.go       → aveloxis data-test (kebab-case multi-word)
+cmd/aveloxis/staging_stats_cmd.go   → aveloxis staging-stats
+```
+
+Each command:
+
+1. Defines a `func runX(cmd *cobra.Command, args []string) error` handler.
+2. Has a `func newXCommand() *cobra.Command` constructor that registers flags.
+3. Is added to `root.AddCommand(...)` in `main.go`.
+4. Has a `_test.go` with at least a source-contract test pinning the registration (so the command can't accidentally disappear from `root` during a refactor).
+
+Don't call `store.Migrate(ctx)` from any subcommand other than `serve` and `migrate`. v0.21.5 made this explicit after `aveloxis import-foundations --dry-run` was triggering schema rebuilds. The contract: only `serve` and `migrate` migrate.
+
+## What NOT to do
+
+- **No emojis** in code, comments, commit messages, or markdown docs unless explicitly requested by the user/operator.
+- **No `panic` outside of `cmd/` startup paths.** Library code returns errors.
+- **No global mutable state.** Use struct fields and dependency injection.
+- **No `init()` functions** for non-trivial setup. They obscure what runs when. Constructor functions (`NewX`) are clearer.
+- **No reading from `pg.pool` directly outside `internal/db/`.** The store is the boundary; everything else goes through its methods. (This is a soft rule — there are a few legacy exceptions in `internal/scheduler/` but new code should respect the layering.)
+- **No "I'll add tests later."** Tests get written with the code. See [`testing.md`](testing.md).

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -1,0 +1,205 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Local development setup
+
+This chapter gets you from an empty machine to a working aveloxis dev environment with a database you can run integration tests against.
+
+## Prerequisites
+
+- **Go 1.23 or later.** Aveloxis uses Go 1.23 iterator syntax (`iter.Seq2`) in the platform layer.
+- **PostgreSQL 14 or later.** 18.x is what the maintainers use; anything 14+ should work (the schema uses `gen_random_uuid()` and `pg_trgm`).
+- **git** (obviously).
+- **scc** and **scorecard** — installed automatically via `aveloxis install-tools`, see below.
+
+## 1. Clone and build
+
+```bash
+git clone https://github.com/aveloxis/aveloxis
+cd aveloxis
+go build ./...
+```
+
+If the build fails, you're missing a Go module — `go mod download` should fix it. If it still fails, file an issue with your Go version (`go version`) and OS.
+
+## 2. Run the unit test suite
+
+```bash
+go test ./...
+```
+
+Expect everything green in a few minutes (the `internal/platform` package's network mock tests are the slowest at ~40 s). Any failure here means your environment is broken; fix it before writing code.
+
+The unit tests do NOT require a database. Integration tests (which DO require a database) are gated behind the `AVELOXIS_TEST_DB` env var and skip cleanly when it's unset.
+
+## 3. Set up a local PostgreSQL
+
+You need two things: a running PostgreSQL server, and a database/user the binary can connect to.
+
+### macOS (Homebrew)
+
+```bash
+brew install postgresql@18
+brew services start postgresql@18
+createuser --superuser aveloxis    # or use your own username
+createdb aveloxis_dev
+```
+
+### Linux (Debian/Ubuntu)
+
+```bash
+sudo apt install postgresql postgresql-contrib
+sudo -u postgres createuser --superuser $USER
+createdb aveloxis_dev
+```
+
+### Verify
+
+```bash
+psql -d aveloxis_dev -c "SELECT version();"
+```
+
+You should see something like `PostgreSQL 18.3 on ...`. If you don't, the rest of this chapter won't work — fix your PostgreSQL setup first.
+
+## 4. Configure aveloxis.json
+
+The committed example `aveloxis.runlocal.json` is what the maintainers use. Copy it to a working config:
+
+```bash
+cp aveloxis.runlocal.json aveloxis.json
+```
+
+Edit `aveloxis.json` and adjust the `database` block to point at your local PostgreSQL:
+
+```jsonc
+{
+  "database": {
+    "host": "localhost",
+    "port": 5432,
+    "user": "aveloxis",       // or your username
+    "password": "...",        // your local password (or "" if trust auth)
+    "dbname": "aveloxis_dev",
+    "sslmode": "prefer"
+  },
+  // ...
+}
+```
+
+The other blocks (`github`, `gitlab`, `web`, `collection`, `log_level`) can stay as the example committed. They configure tokens you can leave empty for now.
+
+**Tip:** keep your real-token `aveloxis.json` separate. `.gitignore` excludes it by default. If you want to commit a config template for someone else, use a name like `aveloxis.<your-purpose>.example.json` and don't include any secrets.
+
+## 5. Run the migration
+
+```bash
+go run ./cmd/aveloxis migrate
+```
+
+Expect a short stream of `migration step ok` log lines. The full schema (108+ tables, 22+ materialized views, 50+ indexes) lands in two passes — DDL then matview creation.
+
+If you want to skip the matview build for faster iteration (you typically do during development):
+
+```bash
+go run ./cmd/aveloxis migrate --skip-views
+```
+
+You can refresh views later with `go run ./cmd/aveloxis refresh-views` or let the scheduler's weekly rebuild handle them.
+
+## 6. (Optional) Install scc + scorecard
+
+These are external tools the collector shells out to. Aveloxis runs without them — the relevant phases just log "tool not installed, skipping" — but if you want full coverage:
+
+```bash
+go run ./cmd/aveloxis install-tools
+```
+
+Installs both `scc` (code-complexity scanner) and `scorecard` (OpenSSF Scorecard) into `$HOME/go/bin`. Make sure that's on your `$PATH`.
+
+## 7. (Optional) Add API keys
+
+To do any actual collection from GitHub/GitLab, you need API tokens:
+
+```bash
+# GitHub: any classic PAT or fine-grained token with `public_repo` scope.
+go run ./cmd/aveloxis add-key ghp_yourtokenhere --platform github
+
+# GitLab: a personal access token with `read_api` scope.
+go run ./cmd/aveloxis add-key glpat-yourtokenhere --platform gitlab
+```
+
+Keys land in `aveloxis_ops.worker_oauth`. The CLI reads them on every startup; no in-process token reload yet.
+
+## 8. Run the binary
+
+A typical dev session uses just `serve` (the scheduler):
+
+```bash
+go run ./cmd/aveloxis serve --workers 4
+```
+
+For the full GUI + REST API trio:
+
+```bash
+go run ./cmd/aveloxis start all
+```
+
+That backgrounds three processes (`serve`, `web`, `api`). Logs land in `~/.aveloxis/aveloxis.log`, `~/.aveloxis/web.log`, `~/.aveloxis/api.log`. Stop them with `go run ./cmd/aveloxis stop all`.
+
+## 9. Run integration tests
+
+Integration tests live alongside unit tests under `internal/db/` (and a few other packages). They're gated on `AVELOXIS_TEST_DB`:
+
+```bash
+# Point at a SCRATCH database — NOT your production aveloxis_dev.
+# Integration tests truncate tables and write fixture rows.
+createdb aveloxis_scratch_test
+
+AVELOXIS_TEST_DB="postgres://aveloxis:yourpass@localhost:5432/aveloxis_scratch_test?sslmode=prefer" \
+    go test ./internal/db/ -v -timeout 120s
+```
+
+The tests run migrations against the scratch DB first, then exercise specific code paths. Tests skip cleanly if `AVELOXIS_TEST_DB` is unset, so `go test ./...` stays fast for contributors without a database.
+
+**Safety:** integration tests assume a scratch database. Some helpers (e.g. v0.16.6's `RealignDueDates`) update every matching row in the queue. Pointing them at a production database would damage operator data. Use a separate scratch DB or accept the consequences.
+
+See [`testing.md`](testing.md) for the testing philosophy and patterns.
+
+## 10. Set up your editor
+
+The codebase is plain Go — any Go editor works. Recommended extras:
+
+- **gopls** language server (default).
+- **golangci-lint** for vet/staticcheck/etc. Aveloxis doesn't enforce it in CI yet but the maintainers run it locally.
+- **EditorConfig** support. Aveloxis uses tabs in Go files, two-space indent in Markdown / JSON / YAML.
+
+## Common problems
+
+### `relation "aveloxis_data.repos" does not exist`
+
+You skipped step 5 (or your `aveloxis.json` points at the wrong database). Run `go run ./cmd/aveloxis migrate` first.
+
+### `column "X" does not exist`
+
+Your binary is newer than the DB. Re-run `go run ./cmd/aveloxis migrate --skip-views`. This is the v0.20.15 ERROR-level startup log that warns about exactly this state.
+
+### `failed to connect to ... server is starting up`
+
+PostgreSQL is still booting (typical right after `brew services start`). Wait 10 seconds and retry. If it persists, check `psql -c "SELECT 1"` works in a fresh shell.
+
+### `no API keys configured for any platform`
+
+You haven't run `aveloxis add-key`. Required for `serve` and `collect`; `web` and `api` can run without keys (they just don't collect anything new).
+
+### Tests pass locally but fail in CI
+
+CI runs `go test ./...` with no `AVELOXIS_TEST_DB`. If your test only passes when the env var is set, gate it on `os.Getenv("AVELOXIS_TEST_DB") == ""` → `t.Skip(...)`. See existing patterns in `internal/db/*_integration_test.go`.
+
+## Next steps
+
+You have a working dev environment. Pick a chapter:
+
+- Want to write code? [`code-conventions.md`](code-conventions.md) then [`testing.md`](testing.md).
+- Want to add a column? [`schema-migrations.md`](schema-migrations.md).
+- Want to add a platform? [`adding-a-platform.md`](adding-a-platform.md).

--- a/docs/contributing/schema-migrations.md
+++ b/docs/contributing/schema-migrations.md
@@ -1,0 +1,312 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Schema migrations
+
+How to add, change, or backfill database state without losing operator data. The patterns here are the result of several production incidents; the rules are non-negotiable.
+
+## The two sources of truth
+
+1. **`internal/db/schema.sql`** — declarative CREATE TABLE / CREATE INDEX / INSERT statements. This is what gets applied to a brand-new database via `pg.pool.Exec(ctx, schemaSQL)` at the top of `RunMigrations`. Fresh installs land here directly.
+
+2. **`internal/db/migrate.go`** — imperative `addColumnIfMissing`, `execMigrationStep`, `execCreateIndexConcurrently` calls that bring existing deployments up to the current schema. Operators with a running database run `aveloxis migrate` after deploying a new binary.
+
+**Both must reflect the same final state.** Adding a column to `schema.sql` without a corresponding `addColumnIfMissing` in `migrate.go` means existing deployments will be missing that column. Adding it to `migrate.go` without `schema.sql` means fresh installs will be missing it.
+
+## The fail-closed contract (v0.19.4)
+
+Every schema-mutating call in `migrate.go` must surface errors. The historical bug: `addColumnIfMissing` used the discard pattern `_, _ = pg.pool.Exec(...)`. ALTER TABLE failures (including typos like the v0.21.0 incident's `aveloxis_scan.scancode_scans.created_at` referencing a column that doesn't exist) silently failed, migrate logged `"schema migrations complete"`, and operators discovered the gap weeks later when a feature queried the missing column.
+
+The post-v0.19.4 contract:
+
+```go
+func RunMigrations(ctx context.Context, store *PostgresStore, logger *slog.Logger) error {
+    var errs []error
+    pg := store
+
+    // Base schema first.
+    if _, err := pg.pool.Exec(ctx, schemaSQL); err != nil {
+        errs = append(errs, fmt.Errorf("base schema: %w", err))
+    }
+
+    // Per-version idempotent steps. Each helper appends to `errs` on failure
+    // and continues to the next step — so a single broken step surfaces every
+    // OTHER step's failure too, instead of bailing on the first.
+    addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data", "repos",
+        "scancode_failed_attempts", "INTEGER DEFAULT 0")
+    execMigrationStep(ctx, pg, logger, &errs,
+        "v0.23.5 example backfill",
+        `UPDATE aveloxis_data.foo SET bar = COALESCE(bar, 0)`)
+    execCreateIndexConcurrently(ctx, pg, logger, &errs,
+        "aveloxis_data", "idx_foo_bar",
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_foo_bar
+            ON aveloxis_data.foo (bar) WHERE bar > 0`)
+
+    if len(errs) > 0 {
+        return fmt.Errorf("schema migration had %d error(s): %w",
+            len(errs), errors.Join(errs...))
+    }
+    return nil
+}
+```
+
+The aggregated error is what `aveloxis serve` returns from `runServe` → causes the process to exit non-zero. Operators see every failure at once, fix everything, re-run.
+
+**Never** introduce a `_, _ = pg.pool.Exec(...)` in `migrate.go`. The pre-existing source-contract test `TestRunMigrationsNoBareExecWithoutCheck` fires the build if you do.
+
+## Adding a column
+
+The pattern, idempotent across re-runs:
+
+```go
+// internal/db/migrate.go — in RunMigrations
+addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data", "repos",
+    "languages", "JSONB DEFAULT '{}'::jsonb")
+```
+
+And `internal/db/schema.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
+    repo_id          BIGSERIAL PRIMARY KEY,
+    -- ... existing columns ...
+    languages        JSONB DEFAULT '{}'::jsonb,
+    -- ...
+);
+```
+
+`addColumnIfMissing` issues `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...` so it's a no-op on databases that already have the column. Set a non-NULL default if existing rows need a sensible value at migration time.
+
+### Source-contract test
+
+Pin both sides:
+
+```go
+func TestSchemaHasLanguagesColumn(t *testing.T) {
+    schema, _ := os.ReadFile("schema.sql")
+    if !strings.Contains(string(schema), "languages") {
+        t.Error("schema.sql must declare repos.languages")
+    }
+}
+
+func TestMigrateAddsLanguagesColumn(t *testing.T) {
+    migrate, _ := os.ReadFile("migrate.go")
+    if !strings.Contains(string(migrate), `"languages"`) {
+        t.Error("migrate.go must add languages via addColumnIfMissing")
+    }
+}
+```
+
+### Integration test (the v0.21.1 lesson)
+
+Source-contract tests verify the code says what you wrote, not that it's CORRECT against the actual schema. Add an integration test that runs the migration against a real DB:
+
+```go
+//go:build integration  // gate on AVELOXIS_TEST_DB
+
+func TestLanguagesColumnExistsAfterMigrate(t *testing.T) {
+    store := openTestStore(t)  // applies RunMigrations
+    ctx := context.Background()
+
+    var dataType string
+    err := store.pool.QueryRow(ctx, `
+        SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'aveloxis_data'
+          AND table_name = 'repos'
+          AND column_name = 'languages'`).Scan(&dataType)
+    if err != nil {
+        t.Fatalf("languages column not found post-migrate: %v", err)
+    }
+    if dataType != "jsonb" {
+        t.Errorf("expected jsonb, got %s", dataType)
+    }
+}
+```
+
+## Adding an index
+
+For indexes on existing populated tables, **always use `CREATE INDEX CONCURRENTLY`**. A plain `CREATE INDEX` acquires `ACCESS EXCLUSIVE` for the duration of the build — on fleet-scale tables (5M+ rows) that's minutes of blocked writes, which stalls every collection worker. CONCURRENTLY trades ~2x build time for not blocking writes.
+
+```go
+execCreateIndexConcurrently(ctx, pg, logger, &errs,
+    "aveloxis_data", "idx_repos_owner_name_trgm",
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_owner_name_trgm
+        ON aveloxis_data.repos USING GIN ((repo_owner || '/' || repo_name) gin_trgm_ops)`)
+```
+
+The helper handles `IF NOT EXISTS` semantics AND the failure-recovery edge case where a prior interrupted CONCURRENTLY build left an INVALID index (cleaned up via `DROP INDEX` before retry). See v0.20.1.
+
+For indexes in `schema.sql` (fresh installs), use `CREATE INDEX IF NOT EXISTS ...` — fresh installs run inside the base-schema transaction, so blocking-during-build isn't a concern.
+
+## Adding a backfill
+
+Backfill = a one-shot UPDATE that brings existing rows in line with new column semantics.
+
+Pattern (idempotent — re-running is a no-op once the rows match):
+
+```go
+execMigrationStep(ctx, pg, logger, &errs,
+    "v0.23.X backfill repos.languages from JSONB default",
+    `UPDATE aveloxis_data.repos
+     SET languages = '{}'::jsonb
+     WHERE languages IS NULL`)
+```
+
+### Idempotency is mandatory
+
+Migrations re-run on every `aveloxis migrate` invocation (operator may run it multiple times during a fix cycle). A backfill that ISN'T idempotent will either:
+
+- do duplicate work on each run (wasteful but harmless), OR
+- corrupt data on each run (catastrophic).
+
+Make the WHERE clause exclude already-backfilled rows. Common patterns:
+
+- `WHERE column IS NULL` — only touch unset rows.
+- `WHERE column IS DISTINCT FROM target_value` — handles NULL correctly (`IS DISTINCT FROM` returns TRUE when one side is NULL and the other isn't).
+- `WHERE column = old_default OR column = ''` — only touch rows still at the pre-fix value.
+
+The v0.21.2 backfill of cumulative `last_commits` is a good model:
+
+```sql
+UPDATE aveloxis_ops.collection_queue q
+SET last_commits = sub.cnt
+FROM (
+    SELECT repo_id, COUNT(DISTINCT cmt_commit_hash) AS cnt
+    FROM aveloxis_data.commits
+    GROUP BY repo_id
+) sub
+WHERE q.repo_id = sub.repo_id
+  AND q.last_commits IS DISTINCT FROM sub.cnt;   -- the idempotency gate
+```
+
+### Source-contract test
+
+```go
+func TestMigrationBackfillsLanguages(t *testing.T) {
+    src, _ := os.ReadFile("migrate.go")
+    code := string(src)
+    if !strings.Contains(code, "v0.23.X backfill repos.languages") {
+        t.Error("backfill step missing from migrate.go")
+    }
+    if !strings.Contains(code, "IS NULL") {
+        t.Error("backfill must include an idempotency gate (WHERE ... IS NULL)")
+    }
+}
+```
+
+### Integration test
+
+Test both the first-run effect and the idempotency:
+
+```go
+func TestLanguagesBackfillIsIdempotent(t *testing.T) {
+    store := openTestStore(t)  // applies migrations once
+    ctx := context.Background()
+
+    // Insert a row with NULL languages.
+    repoID := seedRepo(t, store, /* languages = */ nil)
+
+    // Run RunMigrations again — backfill should fire.
+    _ = RunMigrations(ctx, store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+    var langs string
+    store.pool.QueryRow(ctx, `SELECT languages::text FROM aveloxis_data.repos WHERE repo_id = $1`, repoID).Scan(&langs)
+    if langs != "{}" {
+        t.Errorf("expected backfill to set languages to '{}', got %s", langs)
+    }
+
+    // Run a THIRD time. Should be a no-op.
+    _ = RunMigrations(ctx, store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+    var langsAfter string
+    store.pool.QueryRow(ctx, `SELECT languages::text FROM aveloxis_data.repos WHERE repo_id = $1`, repoID).Scan(&langsAfter)
+    if langsAfter != "{}" {
+        t.Errorf("re-running migrations changed the value (should be idempotent), got %s", langsAfter)
+    }
+}
+```
+
+## Adding a foreign key
+
+If the FK is on a column referencing `aveloxis_data.contributors(cntrb_id)`, it needs to participate in the v0.22.1 cascade contract. See the existing `cntrb_id_cascade.go` and `cntrb_id_fk_indexes.go` — the test `TestSchemaDeclaresDeferredOnCntrbIDFKs` enforces the count (currently 17). Add your new FK to `cntrbIDChildFKs` AND bump the expected count in the test.
+
+For other FK additions:
+
+- Use `DEFERRABLE INITIALLY DEFERRED` if the inserts will happen in any order within a transaction (v0.22.7 made every FK deferrable for consistency).
+- Add an index on the child column. Postgres doesn't auto-index FK child columns; without an index, every DELETE on the parent triggers a full scan of the child table. v0.22.6 added 15 missing such indexes — don't add the 16th.
+- Use `ON UPDATE CASCADE ON DELETE RESTRICT` for FKs to mutable identity keys (like cntrb_id which sometimes gets rewritten by the migration tools). Use plain `ON DELETE NO ACTION` for FKs to immutable surrogate keys (most cases).
+
+## Migration ordering
+
+Within `RunMigrations`, steps run in source order. Order matters when:
+
+- Step B depends on a column or table created by step A.
+- Step B's backfill needs data shape established by step A's column add.
+
+The convention: order steps roughly by version (oldest at top, newest at bottom). Add a comment noting which version owns each step. The v0.22.x cntrb_id work is the canonical example — `ensureOnUpdateCascadeOnCntrbIDFKs` runs BEFORE `ensureCntrbIDFKIndexes` because cascade behavior is the load-bearing change, the indexes just make it fast (pinned by `TestEnsureCntrbIDFKIndexesRunsAfterCascadeStep`).
+
+## Materialized views
+
+Materialized views are `dm_repo_annual`, `dm_repo_monthly`, `dm_repo_weekly`, plus group variants and Augur compatibility views. They're declared in `schema.sql` AND have helper functions for refresh:
+
+```go
+// Bulk refresh — used by the scheduler's weekly rebuild (default Saturday).
+store.RefreshAllRepoAggregates(ctx)
+
+// Per-repo — left in internal/db/aggregates.go for manual recalc, not on the hot path.
+store.RefreshRepoAggregates(ctx, repoID)
+```
+
+If you add a new materialized view:
+
+1. Declare it in `schema.sql` (CREATE MATERIALIZED VIEW ... WITH NO DATA so fresh installs land without blocking on a populated build).
+2. Add its name to the list in `CreateMaterializedViewsIfNotExist`.
+3. Add it to `RefreshAllRepoAggregates`.
+4. Test that `aveloxis refresh-views` rebuilds it (integration test).
+
+Operators rebuild matviews on the configured day (`collection.matview_rebuild_day`, default Saturday). Pre-existing matviews are NOT refreshed on every startup — that was a 2024 design decision to avoid multi-hour startup delays on fleet-scale databases.
+
+## The `aveloxis migrate --skip-views` flag
+
+When iterating on a schema fix:
+
+```bash
+aveloxis migrate --skip-views   # schema + columns + backfills, no matview rebuild
+```
+
+This was added in v0.19.5 specifically for the "iterate on a v0.19.4 schema-error fix" workflow — the matview rebuild adds significant wall-clock time per attempt, and the views are derived data anyway. Use this during dev; let operators decide when to refresh views in production.
+
+## Version-bump checklist for a schema-touching change
+
+1. Add the column / index / FK / backfill to `schema.sql`.
+2. Add the corresponding `addColumnIfMissing` / `execCreateIndexConcurrently` / `execMigrationStep` to `migrate.go`.
+3. Write source-contract tests for both files.
+4. Write an integration test that runs RunMigrations + asserts the post-state.
+5. Bump `internal/db/version.go`.
+6. Add a `### Changes in vX.Y.Z` section to `CLAUDE.md` documenting:
+   - What was added and why.
+   - What the migration does on existing deployments.
+   - The operator command sequence to deploy (`aveloxis stop all; aveloxis migrate --skip-views; aveloxis start all`).
+   - Any operational concern (long-running CONCURRENTLY index builds, fail-closed startup behavior, etc.).
+7. Run `go test ./...` AND the integration tier.
+8. (Optional but recommended) Run `aveloxis data-test --released-tag <prev> --repo <test-repo>` to verify the new version doesn't lose data vs the prior release. See [`docs/guide/data-test.md`](../guide/data-test.md).
+
+## What v0.21.5 made explicit: who can run migrations
+
+Only `aveloxis serve` (which migrates at startup) and the dedicated `aveloxis migrate` subcommand are allowed to call `store.Migrate(ctx)`. Other CLIs (`collect`, `add-repo`, `import-from-augur`, `add-key`, etc.) used to defensively migrate; v0.21.5 removed those calls.
+
+The reason: defensive migration meant `aveloxis import-foundations --dry-run` was triggering `CREATE INDEX CONCURRENTLY` rebuilds — surprising operators who expected dry-run to mean inspect-only. The current contract: if a column is missing, the operator must run `aveloxis migrate` first. Postgres's "column does not exist" error is self-describing enough.
+
+If you're adding a new subcommand, do NOT call `store.Migrate`. The pre-existing test `TestNonServerCommandsDoNotMigrate` will catch it.
+
+## When NOT to write a migration
+
+Don't migrate when the change is purely in-process behavior:
+
+- Adding a new column to a Go struct that doesn't map to a DB column.
+- Refactoring a function signature.
+- Adding a new config knob (those land in `aveloxis.json`, not the DB).
+
+But bump the version anyway — the version is the only way operators tell two binaries apart. See [`code-conventions.md`](code-conventions.md).

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,317 @@
+<!--
+SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+SPDX-License-Identifier: MIT
+-->
+
+# Testing
+
+Aveloxis follows TDD as a discipline: failing test first, then implementation, then verify. This chapter covers what kinds of tests exist, when to use which, and the patterns that have proved durable.
+
+## The three tiers
+
+### Tier 1 — Unit tests
+
+Run against pure code, no database, no network. Live in `*_test.go` next to the code.
+
+```bash
+go test ./...
+```
+
+This is what CI runs and what every contributor runs constantly. Should always be green. Should always be fast (the full suite finishes in well under a minute, except for `internal/platform` which has ~40 s of network mock tests).
+
+### Tier 2 — Integration tests
+
+Run against a real PostgreSQL via the `AVELOXIS_TEST_DB` env var. Live in `*_integration_test.go` files.
+
+```bash
+AVELOXIS_TEST_DB="postgres://aveloxis:pw@localhost:5432/aveloxis_scratch?sslmode=prefer" \
+    go test ./internal/db/ -v
+```
+
+Every integration test starts with:
+
+```go
+func TestSomething(t *testing.T) {
+    dsn := os.Getenv("AVELOXIS_TEST_DB")
+    if dsn == "" {
+        t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+    }
+    // ... rest of test
+}
+```
+
+This means `go test ./...` (no env var) skips them cleanly. CI runs both modes — see `.github/workflows/integration.yml` for the Postgres-service-container recipe.
+
+**Safety:** integration tests assume a scratch database. Some helpers (`store.RealignDueDates`, the `dm_` aggregate refresh, the `cntrb_id` migration) update every matching row. Pointing them at a production database is destructive.
+
+### Tier 3 — `data-test` harness (cross-version regression detection)
+
+The `aveloxis data-test` subcommand collects the same repo into two scratch databases (one with a released-tag binary, one with the local working-tree binary) and row-count-diffs them. Catches schema-regression data loss before it ships.
+
+```bash
+aveloxis data-test \
+  --released-tag 0.23.3 \
+  --repo https://github.com/augurlabs/augur
+```
+
+This is documented in [`docs/guide/data-test.md`](../guide/data-test.md). You don't run it during normal feature work — it's the operator-side gate before a release.
+
+## TDD discipline
+
+The contract:
+
+1. **Write a failing test.** Run it. See it fail. The failure message should make it obvious what behavior is missing.
+2. **Implement the minimum needed to pass.** Don't add features beyond what the test requires.
+3. **Verify everything passes.** Run `go test ./...` AND the integration tier if your change touches the DB.
+4. **Then refactor if useful.** With tests passing, you can clean up confidently.
+
+This isn't optional. It's the rule that prevents bugs like the v0.21.0 backfill that referenced a column name that didn't exist — the source-contract test PASSED because the SQL string contained the wrong column name and the test scanned for that same wrong name. v0.21.1's lesson: source-contract tests verify the code SAYS what you wrote, not that what you wrote is CORRECT against the actual schema. Hence the integration tier.
+
+## The source-contract pattern
+
+A test that reads the implementation file and asserts certain text/structure exists. Looks like this:
+
+```go
+func TestRunMigrationsAddsOnUpdateCascadeToAllCntrbIDFKs(t *testing.T) {
+    src, err := os.ReadFile("migrate.go")
+    if err != nil {
+        t.Fatal(err)
+    }
+    code := string(src)
+
+    if !strings.Contains(code, "ON UPDATE CASCADE") {
+        t.Error("RunMigrations must add ON UPDATE CASCADE to every " +
+            "cntrb_id child FK. Without this, the v0.22.2 cntrb_id " +
+            "data migration can't propagate UPDATEs to child rows.")
+    }
+}
+```
+
+### When to use a source-contract test
+
+- Pinning a load-bearing design choice that a "helpful" refactor might silently revert. Example: the v0.20.18 negative tripwire that fails CI if `batch_size` ever reappears as a JSON tag (the field was removed; tests prevent it sneaking back).
+- Verifying the FROM of a query, the WHERE clause, the column list, when behavioral testing would require a complex DB fixture.
+- Pinning that a function is wired into the right caller (`TestRunMigrationsInvokesEnsureCntrbIDFKIndexes` proves the helper is actually called from RunMigrations).
+
+### When NOT to use a source-contract test
+
+- When you can write a behavioral test that actually exercises the code. Behavioral > source-contract every time.
+- When the "contract" is just gofmt formatting (the v0.22.0 phase-5 test had to be rewritten to be whitespace-tolerant after gofmt re-aligned a struct).
+
+### The v0.21.1 lesson
+
+Source-contract tests can give false confidence:
+
+> v0.21.0 backfill SQL referenced `aveloxis_scan.scancode_scans.created_at` but the table uses `data_collection_date`. The source-contract test pinned `MAX(created_at)` as a needle in `migrate.go` and passed because both sides of the contract agreed on the wrong answer. Production migrate failed with `ERROR: column "created_at" does not exist (SQLSTATE 42703)`.
+
+If you write a source-contract test for SQL that references a column from a different table, **also** write an integration test that runs the migration against a fresh database. The combination catches both refactor-rename drift (source-contract) and column-name typos (integration).
+
+## The behavioral test pattern
+
+Tests that exercise actual code through its public API:
+
+```go
+func TestSalvageHelperBehavioral(t *testing.T) {
+    tempDir := t.TempDir()
+    outputPath := filepath.Join(tempDir, "scan.json")
+    jsonContent := map[string]any{
+        "headers": []map[string]any{{
+            "tool_version": "32.5.0",
+            "errors":       []string{"Path: foo/bar.pdf"},
+            "extra_data":   map[string]any{"files_count": 38},
+        }},
+    }
+    b, _ := json.Marshal(jsonContent)
+    os.WriteFile(outputPath, b, 0o644)
+
+    filesCount, headerErrors, ok := salvageScancodeOutput(outputPath)
+    if !ok {
+        t.Fatal("expected salvage to succeed for valid JSON")
+    }
+    if filesCount != 38 {
+        t.Errorf("expected filesCount=38, got %d", filesCount)
+    }
+    if len(headerErrors) != 1 {
+        t.Errorf("expected 1 header error, got %d", len(headerErrors))
+    }
+}
+```
+
+Behavioral tests are preferred when they're cheap. Use source-contract tests only when behavioral testing is genuinely hard.
+
+## The integration test pattern
+
+```go
+//go:build integration  // optional, if you want a build tag
+
+func TestUpsertCommitProtectedFromInvalidUTF8(t *testing.T) {
+    dsn := os.Getenv("AVELOXIS_TEST_DB")
+    if dsn == "" {
+        t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+    }
+
+    ctx := context.Background()
+    logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+    store, err := NewPostgresStore(ctx, dsn, logger)
+    if err != nil {
+        t.Fatalf("connect: %v", err)
+    }
+    defer store.Close()
+
+    store.SetMatviewSkip(true)
+    if err := RunMigrations(ctx, store, logger); err != nil {
+        t.Fatalf("migrate: %v", err)
+    }
+
+    // Seed any prerequisite rows (e.g. a parent repo for FK satisfaction).
+    repoID := int64(-191919)
+    if _, err := store.pool.Exec(ctx, `
+        INSERT INTO aveloxis_data.repos (repo_id, platform_id, repo_git, repo_owner, repo_name, repo_archived)
+        VALUES ($1, 1, 'https://example.invalid/x', 'x', 'x', FALSE)
+        ON CONFLICT (repo_id) DO NOTHING`, repoID); err != nil {
+        t.Fatalf("seed: %v", err)
+    }
+    t.Cleanup(func() {
+        _, _ = store.pool.Exec(context.Background(),
+            `DELETE FROM aveloxis_data.commits WHERE repo_id = $1`, repoID)
+        _, _ = store.pool.Exec(context.Background(),
+            `DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, repoID)
+    })
+
+    // The actual test...
+}
+```
+
+Patterns to follow:
+
+- **Negative repo IDs** for fixture rows so they can't collide with operator-imported data.
+- **`t.Cleanup`** to delete fixtures even if the test fails mid-run.
+- **Pre-cleanup** at the top of tests that share fixture row IDs across runs (the test DB persists between invocations; without pre-cleanup a previous failure leaves rows that break the next run).
+- **Use `store.SetMatviewSkip(true)`** unless you specifically test matview behavior. Building 22+ matviews on every test run is several seconds wasted.
+
+## What to test
+
+### Always
+
+- The success case (the happy path).
+- At least one edge case — empty input, zero values, NULL, the boundary condition.
+- Any branch in the code. If `if err != nil { ... } else { ... }`, both branches need coverage.
+
+### Often valuable
+
+- Idempotency: re-running the operation shouldn't change state. Especially for migrations + backfills.
+- Concurrency edge cases: what happens if two collectors hit the same row?
+- Error-class behavior: does the right error type bubble?
+- Source-contract pins for invariants that "helpful" refactors might violate. The v0.20.18 dead-config tripwire and v0.22.13's R2-cntrb-login-preservation pin are good models.
+
+### Skip
+
+- Trivial getters/setters.
+- Pure wiring (e.g. struct initialization in main.go) — unless the wiring is load-bearing (e.g. `TestRunMigrationsInvokesUTF8Tracer`).
+- Standard library behavior (don't test `time.Now()`).
+
+## Naming
+
+Test names should describe what's pinned, not just what's tested:
+
+```
+TestRunOneAttemptsSalvageOnSubprocessFailure  // good — describes the contract
+TestRunOne                                    // bad — too vague
+TestSalvageWorks                              // bad — what does "works" mean
+```
+
+The maintainers use long test names. They show up in `go test -v` output and serve as documentation.
+
+## Run patterns
+
+```bash
+# Everything (unit only, since AVELOXIS_TEST_DB not set)
+go test ./...
+
+# One package, verbose
+go test ./internal/db/ -v
+
+# Single test
+go test ./internal/collector/ -run TestSalvageHelperBehavioral -v
+
+# Pattern match
+go test ./internal/db/ -run "TestUTF8Tracer.*" -v
+
+# Race detector (run periodically; slows tests ~2x)
+go test ./... -race
+
+# Force re-run (skip caching)
+go test ./... -count=1
+
+# Integration tier
+AVELOXIS_TEST_DB="postgres://..." go test ./internal/db/ -v -timeout 120s
+```
+
+## What good test failures look like
+
+When a test fails, the failure message should:
+
+1. Say what was expected vs what was observed.
+2. Explain WHY this matters (the load-bearing invariant being violated).
+3. Point at the relevant CLAUDE.md section or production incident if applicable.
+
+```go
+if !strings.Contains(code, "ON UPDATE CASCADE") {
+    t.Error("RunMigrations must add ON UPDATE CASCADE to every " +
+        "cntrb_id child FK. Without this, the v0.22.2 cntrb_id " +
+        "data migration can't propagate UPDATEs to child rows. " +
+        "See CLAUDE.md `Changes in v0.22.1`.")
+}
+```
+
+A future contributor seeing this fail will understand both what to fix and why. Compare to a bare `t.Error("missing CASCADE")` which leaves them spelunking.
+
+## Writing tests for code that depends on time
+
+Use `time.Now()` directly in production code; in tests, either:
+
+- Use real durations and accept ~10 ms tolerance: `if elapsed > 100*time.Millisecond { ... }`.
+- Inject a clock function: `clock func() time.Time` field on the struct.
+
+Aveloxis tends to use the first pattern — most time-sensitive code is at second / minute granularity, so millisecond drift in tests doesn't matter.
+
+## Writing tests for goroutines
+
+If your test spawns goroutines, use `sync.WaitGroup` or buffered channels to coordinate. Never use `time.Sleep` to wait for a goroutine — it's flaky.
+
+For watchdog / ticker-style code, accept an injectable ticker duration:
+
+```go
+type LongJobsWatchdog struct {
+    interval time.Duration
+    // ...
+}
+
+// In tests: use 10ms; in production: 30s.
+```
+
+## Writing tests for HTTP clients
+
+`httptest.NewServer` for full mock servers. For finer control, implement `http.RoundTripper` and inject it.
+
+```go
+type mockTransport struct {
+    handler http.HandlerFunc
+}
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    rec := httptest.NewRecorder()
+    m.handler(rec, req)
+    return rec.Result(), nil
+}
+```
+
+See `internal/platform/httpclient_test.go` for patterns. Tests like `TestHTTPClientTreats500AsTransient` use httptest to verify retry behavior without hitting GitHub.
+
+## CI
+
+GitHub Actions runs:
+
+- `test.yml`: `go test ./...` on every push.
+- `integration.yml`: PostgreSQL service container + `AVELOXIS_TEST_DB` integration tests.
+
+Both must pass for a PR to merge. The maintainers can override but rarely do.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,21 @@ architecture/db-package
 
 ```{toctree}
 :maxdepth: 2
+:caption: Contributing
+
+contributing/README
+contributing/development-setup
+contributing/code-conventions
+contributing/testing
+contributing/schema-migrations
+contributing/adding-a-platform
+contributing/adding-a-rest-endpoint
+contributing/adding-a-collection-phase
+contributing/adding-a-visualization
+```
+
+```{toctree}
+:maxdepth: 2
 :caption: Reference
 
 schema


### PR DESCRIPTION
### Added Contributor handbook

  - CONTRIBUTING.md (repo root, 66 lines) — short orientation, ground rules, pointer to the handbook.
  - docs/contributing/:
    - README.md (79) — index + codebase layout
    - development-setup.md (205) — local PostgreSQL, build/test, AVELOXIS_TEST_DB, common problems
    - code-conventions.md (245) — SPDX headers, naming, error handling, slog, version bumping, commit style
    - testing.md (317) — three-tier model (unit/integration/data-test), source-contract pattern, TDD discipline
    - schema-migrations.md (312) — addColumnIfMissing, execMigrationStep, fail-closed contract, backfill idempotency
    - adding-a-platform.md (872, the main deliverable) — Bugzilla case study with concrete code skeletons. 13 explicit steps from Platform enum to CLAUDE.md changelog, honest about what fits the existing platform.Client interface (issues, comments, contributors, events) and what doesn't (PRs, releases, git, SBOM, vulnerability scanning). Introduces the parallel-predicate design call (Platform.HasGit() alongside IsGitOnly()).
    - adding-a-rest-endpoint.md (286) — handler + store-method pattern
    - adding-a-collection-phase.md (281) — phase types (inline / background ticker / decoupled worker), cooldown discipline, staging-writer contract
    - adding-a-visualization.md (267) — Chart.js patterns, color palette, what NOT to do (no frameworks)

  Cross-references between docs are wired throughout — every chapter that mentions schema migrations or testing links to those specific chapters. The Bugzilla walkthrough explicitly cites the production patterns from the v0.18.29 enrichment pattern, the v0.20.17 cooldown discipline, the v0.19.4 fail-closed contract, and the v0.21.1 source-contract limitation lesson).