### PR TITLE
Api/contributor endpoints

### DIFF
--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -134,6 +134,115 @@ Generates and downloads a Software Bill of Materials in CycloneDX 1.5 or SPDX 2.
 
 Returns JSON with `Content-Disposition: attachment` header for download.
 
+### Contributor identities in a window
+
+```
+GET /api/v1/repos/{repoID}/contributions/identities
+GET /api/v1/repos/{repoID}/contributions/identities?since=2024-01-01
+GET /api/v1/repos/{repoID}/contributions/identities?since=2024-01-01&until=2024-12-31
+```
+
+Returns every distinct contributor who made any kind of contribution to the repo in the requested window. The result is one row per person, suitable for rendering a roster or building an affiliation chart against a derived per-person grouping.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `since` | date (YYYY-MM-DD) | 2 years ago | Window lower bound (inclusive) |
+| `until` | date (YYYY-MM-DD) | unbounded (now) | Window upper bound (inclusive — see note below) |
+
+The `until` date is treated as **inclusive** of the entire calendar day — the server shifts it by +1 day before comparing against the half-open `< upper` SQL filter, so passing `until=2024-12-31` captures everything through `2024-12-31T23:59:59.999Z`.
+
+Malformed dates fall back to the defaults rather than returning 400, matching the existing `/timeseries` endpoint behavior so charts and dashboards keep rendering. The one validation error that does surface as 400 is `since >= until`, which is almost certainly an operator typo.
+
+Response shape:
+
+```json
+[
+  {
+    "cntrb_id": "01000001-0000-4000-8000-000000000000",
+    "login": "alice",
+    "full_name": "Alice Anderson",
+    "email": "alice@example.com",
+    "profile_company": "Acme Corp",
+    "location": "Berlin"
+  },
+  ...
+]
+```
+
+All string fields are normalized server-side: `""` represents "no value recorded" (no per-field null handling needed on the client). Ordering is by `login NULLS LAST, full_name NULLS LAST` so unidentifiable contributors sort to the bottom of the roster.
+
+**What counts as a contribution** (all in one window via the unified messages table and the standard work-tracking tables):
+
+| Kind | Source table | Time column |
+|---|---|---|
+| Commit authorship | `aveloxis_data.commits` | `cmt_author_timestamp` |
+| Issue opened | `aveloxis_data.issues` (`reporter_id`) | `created_at` |
+| Issue closed | `aveloxis_data.issues` (`closed_by_id`) | `closed_at` |
+| Issue event (label / assignment / reference) | `aveloxis_data.issue_events` | `created_at` |
+| PR opened | `aveloxis_data.pull_requests` (`author_id`) | `created_at` |
+| PR review submitted | `aveloxis_data.pull_request_reviews` | `submitted_at` |
+| PR event | `aveloxis_data.pull_request_events` | `created_at` |
+| Any message (issue comment, PR conversation comment, inline review comment body) | `aveloxis_data.messages` | `msg_timestamp` |
+
+Per the "Unified message architecture" contract, all three text-contribution kinds live in `messages` with `cntrb_id` as the author — one filter covers them all.
+
+**What's intentionally not counted**:
+
+- **Assignees and reviewers** who never actually *did* anything — being asked to review isn't a contribution. They show up in `*_assignees` / `*_reviewers` tables but aren't surfaced here.
+- **Commits whose `cmt_ght_author_id` is NULL** — these are commits aveloxis hasn't been able to resolve to a contributor row (private email, or the search-resolve background ticker hasn't reached them yet). They don't have a `cntrb_id` to return. The number of such commits in a given window is queryable via the metric endpoints (`/code-changes`) and the gap is closed over time by the v0.19.2 search-resolve work.
+- **`contributor_repo` rows from the breadth worker** — those represent "this person was active *anywhere* on the repo at some point" but the time semantics are different (collection-cycle timestamp, not when the contribution happened), so they don't belong in a contribution-window query.
+- **Soft-deleted contributors** (`cntrb_deleted != 0`) — the v0.20.2 logical-merge path marks loser rows when a rename was detected. Filtering them out is the contract; merged identities surface only under the winning `cntrb_id`.
+
+### Affiliation breakdown for the same window
+
+```
+GET /api/v1/repos/{repoID}/contributions/affiliations
+GET /api/v1/repos/{repoID}/contributions/affiliations?since=2024-01-01&until=2024-12-31
+```
+
+Returns the count of **distinct contributors** per affiliation, using the same window and the same contribution-kind definition as `/contributions/identities`. The two endpoints share a single SQL CTE on the server so the two responses can never disagree on which people are in scope — a sum across this endpoint's `contributor_count` values equals the row count of `/contributions/identities`.
+
+Same `since` / `until` parameters as the identities endpoint; same behavior on malformed input and `since >= until`.
+
+Response shape:
+
+```json
+[
+  {"affiliation": "Acme Corp", "contributor_count": 47},
+  {"affiliation": "RedHat",    "contributor_count": 12},
+  {"affiliation": "(unknown)", "contributor_count": 31}
+]
+```
+
+Ordered by `contributor_count DESC` then `affiliation ASC`. The `(unknown)` bucket is included rather than hidden so callers can decide whether to surface unaffiliated contributors (often the right call on community projects) or omit them.
+
+**Affiliation derivation priority** (applied per-contributor):
+
+1. **`contributor_affiliations[domain_of(cntrb_canonical)]`** — the curated email-domain → org map maintained by aveloxis's `PopulateAffiliations` background task. This is the most reliable signal because it covers people whose GitHub/GitLab profile is blank but whose verified email domain is well-known (e.g. `@redhat.com` → "RedHat").
+2. **`cntrb_company`** — what the user typed into their GitHub or GitLab profile. Freeform text; often blank, sometimes "@org" (the GitHub `@`-mention reference style — aveloxis strips the leading `@` before using it as an affiliation label).
+3. **`(unknown)`** — fallback bucket for contributors with neither a domain-mapped canonical email nor a profile company string.
+
+The derivation priority is deliberate: the curated domain map is updated by a background task that watches observed contributor data, while the profile field is freeform and easily stale ("Self-employed", "Earth", typos of well-known company names, etc.). When both are present the domain-mapped value wins because it's more likely to be canonical.
+
+### Tweaks you can make on the client side
+
+- **Narrow to creative work only**: this endpoint includes everything. To exclude event-only activity (labels, references) post-process the identities list against another endpoint that's restricted to commits/PRs/issues only, or filter on the client.
+- **Group of repos**: the two endpoints are per-repo. For an org-wide rollup, call them for each repo in the group and merge the responses (the `cntrb_id` column is stable across repos so dedup is trivial).
+- **Hide the `(unknown)` bucket**: filter on the client. The server returns it so the math reconciles with `/contributions/identities`.
+- **Different windows**: `?since=YYYY-MM-DD` and `?until=YYYY-MM-DD` are both accepted independently. Omit `until` for "everything since `since`".
+
+### When to use which endpoint
+
+| Need | Use |
+|---|---|
+| "Who contributed to this repo in the last two years?" | `/contributions/identities` |
+| "How many people from each company contributed?" | `/contributions/affiliations` |
+| "How many *new* contributors per month did this repo gain?" (Augur metric) | `/contributors-new` (the Augur-compatible aggregate endpoint) |
+| "Total contributor count, no window" | `/contributors` (the Augur-compatible monthly aggregate) |
+| "How many commits per week?" | `/timeseries` |
+
+The Augur-compatible endpoints (`/contributors`, `/contributors-new`, etc.) follow Augur's swagger spec with `begin_date` / `end_date` / `period` query params and return aggregated counts. The v0.23.10 `/contributions/*` endpoints follow the aveloxis convention (`since` / `until`) and return per-contributor identity rows and a single aggregated affiliation roll-up. The two groups serve different questions and don't overlap.
+
 ## CORS
 
 All API endpoints return `Access-Control-Allow-Origin: *` to allow cross-origin requests from the web GUI (which runs on a different port).

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -231,17 +231,92 @@ The derivation priority is deliberate: the curated domain map is updated by a ba
 - **Hide the `(unknown)` bucket**: filter on the client. The server returns it so the math reconciles with `/contributions/identities`.
 - **Different windows**: `?since=YYYY-MM-DD` and `?until=YYYY-MM-DD` are both accepted independently. Omit `until` for "everything since `since`".
 
+### Knowing whether your coverage is complete
+
+```
+GET /api/v1/repos/{repoID}/contributions/coverage
+GET /api/v1/repos/{repoID}/contributions/coverage?since=2024-01-01&until=2024-12-31
+```
+
+Returns the enrichment-state snapshot for the same cohort as `/contributions/identities` and `/contributions/affiliations`. Operators call this **before drawing conclusions** from the affiliation breakdown to tell whether an `(unknown)` bucket represents truly unaffiliated contributors or just people the v0.18.29 enrichment ticker hasn't reached yet.
+
+Same `since` / `until` parameters as the other two endpoints; same behavior on malformed input and `since >= until`.
+
+Response shape:
+
+```json
+{
+  "window_since": "2024-05-21T00:00:00Z",
+  "window_until": "2026-05-21T00:00:00Z",
+  "total_contributors":       412,
+  "enriched":                  389,
+  "canonical_email":           356,
+  "gh_user_id_resolved":       401,
+  "search_resolve_attempted":   47,
+  "breadth_attempted":         378,
+  "affiliation_resolved":      318,
+  "affiliation_unknown":        94,
+  "enrichment_oldest_pending": "2026-05-12T18:31:04Z",
+  "enrichment_stalest":        "2024-08-15T03:22:11Z"
+}
+```
+
+The two timestamp fields are omitted entirely when the cohort has no rows in the relevant state (no pointer → field absent in JSON rather than emitting zero-time, which is operator-confusing).
+
+**Reading the response.** A response with `total=412, enriched=389, affiliation_resolved=318, affiliation_unknown=94` reads as:
+
+> 412 people contributed in the window. 389 of them have been successfully enriched via `/users/{login}` and 23 haven't yet — the enrichment ticker is still working through them. 318 have a resolvable affiliation (either via the curated email-domain map or via their profile company field). 94 are bucketed as `(unknown)` — but 23 of those might be the unenriched cohort that will pick up an affiliation once the ticker reaches them. So the **true** unaffiliated count for this window is somewhere between **71** (if all 23 unenriched contributors turn out to be unaffiliated) and **94** (if none of them do).
+
+Operators surface this floor-and-ceiling on dashboards rather than reporting `(unknown)` alone — the latter conflates "no affiliation" with "we haven't asked yet."
+
+**Field-by-field reference**:
+
+| Field | Source signal | What it tells you |
+|---|---|---|
+| `total_contributors` | The cohort | Denominator for everything else |
+| `enriched` | `contributors.cntrb_last_enriched_at IS NOT NULL` | `/users/{login}` successfully ran via v0.18.29 enrichment ticker (30-day cooldown) |
+| `canonical_email` | `contributors.cntrb_canonical != ''` | Verified email known — drives domain → affiliation lookup |
+| `gh_user_id_resolved` | `contributors.gh_user_id IS NOT NULL` | Person matched to numeric GitHub user (stable identity across renames) |
+| `search_resolve_attempted` | `contributors.cntrb_last_search_attempted_at IS NOT NULL` | v0.19.2 search-resolve ticker has tried to look this person up by email (60-min cooldown, 30-day re-attempt) |
+| `breadth_attempted` | `contributors.cntrb_last_breadth_at IS NOT NULL` | v0.20.17 breadth worker has tried `/users/{login}/events` (7-day cooldown) |
+| `affiliation_resolved` | Domain-mapped via `contributor_affiliations` OR `cntrb_company != ''` | Will show up under a non-`(unknown)` affiliation in `/contributions/affiliations` |
+| `affiliation_unknown` | `total_contributors − affiliation_resolved` | The `(unknown)` bucket in the affiliations breakdown |
+| `enrichment_oldest_pending` | `MIN(data_collection_date)` among rows with NULL `cntrb_last_enriched_at` | How long the most-delayed unenriched contributor has been waiting — compare against your configured `enrich_interval_minutes` cadence |
+| `enrichment_stalest` | `MIN(cntrb_last_enriched_at)` among enriched rows | Oldest "last refreshed" timestamp — surfaces the long tail of "enriched 18 months ago and never refreshed" |
+
+**Spotting a stuck enrichment ticker.** If `enrichment_oldest_pending` is more than ~2× your configured `enrich_interval_minutes` behind `NOW()`, the ticker may be stuck. Investigation:
+
+```bash
+# What does the enrich interval look like?
+grep enrich_interval_minutes ~/.aveloxis/aveloxis.json
+
+# Has the enrichment ticker been ticking?
+grep -E "EnrichThinContributors|enrichment" ~/.aveloxis/aveloxis.log | tail -20
+
+# Are we burning API budget?
+grep -E "all API keys rate-limited|rate limit" ~/.aveloxis/aveloxis.log | tail -10
+```
+
+If the ticker is running but enrichment is still falling behind, it's almost always API-key budget exhaustion (the v0.18.29 `EnrichBatchSize = 14000` per tick is sized for a 73-key fleet; smaller key pools can't keep up).
+
+**What this endpoint doesn't tell you**:
+
+- **Per-affiliation coverage drill-down**: the response is global to the cohort. If you need "what % of Acme Corp contributors have canonical emails" specifically, that's a derived query — call `/identities` and group client-side, or open an issue for a per-affiliation coverage endpoint.
+- **Whether `PopulateAffiliations` is current**: the domain-mapped affiliations come from the `contributor_affiliations` table, which is rebuilt hourly by the v0.19.7 ticker. The table state at any given moment reflects the most recent successful rebuild, not a continuous live view. If you've just added new contributors with novel company strings, give it an hour for `PopulateAffiliations` to surface them in the map.
+- **Fleet-wide coverage**: this endpoint is per-repo. For a fleet-wide rollup, call it per repo and aggregate (or, if there's operator demand, request a `/api/v1/contributions/coverage` global endpoint as a follow-up).
+
 ### When to use which endpoint
 
 | Need | Use |
 |---|---|
 | "Who contributed to this repo in the last two years?" | `/contributions/identities` |
 | "How many people from each company contributed?" | `/contributions/affiliations` |
+| "Is the affiliation data trustworthy yet, or is enrichment still catching up?" | `/contributions/coverage` |
 | "How many *new* contributors per month did this repo gain?" (Augur metric) | `/contributors-new` (the Augur-compatible aggregate endpoint) |
 | "Total contributor count, no window" | `/contributors` (the Augur-compatible monthly aggregate) |
 | "How many commits per week?" | `/timeseries` |
 
-The Augur-compatible endpoints (`/contributors`, `/contributors-new`, etc.) follow Augur's swagger spec with `begin_date` / `end_date` / `period` query params and return aggregated counts. The v0.23.10 `/contributions/*` endpoints follow the aveloxis convention (`since` / `until`) and return per-contributor identity rows and a single aggregated affiliation roll-up. The two groups serve different questions and don't overlap.
+The Augur-compatible endpoints (`/contributors`, `/contributors-new`, etc.) follow Augur's swagger spec with `begin_date` / `end_date` / `period` query params and return aggregated counts. The `/contributions/*` endpoints follow the aveloxis convention (`since` / `until`) and return per-contributor identity rows, an aggregated affiliation roll-up, and a coverage snapshot respectively. The two groups serve different questions and don't overlap.
 
 ## CORS
 

--- a/internal/api/contributions.go
+++ b/internal/api/contributions.go
@@ -76,6 +76,37 @@ func (s *Server) handleRepoContributors(w http.ResponseWriter, r *http.Request) 
 	_ = json.NewEncoder(w).Encode(contribs)
 }
 
+// handleRepoContributionsCoverage returns the enrichment-state
+// snapshot for the same cohort as /identities and /affiliations: how
+// many contributors have been enriched / have a canonical email / have
+// a resolved gh_user_id / have an affiliation. The "are my numbers
+// trustworthy?" endpoint — operators read this before drawing
+// conclusions from /affiliations. See store-side
+// GetRepoContributionsCoverage and docs/guide/api.md for the full
+// semantics of each field.
+func (s *Server) handleRepoContributionsCoverage(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	since, until, ok := parseWindow(r)
+	if !ok {
+		http.Error(w, "since must be before until", http.StatusBadRequest)
+		return
+	}
+
+	cov, err := s.store.GetRepoContributionsCoverage(r.Context(), repoID, since, until)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	setCORSIfLocalhost(r, w)
+	_ = json.NewEncoder(w).Encode(cov)
+}
+
 // handleRepoAffiliations returns the per-affiliation contributor count
 // for the same window. The "(unknown)" bucket is included in the
 // response so the caller can decide whether to surface or hide it.

--- a/internal/api/contributions.go
+++ b/internal/api/contributions.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// parseWindow parses ?since=YYYY-MM-DD and ?until=YYYY-MM-DD off the
+// request and returns a (since, until) pair shaped exactly like the
+// existing handleTimeSeries window:
+//
+//   - default since: 2 years ago.
+//   - default until: zero time, which the store layer treats as "no
+//     upper bound" via resolveWindow.
+//   - until is treated as INCLUSIVE — we advance it one day before
+//     handing off to the store, so the store's exclusive-upper
+//     comparison includes the end-date.
+//
+// An invalid date in either field reverts that field to its default
+// instead of erroring, matching the existing timeseries behavior so
+// charts and dashboards keep rendering on malformed input.
+//
+// Returns ok=false if since >= until after parsing — the caller
+// surfaces a 400 in that case.
+func parseWindow(r *http.Request) (since, until time.Time, ok bool) {
+	since = time.Now().AddDate(-2, 0, 0)
+	if sinceParam := r.URL.Query().Get("since"); sinceParam != "" {
+		if t, err := time.Parse("2006-01-02", sinceParam); err == nil {
+			since = t
+		}
+	}
+	var u time.Time
+	if untilParam := r.URL.Query().Get("until"); untilParam != "" {
+		if t, err := time.Parse("2006-01-02", untilParam); err == nil {
+			// Inclusive end-date: shift by one day so the store's
+			// exclusive-upper compare (< $3) covers the requested
+			// final calendar day.
+			u = t.AddDate(0, 0, 1)
+		}
+	}
+	if !u.IsZero() && !since.Before(u) {
+		return since, u, false
+	}
+	return since, u, true
+}
+
+// handleRepoContributors returns all distinct contributors who made any
+// kind of contribution to the repo in the requested window. See the
+// store-side GetRepoContributors docstring and docs/guide/api.md for
+// the full inclusion list and known limitations.
+func (s *Server) handleRepoContributors(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	since, until, ok := parseWindow(r)
+	if !ok {
+		http.Error(w, "since must be before until", http.StatusBadRequest)
+		return
+	}
+
+	contribs, err := s.store.GetRepoContributors(r.Context(), repoID, since, until)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	setCORSIfLocalhost(r, w)
+	_ = json.NewEncoder(w).Encode(contribs)
+}
+
+// handleRepoAffiliations returns the per-affiliation contributor count
+// for the same window. The "(unknown)" bucket is included in the
+// response so the caller can decide whether to surface or hide it.
+func (s *Server) handleRepoAffiliations(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	since, until, ok := parseWindow(r)
+	if !ok {
+		http.Error(w, "since must be before until", http.StatusBadRequest)
+		return
+	}
+
+	counts, err := s.store.GetRepoAffiliationCounts(r.Context(), repoID, since, until)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	setCORSIfLocalhost(r, w)
+	_ = json.NewEncoder(w).Encode(counts)
+}

--- a/internal/api/contributions_test.go
+++ b/internal/api/contributions_test.go
@@ -15,10 +15,11 @@ import (
 // Source-contract: routes are registered + handlers exist
 // ============================================================
 
-// TestContributionsRoutesRegistered pins that the two v0.23.10 routes
-// flow through the same mux as the existing endpoints. If a future
-// refactor moves them to a different package or drops the registration,
-// this test catches it.
+// TestContributionsRoutesRegistered pins that the three contributions
+// routes (v0.23.10 identities + affiliations, v0.23.11 coverage) flow
+// through the same mux as the existing endpoints. If a future refactor
+// moves them to a different package or drops the registration, this
+// test catches it.
 func TestContributionsRoutesRegistered(t *testing.T) {
 	body, err := os.ReadFile("server.go")
 	if err != nil {
@@ -28,12 +29,39 @@ func TestContributionsRoutesRegistered(t *testing.T) {
 	for _, needle := range []string{
 		`/api/v1/repos/{repoID}/contributions/identities`,
 		`/api/v1/repos/{repoID}/contributions/affiliations`,
+		`/api/v1/repos/{repoID}/contributions/coverage`,
 		`s.handleRepoContributors`,
 		`s.handleRepoAffiliations`,
+		`s.handleRepoContributionsCoverage`,
 	} {
 		if !strings.Contains(src, needle) {
 			t.Errorf("server.go missing route registration token %q", needle)
 		}
+	}
+}
+
+// TestRepoContributionsCoverage_InvalidID pins the 400-on-bad-repo_id
+// contract for the coverage endpoint.
+func TestRepoContributionsCoverage_InvalidID(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/v1/repos/abc/contributions/coverage", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for invalid repo_id", w.Code)
+	}
+}
+
+// TestRepoContributionsCoverage_SinceAfterUntil pins the same
+// window-validation contract as the other two endpoints.
+func TestRepoContributionsCoverage_SinceAfterUntil(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET",
+		"/api/v1/repos/1/contributions/coverage?since=2026-01-01&until=2025-01-01", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for since >= until", w.Code)
 	}
 }
 

--- a/internal/api/contributions_test.go
+++ b/internal/api/contributions_test.go
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// Source-contract: routes are registered + handlers exist
+// ============================================================
+
+// TestContributionsRoutesRegistered pins that the two v0.23.10 routes
+// flow through the same mux as the existing endpoints. If a future
+// refactor moves them to a different package or drops the registration,
+// this test catches it.
+func TestContributionsRoutesRegistered(t *testing.T) {
+	body, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("read server.go: %v", err)
+	}
+	src := string(body)
+	for _, needle := range []string{
+		`/api/v1/repos/{repoID}/contributions/identities`,
+		`/api/v1/repos/{repoID}/contributions/affiliations`,
+		`s.handleRepoContributors`,
+		`s.handleRepoAffiliations`,
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("server.go missing route registration token %q", needle)
+		}
+	}
+}
+
+// ============================================================
+// Parameter validation (nil store — routing-layer only)
+// ============================================================
+
+func TestRepoContributors_InvalidID(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/v1/repos/abc/contributions/identities", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for invalid repo_id", w.Code)
+	}
+}
+
+func TestRepoAffiliations_InvalidID(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/v1/repos/abc/contributions/affiliations", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for invalid repo_id", w.Code)
+	}
+}
+
+// TestRepoContributors_SinceAfterUntil pins that an invalid window
+// surfaces as 400 instead of being silently flipped to a default
+// (which would mask the operator's mistake).
+func TestRepoContributors_SinceAfterUntil(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET",
+		"/api/v1/repos/1/contributions/identities?since=2026-01-01&until=2025-01-01", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for since >= until", w.Code)
+	}
+}
+
+func TestRepoAffiliations_SinceAfterUntil(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET",
+		"/api/v1/repos/1/contributions/affiliations?since=2026-01-01&until=2025-01-01", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for since >= until", w.Code)
+	}
+}
+
+// ============================================================
+// parseWindow unit tests
+// ============================================================
+
+// TestParseWindowDefaults pins the 2-year default for ?since with no
+// upper bound (zero until). Matches the operator's "last 2 years" ask
+// from the original query request.
+func TestParseWindowDefaults(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/v1/repos/1/contributions/identities", nil)
+	since, until, ok := parseWindow(r)
+	if !ok {
+		t.Fatal("default window should be ok")
+	}
+	// since should be ~2 years before now; until should be zero.
+	if since.IsZero() {
+		t.Error("default since should not be zero")
+	}
+	if !until.IsZero() {
+		t.Error("default until should be zero (unbounded)")
+	}
+}
+
+// TestParseWindowInclusiveUntil pins the "until is inclusive" contract:
+// a YYYY-MM-DD until param is shifted by +1 day before going to the
+// store, so the store's exclusive-upper comparison includes the
+// requested final calendar day.
+func TestParseWindowInclusiveUntil(t *testing.T) {
+	r := httptest.NewRequest("GET",
+		"/api/v1/repos/1/contributions/identities?since=2024-01-01&until=2024-12-31", nil)
+	since, until, ok := parseWindow(r)
+	if !ok {
+		t.Fatal("window should be ok")
+	}
+	if since.Format("2006-01-02") != "2024-01-01" {
+		t.Errorf("since = %v, want 2024-01-01", since)
+	}
+	// until passed as 2024-12-31 should land as 2025-01-01 after the
+	// inclusive-end shift.
+	if until.Format("2006-01-02") != "2025-01-01" {
+		t.Errorf("until = %v, want 2025-01-01 (one day past 2024-12-31)", until)
+	}
+}
+
+// TestParseWindowInvalidSinceFallsBackToDefault pins the
+// "malformed input doesn't error" behavior — matches the existing
+// /timeseries endpoint's resilience.
+func TestParseWindowInvalidSinceFallsBackToDefault(t *testing.T) {
+	r := httptest.NewRequest("GET",
+		"/api/v1/repos/1/contributions/identities?since=garbage", nil)
+	since, _, ok := parseWindow(r)
+	if !ok {
+		t.Fatal("garbage since should fall back, not error")
+	}
+	if since.IsZero() {
+		t.Error("since should fall back to 2-year default, not zero")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,6 +53,7 @@ func New(store *db.PostgresStore, logger *slog.Logger) *Server {
 	// so they can never drift on the definition of "contribution."
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributions/identities", s.handleRepoContributors)
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributions/affiliations", s.handleRepoAffiliations)
+	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributions/coverage", s.handleRepoContributionsCoverage)
 	s.mux.HandleFunc("GET /api/v1/repos/search", s.handleRepoSearch)
 	s.registerMetricRoutes()
 	return s

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -44,6 +44,15 @@ func New(store *db.PostgresStore, logger *slog.Logger) *Server {
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/licenses", s.handleLicenses)
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/scancode-licenses", s.handleScancodeLicenses)
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/scancode-files", s.handleScancodeFiles)
+	// v0.23.10 — list-of-identities + affiliation-breakdown over an
+	// operator-supplied time window. Nested under contributions/ so the
+	// paths don't collide with the Augur-compatible
+	// /api/v1/repos/{repoID}/contributors metric (which returns
+	// aggregated counts per Augur's swagger spec). The two endpoints
+	// share a single SQL CTE on the store side (contributorsInWindowCTE)
+	// so they can never drift on the definition of "contribution."
+	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributions/identities", s.handleRepoContributors)
+	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributions/affiliations", s.handleRepoAffiliations)
 	s.mux.HandleFunc("GET /api/v1/repos/search", s.handleRepoSearch)
 	s.registerMetricRoutes()
 	return s

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// RepoContributor is a single contributor returned by GetRepoContributors.
+// All "may be empty" string fields are passed through NULLIF/COALESCE in
+// SQL so the Go-side value is either the meaningful text or "" — callers
+// can render it directly without per-field null checks.
+type RepoContributor struct {
+	CntrbID        string `json:"cntrb_id"`
+	Login          string `json:"login"`
+	FullName       string `json:"full_name"`
+	Email          string `json:"email"`
+	ProfileCompany string `json:"profile_company"`
+	Location       string `json:"location"`
+}
+
+// AffiliationCount is a single row in the affiliation breakdown returned
+// by GetRepoAffiliationCounts. ContributorCount is the number of DISTINCT
+// contributors (not the number of contributions) tagged with the
+// affiliation in the requested window.
+type AffiliationCount struct {
+	Affiliation      string `json:"affiliation"`
+	ContributorCount int    `json:"contributor_count"`
+}
+
+// contributorsInWindowCTE is the shared SQL fragment that enumerates every
+// distinct cntrb_id that produced any kind of contribution to repoID
+// between since and until. Defined once here and embedded into both
+// GetRepoContributors and GetRepoAffiliationCounts so the two endpoints
+// can never drift on which actions count as "contribution."
+//
+// The contribution kinds covered are documented in docs/guide/api.md
+// under "Contributors in a window" / "Affiliation breakdown." Adding a
+// new kind means adding a UNION arm here AND updating that doc — both
+// pinned by source-contract tests.
+//
+// All arms reference the same three positional parameters: $1=repoID,
+// $2=since, $3=until.
+const contributorsInWindowCTE = `
+contributors_in_window AS (
+    -- Commit authorship: cmt_author_timestamp is the TIMESTAMPTZ field
+    -- (cmt_author_date is TEXT and not safe to range-filter).
+    SELECT DISTINCT c.cmt_ght_author_id AS cntrb_id
+    FROM aveloxis_data.commits c
+    WHERE c.repo_id = $1
+      AND c.cmt_ght_author_id IS NOT NULL
+      AND c.cmt_author_timestamp >= $2
+      AND c.cmt_author_timestamp <  $3
+
+    UNION
+    SELECT DISTINCT i.reporter_id
+    FROM aveloxis_data.issues i
+    WHERE i.repo_id = $1 AND i.reporter_id IS NOT NULL
+      AND i.created_at >= $2 AND i.created_at < $3
+
+    UNION
+    SELECT DISTINCT i.closed_by_id
+    FROM aveloxis_data.issues i
+    WHERE i.repo_id = $1 AND i.closed_by_id IS NOT NULL
+      AND i.closed_at >= $2 AND i.closed_at < $3
+
+    UNION
+    SELECT DISTINCT e.cntrb_id
+    FROM aveloxis_data.issue_events e
+    WHERE e.repo_id = $1 AND e.cntrb_id IS NOT NULL
+      AND e.created_at >= $2 AND e.created_at < $3
+
+    UNION
+    SELECT DISTINCT pr.author_id
+    FROM aveloxis_data.pull_requests pr
+    WHERE pr.repo_id = $1 AND pr.author_id IS NOT NULL
+      AND pr.created_at >= $2 AND pr.created_at < $3
+
+    UNION
+    SELECT DISTINCT prr.cntrb_id
+    FROM aveloxis_data.pull_request_reviews prr
+    WHERE prr.repo_id = $1 AND prr.cntrb_id IS NOT NULL
+      AND prr.submitted_at >= $2 AND prr.submitted_at < $3
+
+    UNION
+    SELECT DISTINCT pe.cntrb_id
+    FROM aveloxis_data.pull_request_events pe
+    WHERE pe.repo_id = $1 AND pe.cntrb_id IS NOT NULL
+      AND pe.created_at >= $2 AND pe.created_at < $3
+
+    UNION
+    -- Unified messages: issue comments + PR conversation comments +
+    -- inline review comment bodies all live here. cntrb_id is the
+    -- author across all three message kinds.
+    SELECT DISTINCT m.cntrb_id
+    FROM aveloxis_data.messages m
+    WHERE m.repo_id = $1 AND m.cntrb_id IS NOT NULL
+      AND m.msg_timestamp >= $2 AND m.msg_timestamp < $3
+)`
+
+// resolveWindow normalizes a (since, until) pair the same way
+// GetRepoTimeSeries does: a zero until is treated as "no upper bound"
+// by substituting a far-future timestamp so the SQL stays parameterized.
+// A zero since is treated as "since the beginning of time" (1970-01-01).
+// since must be strictly less than until; the caller validates this and
+// surfaces a 400 if violated.
+func resolveWindow(since, until time.Time) (time.Time, time.Time) {
+	lower := since
+	if lower.IsZero() {
+		lower = time.Unix(0, 0)
+	}
+	upper := until
+	if upper.IsZero() {
+		upper = time.Now().AddDate(100, 0, 0)
+	}
+	return lower, upper
+}
+
+// GetRepoContributors returns every distinct contributor who made any
+// kind of contribution to repoID between since and until.
+//
+// "Contribution" covers: commit authorship, opening or closing an issue,
+// opening a PR, submitting a PR review, any issue or PR event (label /
+// assignment / reference), and any message (issue comment, PR
+// conversation comment, inline review comment body — all unified in
+// aveloxis_data.messages per the architecture doc).
+//
+// Soft-deleted contributors (cntrb_deleted != 0, set by the v0.20.2
+// rename-merge path) are excluded; the operator wants active identities,
+// not merge tombstones.
+//
+// Commits whose cmt_ght_author_id is NULL — author email never matched
+// a known contributor — are excluded. Those people don't have a cntrb_id
+// to return; surfacing them would require a separate "unresolved commit
+// authors" endpoint that returns name+email tuples instead.
+func (s *PostgresStore) GetRepoContributors(ctx context.Context, repoID int64, since, until time.Time) ([]RepoContributor, error) {
+	lower, upper := resolveWindow(since, until)
+
+	sql := `
+WITH ` + contributorsInWindowCTE + `
+SELECT
+    c.cntrb_id::text,
+    COALESCE(NULLIF(c.cntrb_login, ''), c.gh_login, c.gl_username, '') AS login,
+    COALESCE(NULLIF(c.cntrb_full_name, ''), '')                        AS full_name,
+    COALESCE(NULLIF(c.cntrb_email, ''), '')                            AS email,
+    COALESCE(NULLIF(c.cntrb_company, ''), '')                          AS profile_company,
+    COALESCE(NULLIF(c.cntrb_location, ''), '')                         AS location
+FROM contributors_in_window ciw
+JOIN aveloxis_data.contributors c USING (cntrb_id)
+WHERE COALESCE(c.cntrb_deleted, 0) = 0
+ORDER BY login NULLS LAST, full_name NULLS LAST`
+
+	rows, err := s.pool.Query(ctx, sql, repoID, lower, upper)
+	if err != nil {
+		return nil, fmt.Errorf("GetRepoContributors query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]RepoContributor, 0, 128)
+	for rows.Next() {
+		var rc RepoContributor
+		if err := rows.Scan(&rc.CntrbID, &rc.Login, &rc.FullName, &rc.Email, &rc.ProfileCompany, &rc.Location); err != nil {
+			return nil, fmt.Errorf("GetRepoContributors scan: %w", err)
+		}
+		out = append(out, rc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetRepoContributors rows: %w", err)
+	}
+	return out, nil
+}
+
+// GetRepoAffiliationCounts returns the number of DISTINCT contributors
+// per affiliation in the same window as GetRepoContributors.
+//
+// Affiliation derivation priority (per-contributor):
+//  1. contributor_affiliations[domain_of(cntrb_canonical)] — the curated
+//     email-domain → org map populated by PopulateAffiliations from
+//     observed company strings. Most reliable signal because it covers
+//     people whose profile is blank but whose email domain is well-known.
+//  2. cntrb_company (with leading "@" stripped to handle the GitHub
+//     "@org" reference style) — what the user typed into their profile.
+//     Freeform and often empty.
+//  3. "(unknown)" — fallback bucket for contributors with neither a
+//     canonical-email match nor a company string.
+//
+// The "(unknown)" row is included in the result so the count is
+// honest about coverage; callers can hide or surface it as desired.
+func (s *PostgresStore) GetRepoAffiliationCounts(ctx context.Context, repoID int64, since, until time.Time) ([]AffiliationCount, error) {
+	lower, upper := resolveWindow(since, until)
+
+	sql := `
+WITH ` + contributorsInWindowCTE + `,
+with_affiliation AS (
+    SELECT
+        c.cntrb_id,
+        COALESCE(
+            NULLIF(ca.ca_affiliation, ''),
+            NULLIF(REGEXP_REPLACE(c.cntrb_company, '^@', ''), ''),
+            '(unknown)'
+        ) AS affiliation
+    FROM contributors_in_window ciw
+    JOIN aveloxis_data.contributors c USING (cntrb_id)
+    LEFT JOIN aveloxis_data.contributor_affiliations ca
+        ON LOWER(SPLIT_PART(c.cntrb_canonical, '@', 2)) = LOWER(ca.ca_domain)
+        AND COALESCE(ca.ca_active, 1) = 1
+    WHERE COALESCE(c.cntrb_deleted, 0) = 0
+)
+SELECT affiliation, COUNT(*)::int AS contributor_count
+FROM with_affiliation
+GROUP BY affiliation
+ORDER BY contributor_count DESC, affiliation`
+
+	rows, err := s.pool.Query(ctx, sql, repoID, lower, upper)
+	if err != nil {
+		return nil, fmt.Errorf("GetRepoAffiliationCounts query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]AffiliationCount, 0, 32)
+	for rows.Next() {
+		var ac AffiliationCount
+		if err := rows.Scan(&ac.Affiliation, &ac.ContributorCount); err != nil {
+			return nil, fmt.Errorf("GetRepoAffiliationCounts scan: %w", err)
+		}
+		out = append(out, ac)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetRepoAffiliationCounts rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -173,6 +173,131 @@ ORDER BY login NULLS LAST, full_name NULLS LAST`
 	return out, nil
 }
 
+// ContributionsCoverage answers "is the data I'm about to render
+// complete?" for a given (repo, window) pair. The other two
+// contributions endpoints expose the cohort and its affiliation
+// breakdown; this one exposes what the cohort's enrichment STATE looks
+// like so the operator can tell whether an "(unknown)" bucket
+// represents true unaffiliated contributors vs. people the v0.18.29
+// enrichment ticker simply hasn't reached yet.
+//
+// All count fields are integers; the two timestamp fields are nullable
+// (encoded as the Go zero time when the cohort has no matching rows
+// — JSON-serialized as the omitempty default to keep the response
+// shape stable).
+type ContributionsCoverage struct {
+	WindowSince            time.Time `json:"window_since"`
+	WindowUntil            time.Time `json:"window_until"`
+	TotalContributors      int       `json:"total_contributors"`
+	Enriched               int       `json:"enriched"`
+	CanonicalEmail         int       `json:"canonical_email"`
+	GHUserIDResolved       int       `json:"gh_user_id_resolved"`
+	SearchResolveAttempted int       `json:"search_resolve_attempted"`
+	BreadthAttempted       int       `json:"breadth_attempted"`
+	AffiliationResolved    int       `json:"affiliation_resolved"`
+	AffiliationUnknown     int       `json:"affiliation_unknown"`
+	// Nullable: pointer + omitempty so JSON omits the field entirely
+	// when the cohort has no rows in the relevant state (rather than
+	// emitting the zero time, which is operator-confusing).
+	EnrichmentOldestPending *time.Time `json:"enrichment_oldest_pending,omitempty"`
+	EnrichmentStalest       *time.Time `json:"enrichment_stalest,omitempty"`
+}
+
+// GetRepoContributionsCoverage returns the data-completeness state for
+// the cohort that contributed to repoID in [since, until). Same window
+// CTE as the other two contributions endpoints, so the cohort is
+// identical and operators can correlate counts across all three.
+//
+// The query uses FILTER (WHERE ...) aggregates rather than separate
+// COUNT(column) calls where the predicate isn't simple "column IS NOT
+// NULL" — empty-string and JOIN-derived conditions need explicit
+// predicates. COUNT(column) alone counts non-NULL values and is fine
+// for the timestamp / nullable-int columns.
+//
+// EnrichmentOldestPending is the oldest data_collection_date among
+// contributors with NULL cntrb_last_enriched_at — translates to "this
+// person has been waiting N days for enrichment." Operators compare
+// against their enrich_interval_minutes cadence to spot a stuck ticker.
+//
+// EnrichmentStalest is the oldest cntrb_last_enriched_at among
+// contributors that HAVE been enriched at least once — surfaces the
+// long tail of "enriched 18 months ago and never refreshed." The
+// 30-day re-enrichment cooldown in v0.18.29 caps how stale this can
+// get in steady state.
+//
+// AffiliationUnknown is derived in Go as Total − AffiliationResolved
+// rather than re-counted in SQL — avoids a redundant FILTER scan.
+func (s *PostgresStore) GetRepoContributionsCoverage(ctx context.Context, repoID int64, since, until time.Time) (*ContributionsCoverage, error) {
+	lower, upper := resolveWindow(since, until)
+
+	sql := `
+WITH ` + contributorsInWindowCTE + `,
+enriched_state AS (
+    SELECT
+        c.cntrb_id,
+        c.cntrb_last_enriched_at,
+        c.cntrb_canonical,
+        c.gh_user_id,
+        c.cntrb_last_search_attempted_at,
+        c.cntrb_last_breadth_at,
+        c.cntrb_company,
+        c.data_collection_date,
+        ca.ca_affiliation
+    FROM contributors_in_window ciw
+    JOIN aveloxis_data.contributors c USING (cntrb_id)
+    LEFT JOIN aveloxis_data.contributor_affiliations ca
+        ON LOWER(SPLIT_PART(c.cntrb_canonical, '@', 2)) = LOWER(ca.ca_domain)
+        AND COALESCE(ca.ca_active, 1) = 1
+    WHERE COALESCE(c.cntrb_deleted, 0) = 0
+)
+SELECT
+    COUNT(*)::int                                                        AS total_contributors,
+    COUNT(cntrb_last_enriched_at)::int                                   AS enriched,
+    COUNT(*) FILTER (WHERE cntrb_canonical != '')::int                   AS canonical_email,
+    COUNT(gh_user_id)::int                                               AS gh_user_id_resolved,
+    COUNT(cntrb_last_search_attempted_at)::int                           AS search_resolve_attempted,
+    COUNT(cntrb_last_breadth_at)::int                                    AS breadth_attempted,
+    COUNT(*) FILTER (WHERE
+        COALESCE(
+            NULLIF(ca_affiliation, ''),
+            NULLIF(REGEXP_REPLACE(cntrb_company, '^@', ''), '')
+        ) IS NOT NULL
+    )::int                                                               AS affiliation_resolved,
+    MIN(data_collection_date) FILTER (WHERE cntrb_last_enriched_at IS NULL)
+                                                                         AS enrichment_oldest_pending,
+    MIN(cntrb_last_enriched_at)                                          AS enrichment_stalest
+FROM enriched_state`
+
+	out := &ContributionsCoverage{
+		WindowSince: lower,
+		WindowUntil: upper,
+	}
+
+	// Use pointer destinations for the nullable timestamp columns —
+	// COUNT can never be NULL but MIN over a filtered empty set
+	// returns NULL, which pgx rejects scanning into time.Time directly.
+	var pending, stalest *time.Time
+
+	err := s.pool.QueryRow(ctx, sql, repoID, lower, upper).Scan(
+		&out.TotalContributors,
+		&out.Enriched,
+		&out.CanonicalEmail,
+		&out.GHUserIDResolved,
+		&out.SearchResolveAttempted,
+		&out.BreadthAttempted,
+		&out.AffiliationResolved,
+		&pending,
+		&stalest,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GetRepoContributionsCoverage query: %w", err)
+	}
+	out.EnrichmentOldestPending = pending
+	out.EnrichmentStalest = stalest
+	out.AffiliationUnknown = out.TotalContributors - out.AffiliationResolved
+	return out, nil
+}
+
 // GetRepoAffiliationCounts returns the number of DISTINCT contributors
 // per affiliation in the same window as GetRepoContributors.
 //

--- a/internal/db/contributions_test.go
+++ b/internal/db/contributions_test.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// ============================================================
+// Source-contract: both store methods exist + share the CTE
+// ============================================================
+
+// TestContributionsStoreMethodsExist pins the public API of the v0.23.10
+// contributions endpoints' store layer. A future rename or removal fails
+// the build before merge.
+func TestContributionsStoreMethodsExist(t *testing.T) {
+	body, err := os.ReadFile("contributions.go")
+	if err != nil {
+		t.Fatalf("read contributions.go: %v", err)
+	}
+	src := string(body)
+	for _, needle := range []string{
+		"func (s *PostgresStore) GetRepoContributors(",
+		"func (s *PostgresStore) GetRepoAffiliationCounts(",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("contributions.go missing %q", needle)
+		}
+	}
+}
+
+// TestContributionsShareCTE pins that the two methods both use the
+// contributorsInWindowCTE constant. Centralizing the contribution
+// definition is load-bearing: if the contributors endpoint and the
+// affiliations endpoint ever disagree on "what counts as a
+// contribution," a per-affiliation total will differ from the
+// contributor count for unobvious reasons. This test forces a future
+// refactor to either keep using the constant or update both call sites
+// at the same time.
+func TestContributionsShareCTE(t *testing.T) {
+	body, err := os.ReadFile("contributions.go")
+	if err != nil {
+		t.Fatalf("read contributions.go: %v", err)
+	}
+	src := string(body)
+	if strings.Count(src, "contributorsInWindowCTE") < 3 {
+		// 1 declaration + 2 use sites = at least 3 occurrences.
+		t.Error("contributions.go must reference contributorsInWindowCTE in both " +
+			"GetRepoContributors and GetRepoAffiliationCounts so the two endpoints " +
+			"can't drift on contribution-kind coverage")
+	}
+}
+
+// TestContributionsCTECoversAllKinds pins that every contribution kind
+// the docs say is included actually appears in the SQL. This is the
+// counterpart to the doc that operators read — if the doc says
+// "commits, issues opened, issues closed, issue events, PRs opened, PR
+// reviews, PR events, messages" the SQL had better filter on all of
+// them or the count is wrong.
+func TestContributionsCTECoversAllKinds(t *testing.T) {
+	body, err := os.ReadFile("contributions.go")
+	if err != nil {
+		t.Fatalf("read contributions.go: %v", err)
+	}
+	src := string(body)
+	for _, needle := range []string{
+		"aveloxis_data.commits",
+		"aveloxis_data.issues",
+		"aveloxis_data.issue_events",
+		"aveloxis_data.pull_requests",
+		"aveloxis_data.pull_request_reviews",
+		"aveloxis_data.pull_request_events",
+		"aveloxis_data.messages",
+		"cmt_author_timestamp",
+		"reporter_id",
+		"closed_by_id",
+		"author_id",
+		"submitted_at",
+		"msg_timestamp",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("contributions.go CTE missing required token %q "+
+				"(docs/guide/api.md claims this kind is included)", needle)
+		}
+	}
+}
+
+// TestContributionsCTEExcludesSoftDeletedContributors pins the v0.20.2
+// soft-merge contract: loser rows (cntrb_deleted != 0) must not surface
+// in either endpoint or analytics will double-count merged identities.
+func TestContributionsCTEExcludesSoftDeletedContributors(t *testing.T) {
+	body, err := os.ReadFile("contributions.go")
+	if err != nil {
+		t.Fatalf("read contributions.go: %v", err)
+	}
+	if !strings.Contains(string(body), "COALESCE(c.cntrb_deleted, 0) = 0") {
+		t.Error("both endpoints must filter cntrb_deleted = 0 to honor the v0.20.2 " +
+			"soft-merge contract")
+	}
+}
+
+// ============================================================
+// Integration tier — live Postgres, gated on AVELOXIS_TEST_DB
+// ============================================================
+
+func contributionsConnect(t *testing.T) (*PostgresStore, context.Context) {
+	t.Helper()
+	conn := os.Getenv("AVELOXIS_TEST_DB")
+	if conn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, conn, logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	return store, ctx
+}
+
+func seedContribRepo(ctx context.Context, t *testing.T, store *PostgresStore) int64 {
+	t.Helper()
+	slug := fmt.Sprintf("_avcontrib-%d", time.Now().UnixNano())
+	id, err := store.UpsertRepo(ctx, &model.Repo{
+		Owner:    "_avcontrib",
+		Name:     slug,
+		GitURL:   fmt.Sprintf("https://github.com/_avcontrib/%s", slug),
+		Platform: model.PlatformGitHub,
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	return id
+}
+
+// insertContributor inserts a minimal contributor row and returns its
+// cntrb_id. cntrb_canonical drives affiliation lookup, so callers
+// override it when they want a specific email domain.
+func insertContributor(ctx context.Context, t *testing.T, store *PostgresStore,
+	login, canonical, company string) string {
+	t.Helper()
+	var id string
+	err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.contributors
+			(cntrb_login, cntrb_canonical, cntrb_company)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (cntrb_login) WHERE cntrb_login != ''
+		DO UPDATE SET cntrb_canonical = EXCLUDED.cntrb_canonical,
+		              cntrb_company = EXCLUDED.cntrb_company
+		RETURNING cntrb_id::text`,
+		login, canonical, company).Scan(&id)
+	if err != nil {
+		t.Fatalf("insertContributor(%s): %v", login, err)
+	}
+	return id
+}
+
+// TestGetRepoContributors_FiltersByWindow inserts two issues by the same
+// contributor — one inside the window, one outside — and asserts that
+// the contributor is returned exactly once (DISTINCT works) and that
+// out-of-window contributors don't leak in.
+func TestGetRepoContributors_FiltersByWindow(t *testing.T) {
+	store, ctx := contributionsConnect(t)
+	defer store.Close()
+
+	repoID := seedContribRepo(ctx, t, store)
+	insider := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_in_%d", time.Now().UnixNano()),
+		"insider@example.com", "")
+	outsider := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_out_%d", time.Now().UnixNano()),
+		"outsider@example.com", "")
+
+	insideTime := time.Now().AddDate(0, -3, 0)  // 3 months ago
+	outsideTime := time.Now().AddDate(-5, 0, 0) // 5 years ago
+
+	// Two issues by insider (test DISTINCT) + one by outsider.
+	for i, when := range []time.Time{insideTime, insideTime.Add(time.Hour)} {
+		_, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.issues
+				(repo_id, platform_issue_id, issue_number, reporter_id, created_at)
+			VALUES ($1, $2, $3, $4::uuid, $5)`,
+			repoID, time.Now().UnixNano()+int64(i), i+1, insider, when)
+		if err != nil {
+			t.Fatalf("seed inside issue %d: %v", i, err)
+		}
+	}
+	_, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.issues
+			(repo_id, platform_issue_id, issue_number, reporter_id, created_at)
+		VALUES ($1, $2, 999, $3::uuid, $4)`,
+		repoID, time.Now().UnixNano()+999, outsider, outsideTime)
+	if err != nil {
+		t.Fatalf("seed outside issue: %v", err)
+	}
+
+	// Window: last 2 years. insider should be in, outsider out.
+	since := time.Now().AddDate(-2, 0, 0)
+	got, err := store.GetRepoContributors(ctx, repoID, since, time.Time{})
+	if err != nil {
+		t.Fatalf("GetRepoContributors: %v", err)
+	}
+
+	ids := map[string]bool{}
+	for _, c := range got {
+		ids[c.CntrbID] = true
+	}
+	if !ids[insider] {
+		t.Errorf("insider %s should be in result; got %d contributors: %+v",
+			insider, len(got), got)
+	}
+	if ids[outsider] {
+		t.Errorf("outsider %s should be filtered out by window", outsider)
+	}
+}
+
+// TestGetRepoAffiliationCounts_DerivationPriority pins the documented
+// affiliation derivation order: contributor_affiliations[domain] beats
+// cntrb_company beats "(unknown)".
+func TestGetRepoAffiliationCounts_DerivationPriority(t *testing.T) {
+	store, ctx := contributionsConnect(t)
+	defer store.Close()
+
+	repoID := seedContribRepo(ctx, t, store)
+
+	// Three contributors with deliberately different signal strengths:
+	// 1. domain-mapped: canonical email under a domain we'll insert
+	//    into contributor_affiliations.
+	// 2. profile-only: cntrb_company set but canonical email under an
+	//    unmapped domain.
+	// 3. neither: no canonical, no company.
+	suffix := time.Now().UnixNano()
+	domain := fmt.Sprintf("_avtest-%d.org", suffix)
+	mapped := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_mapped_%d", suffix),
+		"alice@"+domain, "WrongCompanyShouldBeOverridden")
+	profileOnly := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_profile_%d", suffix),
+		"bob@somewhere-else-"+domain, "@SomeOrg")
+	noneCntrb := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_none_%d", suffix), "", "")
+
+	// Map the domain to "TestCorp" in contributor_affiliations.
+	_, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributor_affiliations
+			(ca_domain, ca_affiliation, ca_active)
+		VALUES ($1, 'TestCorp', 1)
+		ON CONFLICT (ca_domain) DO UPDATE SET
+			ca_affiliation = EXCLUDED.ca_affiliation,
+			ca_active = 1`, domain)
+	if err != nil {
+		t.Fatalf("seed affiliation: %v", err)
+	}
+
+	inWindow := time.Now().AddDate(0, -1, 0)
+	for i, cntrb := range []string{mapped, profileOnly, noneCntrb} {
+		_, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.issues
+				(repo_id, platform_issue_id, issue_number, reporter_id, created_at)
+			VALUES ($1, $2, $3, $4::uuid, $5)`,
+			repoID, time.Now().UnixNano()+int64(i*7919), 100+i, cntrb, inWindow)
+		if err != nil {
+			t.Fatalf("seed issue %d: %v", i, err)
+		}
+	}
+
+	since := time.Now().AddDate(-2, 0, 0)
+	got, err := store.GetRepoAffiliationCounts(ctx, repoID, since, time.Time{})
+	if err != nil {
+		t.Fatalf("GetRepoAffiliationCounts: %v", err)
+	}
+
+	byAffil := map[string]int{}
+	for _, ac := range got {
+		byAffil[ac.Affiliation] = ac.ContributorCount
+	}
+
+	if byAffil["TestCorp"] < 1 {
+		t.Errorf("TestCorp should have at least 1 contributor (domain-mapped); got %+v", byAffil)
+	}
+	if byAffil["SomeOrg"] < 1 {
+		t.Errorf("SomeOrg should have at least 1 contributor (profile, @-stripped); got %+v", byAffil)
+	}
+	if byAffil["(unknown)"] < 1 {
+		t.Errorf("(unknown) bucket should hold the no-info contributor; got %+v", byAffil)
+	}
+}

--- a/internal/db/contributions_test.go
+++ b/internal/db/contributions_test.go
@@ -20,9 +20,10 @@ import (
 // Source-contract: both store methods exist + share the CTE
 // ============================================================
 
-// TestContributionsStoreMethodsExist pins the public API of the v0.23.10
-// contributions endpoints' store layer. A future rename or removal fails
-// the build before merge.
+// TestContributionsStoreMethodsExist pins the public API of the
+// contributions endpoints' store layer. A future rename or removal
+// fails the build before merge. Covers v0.23.10 identities +
+// affiliations and v0.23.11 coverage.
 func TestContributionsStoreMethodsExist(t *testing.T) {
 	body, err := os.ReadFile("contributions.go")
 	if err != nil {
@@ -32,9 +33,38 @@ func TestContributionsStoreMethodsExist(t *testing.T) {
 	for _, needle := range []string{
 		"func (s *PostgresStore) GetRepoContributors(",
 		"func (s *PostgresStore) GetRepoAffiliationCounts(",
+		"func (s *PostgresStore) GetRepoContributionsCoverage(",
 	} {
 		if !strings.Contains(src, needle) {
 			t.Errorf("contributions.go missing %q", needle)
+		}
+	}
+}
+
+// TestContributionsCoverageStructHasAllFields pins the response shape.
+// If a future refactor renames a field or drops one, the integration
+// test stops catching the regression — this source-contract pin
+// catches it earlier. Fields listed match docs/guide/api.md.
+func TestContributionsCoverageStructHasAllFields(t *testing.T) {
+	body, err := os.ReadFile("contributions.go")
+	if err != nil {
+		t.Fatalf("read contributions.go: %v", err)
+	}
+	src := string(body)
+	for _, needle := range []string{
+		`"total_contributors"`,
+		`"enriched"`,
+		`"canonical_email"`,
+		`"gh_user_id_resolved"`,
+		`"search_resolve_attempted"`,
+		`"breadth_attempted"`,
+		`"affiliation_resolved"`,
+		`"affiliation_unknown"`,
+		`"enrichment_oldest_pending,omitempty"`,
+		`"enrichment_stalest,omitempty"`,
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("ContributionsCoverage struct missing JSON tag %s", needle)
 		}
 	}
 }
@@ -53,11 +83,15 @@ func TestContributionsShareCTE(t *testing.T) {
 		t.Fatalf("read contributions.go: %v", err)
 	}
 	src := string(body)
-	if strings.Count(src, "contributorsInWindowCTE") < 3 {
-		// 1 declaration + 2 use sites = at least 3 occurrences.
-		t.Error("contributions.go must reference contributorsInWindowCTE in both " +
-			"GetRepoContributors and GetRepoAffiliationCounts so the two endpoints " +
-			"can't drift on contribution-kind coverage")
+	if strings.Count(src, "contributorsInWindowCTE") < 4 {
+		// 1 declaration + 3 use sites (GetRepoContributors,
+		// GetRepoAffiliationCounts, GetRepoContributionsCoverage) = at
+		// least 4 occurrences. If a future refactor splits the CTE or
+		// drops a use site, the endpoints can silently drift on what
+		// counts as a "contribution" — fail the build before merge.
+		t.Error("contributions.go must reference contributorsInWindowCTE in all three " +
+			"endpoint store methods so the three endpoints can't drift on " +
+			"contribution-kind coverage")
 	}
 }
 
@@ -293,5 +327,155 @@ func TestGetRepoAffiliationCounts_DerivationPriority(t *testing.T) {
 	}
 	if byAffil["(unknown)"] < 1 {
 		t.Errorf("(unknown) bucket should hold the no-info contributor; got %+v", byAffil)
+	}
+}
+
+// TestGetRepoContributionsCoverage_ExerciseAllFields seeds a small
+// cohort whose enrichment state is deliberately varied so every
+// coverage field has a non-default value to assert against. Catches
+// regressions like "SELECT column position swapped" or "FILTER
+// predicate flipped" that the source-contract pin can't see.
+func TestGetRepoContributionsCoverage_ExerciseAllFields(t *testing.T) {
+	store, ctx := contributionsConnect(t)
+	defer store.Close()
+
+	repoID := seedContribRepo(ctx, t, store)
+
+	// Three contributors with distinct enrichment states:
+	//   alice: fully enriched + canonical + gh_user_id + breadth +
+	//          search-attempted + domain affiliation. Hits every field.
+	//   bob:   profile-only company "@SomeOrg", no canonical email,
+	//          no enrichment markers. Hits affiliation_resolved but
+	//          NOT enriched/canonical_email/gh_user_id.
+	//   carol: nothing populated. Counts toward total only.
+	suffix := time.Now().UnixNano()
+	domain := fmt.Sprintf("_avcov-%d.org", suffix)
+
+	alice := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_alice_%d", suffix),
+		"alice@"+domain, "")
+	bob := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_bob_%d", suffix), "", "@SomeOrg")
+	carol := insertContributor(ctx, t, store,
+		fmt.Sprintf("_av_carol_%d", suffix), "", "")
+
+	// Map the domain so alice's canonical resolves.
+	_, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributor_affiliations
+			(ca_domain, ca_affiliation, ca_active)
+		VALUES ($1, 'AliceCorp', 1)
+		ON CONFLICT (ca_domain) DO UPDATE SET ca_affiliation = EXCLUDED.ca_affiliation`,
+		domain)
+	if err != nil {
+		t.Fatalf("seed affiliation: %v", err)
+	}
+
+	// Populate alice's enrichment markers + gh_user_id.
+	stampAt := time.Now().AddDate(0, 0, -2) // 2 days ago
+	_, err = store.pool.Exec(ctx, `
+		UPDATE aveloxis_data.contributors
+		SET cntrb_last_enriched_at = $2,
+		    cntrb_last_search_attempted_at = $2,
+		    cntrb_last_breadth_at = $2,
+		    gh_user_id = $3
+		WHERE cntrb_id = $1::uuid`,
+		alice, stampAt, int64(12345))
+	if err != nil {
+		t.Fatalf("populate alice enrichment: %v", err)
+	}
+
+	// All three contribute via an issue inside the window.
+	inWindow := time.Now().AddDate(0, -1, 0)
+	for i, cntrb := range []string{alice, bob, carol} {
+		_, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.issues
+				(repo_id, platform_issue_id, issue_number, reporter_id, created_at)
+			VALUES ($1, $2, $3, $4::uuid, $5)`,
+			repoID, time.Now().UnixNano()+int64(i*1009), 100+i, cntrb, inWindow)
+		if err != nil {
+			t.Fatalf("seed issue %d: %v", i, err)
+		}
+	}
+
+	since := time.Now().AddDate(-2, 0, 0)
+	cov, err := store.GetRepoContributionsCoverage(ctx, repoID, since, time.Time{})
+	if err != nil {
+		t.Fatalf("GetRepoContributionsCoverage: %v", err)
+	}
+
+	if cov.TotalContributors != 3 {
+		t.Errorf("total = %d, want 3", cov.TotalContributors)
+	}
+	if cov.Enriched != 1 {
+		t.Errorf("enriched = %d, want 1 (only alice)", cov.Enriched)
+	}
+	if cov.CanonicalEmail != 1 {
+		t.Errorf("canonical_email = %d, want 1 (only alice)", cov.CanonicalEmail)
+	}
+	if cov.GHUserIDResolved != 1 {
+		t.Errorf("gh_user_id_resolved = %d, want 1 (only alice)", cov.GHUserIDResolved)
+	}
+	if cov.SearchResolveAttempted != 1 {
+		t.Errorf("search_resolve_attempted = %d, want 1 (only alice)", cov.SearchResolveAttempted)
+	}
+	if cov.BreadthAttempted != 1 {
+		t.Errorf("breadth_attempted = %d, want 1 (only alice)", cov.BreadthAttempted)
+	}
+	if cov.AffiliationResolved != 2 {
+		t.Errorf("affiliation_resolved = %d, want 2 (alice via domain + bob via @SomeOrg)",
+			cov.AffiliationResolved)
+	}
+	if cov.AffiliationUnknown != 1 {
+		t.Errorf("affiliation_unknown = %d, want 1 (only carol); derived = total - resolved",
+			cov.AffiliationUnknown)
+	}
+	// EnrichmentOldestPending: oldest data_collection_date among
+	// contributors with NULL cntrb_last_enriched_at. Bob + carol qualify;
+	// pgx populates data_collection_date with NOW() at insert. So we just
+	// assert it's non-nil and within the last minute.
+	if cov.EnrichmentOldestPending == nil {
+		t.Error("EnrichmentOldestPending should be non-nil — bob and carol are unenriched")
+	} else if time.Since(*cov.EnrichmentOldestPending) > time.Minute {
+		t.Errorf("EnrichmentOldestPending = %v, expected within last minute",
+			*cov.EnrichmentOldestPending)
+	}
+	// EnrichmentStalest: oldest cntrb_last_enriched_at among the cohort.
+	// Only alice was enriched, and we stamped her at -2 days, so this
+	// should equal stampAt (within timestamp microsecond precision).
+	if cov.EnrichmentStalest == nil {
+		t.Error("EnrichmentStalest should be non-nil — alice was enriched")
+	} else if diff := cov.EnrichmentStalest.Sub(stampAt); diff > time.Second || diff < -time.Second {
+		t.Errorf("EnrichmentStalest = %v, want ~%v (stampAt)", *cov.EnrichmentStalest, stampAt)
+	}
+}
+
+// TestGetRepoContributionsCoverage_EmptyCohort pins the
+// no-contributors case: zero counts everywhere, nil timestamp pointers
+// so the JSON omits the fields entirely rather than emitting zero-time.
+func TestGetRepoContributionsCoverage_EmptyCohort(t *testing.T) {
+	store, ctx := contributionsConnect(t)
+	defer store.Close()
+
+	repoID := seedContribRepo(ctx, t, store)
+
+	since := time.Now().AddDate(-2, 0, 0)
+	cov, err := store.GetRepoContributionsCoverage(ctx, repoID, since, time.Time{})
+	if err != nil {
+		t.Fatalf("GetRepoContributionsCoverage: %v", err)
+	}
+
+	if cov.TotalContributors != 0 {
+		t.Errorf("total = %d, want 0 for empty cohort", cov.TotalContributors)
+	}
+	if cov.AffiliationUnknown != 0 {
+		t.Errorf("affiliation_unknown should be 0 - 0 = 0; got %d", cov.AffiliationUnknown)
+	}
+	if cov.EnrichmentOldestPending != nil {
+		t.Errorf("EnrichmentOldestPending should be nil on empty cohort, got %v",
+			*cov.EnrichmentOldestPending)
+	}
+	if cov.EnrichmentStalest != nil {
+		t.Errorf("EnrichmentStalest should be nil on empty cohort, got %v",
+			*cov.EnrichmentStalest)
 	}
 }

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.23.10"
+var ToolVersion = "0.23.11"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.23.9"
+var ToolVersion = "0.23.10"


### PR DESCRIPTION
### v0.23.11 

  Route: GET /api/v1/repos/{repoID}/contributions/coverage?since=...&until=... — same window CTE as /identities and /affiliations, returns the enrichment-state snapshot.
  
  Response (per the design you approved, all derived from existing columns — no schema work):

  {
    "window_since": "2024-05-21T00:00:00Z",
    "window_until": "2026-05-21T00:00:00Z",
    "total_contributors":       412,
    "enriched":                  389,
    "canonical_email":           356,
    "gh_user_id_resolved":       401,
    "search_resolve_attempted":   47,
    "breadth_attempted":         378,
    "affiliation_resolved":      318,
    "affiliation_unknown":        94,
    "enrichment_oldest_pending": "2026-05-12T18:31:04Z",
    "enrichment_stalest":        "2024-08-15T03:22:11Z"
  }

  The two timestamp fields use *time.Time + omitempty so they're absent from the JSON entirely on empty cohorts (rather than emitting 0001-01-01T00:00:00Z and confusing operators).

  Shared-CTE invariant tightened: TestContributionsShareCTE now requires ≥4 references to contributorsInWindowCTE (1 declaration + 3 use sites) so a future refactor can't silently drop coverage from the family.

  Tests (5 new, 2 extended in-place):
  - TestContributionsCoverageStructHasAllFields — source-contract pin on all 10 JSON tags including the two omitempty markers
  - TestGetRepoContributionsCoverage_ExerciseAllFields — integration test seeding alice (fully enriched + domain-mapped), bob (@SomeOrg profile only), carol (empty) and asserting every counter + both timestamp signals
  - TestGetRepoContributionsCoverage_EmptyCohort — pins the nil-pointer behavior on no contributors
  - TestRepoContributionsCoverage_InvalidID + TestRepoContributionsCoverage_SinceAfterUntil — handler-side parameter validation

  Verification: full go test ./... green across 19 packages; integration tests pass against aveloxis_cascade_test confirming the math (alice contributes to all the enrichment counters, bob+carol increment only total and affiliation_resolved correctly, enrichment_oldest_pending reflects bob+carol's collection timestamps, enrichment_stalest equals alice's stamped time within 1s of the seeded value).

  Operator usage — the question that started this thread now has an answer:

  curl 'http://localhost:8383/api/v1/repos/24024/contributions/coverage?since=2024-01-01' | jq
    → if enriched/total < ~0.95, /affiliations is premature; wait for the next ticker cycle
    → if enrichment_oldest_pending is more than ~2× enrich_interval_minutes behind NOW(), the ticker may be stuck — grep ~/.aveloxis/aveloxis.log for EnrichThinContributors

  The docs include the full floor/ceiling reading guide ("true unaffiliated count is between 71 and 94, not 94") and the "spotting a stuck ticker" runbook with concrete grep commands.