### PR TITLE
graphql empty body fix

### DIFF
--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.23.8"
+var ToolVersion = "0.23.9"

--- a/internal/platform/graphql.go
+++ b/internal/platform/graphql.go
@@ -162,6 +162,21 @@ func (c *HTTPClient) GraphQL(ctx context.Context, query string, variables map[st
 		case resp.StatusCode == http.StatusOK:
 			respBody, readErr := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
+			// v0.23.9: GitHub's GraphQL gateway has been observed
+			// returning HTTP 200 with a zero-byte body when the
+			// upstream resolver times out AFTER headers have been
+			// committed (production: apache/felix, 2026-05-21). The
+			// TCP stream closes cleanly so io.ReadAll returns
+			// (nil, nil) — no transport error to drive Fix C's
+			// retry. Synthesize io.ErrUnexpectedEOF here so the
+			// existing retry-on-fresh-stream path handles it the
+			// same way it handles mid-body RST_STREAM aborts. An
+			// empty body on a JSON endpoint is never a valid
+			// success: even GraphQL's null-data response is
+			// `{"data":null}` (15 bytes), not zero.
+			if readErr == nil && len(respBody) == 0 {
+				readErr = io.ErrUnexpectedEOF
+			}
 			if readErr != nil {
 				// Fix C (v0.18.23): an HTTP/2 RST_STREAM or a connection
 				// abort during body read used to be terminal here. In

--- a/internal/platform/graphql_empty_body_test.go
+++ b/internal/platform/graphql_empty_body_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package platform
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// v0.23.9: GitHub's GraphQL gateway has been observed returning HTTP 200
+// with a zero-byte body when the upstream resolver times out AFTER the
+// response headers have been committed. The TCP stream closes cleanly so
+// io.ReadAll returns (nil, nil) on the empty body — and the pre-v0.23.9
+// code fell straight into parseGraphQLResponse, which surfaced a cryptic
+// "decode graphql envelope: unexpected end of JSON input (body: )" error
+// that classified as ClassFatal. The v0.20.8 subdivision retry only
+// kicks in on ClassTransient/ClassRateLimit, so one bad batch sank the
+// entire collection (production: apache/felix, 2026-05-21).
+//
+// These tests pin the v0.23.9 fix: the OK branch treats an empty body
+// as a body-read failure, routing through the existing Fix C retry path.
+
+// TestGraphQLRetriesAfterEmptyBody200 is the regression test for the
+// apache/felix failure mode. First attempt: 200 OK with zero bytes.
+// Second attempt: complete response. The GraphQL call must succeed.
+func TestGraphQLRetriesAfterEmptyBody200(t *testing.T) {
+	var attempts atomic.Int32
+	const goodBody = `{"data":{"hello":"world"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			// First call: 200 OK with Content-Length: 0 and zero body.
+			// This is what GitHub's gateway returns when the upstream
+			// query resolution fails after headers have been committed.
+			// io.ReadAll on the client side sees (nil, nil) because the
+			// stream closes cleanly — there's no transport error to
+			// trigger the existing Fix C retry path.
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Length", "0")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Second call: normal complete response.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(goodBody))
+	}))
+	defer server.Close()
+
+	keys := NewKeyPool([]string{"test-token"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c := NewHTTPClient(server.URL, keys, slog.New(slog.NewTextHandler(io.Discard, nil)), AuthGitHub)
+
+	var got struct {
+		Hello string `json:"hello"`
+	}
+	err := c.GraphQL(context.Background(), "{ hello }", nil, &got)
+	if err != nil {
+		t.Fatalf("GraphQL failed after empty-body retry: %v (v0.23.9 should have retried)", err)
+	}
+	if got.Hello != "world" {
+		t.Errorf("got.Hello = %q, want \"world\" (data from second successful attempt did not decode)", got.Hello)
+	}
+	if attempts.Load() != 2 {
+		t.Errorf("expected exactly 2 attempts (first empty-body, second succeeds), got %d", attempts.Load())
+	}
+}
+
+// TestGraphQLGivesUpAfterPersistentEmptyBodies pins that the read-retry
+// budget is respected for empty-body failures the same way it is for
+// mid-body aborts. After maxReadRetries (3) consecutive empty bodies the
+// error surfaces with a "read graphql response" prefix, the call doesn't
+// loop forever, and the retry count matches the budget (1 initial + 3).
+func TestGraphQLGivesUpAfterPersistentEmptyBodies(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	keys := NewKeyPool([]string{"test-token"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c := NewHTTPClient(server.URL, keys, slog.New(slog.NewTextHandler(io.Discard, nil)), AuthGitHub)
+
+	err := c.GraphQL(context.Background(), "{ hello }", nil, nil)
+	if err == nil {
+		t.Fatal("expected error after persistent empty bodies, got nil")
+	}
+	// Expected: 1 initial + 3 read-retries = 4 attempts.
+	if n := attempts.Load(); n != 4 {
+		t.Errorf("expected 4 attempts (1 initial + 3 read-retries), got %d", n)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "read graphql response") {
+		t.Errorf("error message %q should indicate a read failure after the retry budget is exhausted", msg)
+	}
+}


### PR DESCRIPTION
### v0.23.9 

  Diagnosis confirmed: GitHub's GraphQL gateway returned HTTP 200 with a zero-byte body on one of apache/felix's PR batches. io.ReadAll returned (nil, nil) so the v0.18.23 Fix C retry never fired; the empty body fell into json.Unmarshal which produced the (body: ) error. Classified as ClassFatal, so the v0.20.8 subdivision didn't retry either. One bad batch sank all 224 PRs.
  
  Fix (3 lines in internal/platform/graphql.go): after io.ReadAll, if no error AND zero bytes, synthesize io.ErrUnexpectedEOF so the existing Fix C retry path handles it. Empty body on a JSON endpoint is never valid — even {"data":null} is 15 bytes.

  Tests (2 new, both failing pre-fix and passing post-fix):
  - TestGraphQLRetriesAfterEmptyBody200 — first attempt empty, second succeeds, asserts 2 attempts + decoded data
  - TestGraphQLGivesUpAfterPersistentEmptyBodies — pins 1+3 retry budget so we don't loop forever

  Result: full go test ./... green across all 19 packages, clean build, version bumped to 0.23.9.

  Operator deployment: go install ./cmd/aveloxis && aveloxis stop all && aveloxis start all. 