### PR TITLE
deps.dev tidied

### DIFF
--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -340,6 +340,41 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		ON aveloxis_data.repos (distribution_last_run NULLS FIRST)
 		WHERE COALESCE(repo_archived, FALSE) = FALSE`)
 
+	// v0.24.1 — one-shot reset of distribution_last_run for fleets
+	// affected by the v0.24.0 deps.dev URL-encoding bug.
+	//
+	// v0.24.0 built the deps.dev project_id path parameter by URL-
+	// encoding owner and repo separately and joining with raw slashes:
+	//   /v3/projects/github.com/owner/repo:packageversions   ← 404
+	// deps.dev v3 is gRPC-transcoded REST, so the project_id is a
+	// single path segment whose internal slashes must be percent-
+	// encoded:
+	//   /v3/projects/github.com%2Fowner%2Frepo:packageversions ← 200
+	// Every v0.24.0 deps.dev call hit 404, the 404 branch returned
+	// (nil, nil) silently, and the worker fleet produced zero
+	// deps.dev rows fleet-wide while ecosyste.ms / github-* sources
+	// kept working — masking the bug behind a partial-success scan.
+	//
+	// The cadence gate (default 180 days) means an affected repo
+	// would not be re-scanned until its last_run elapsed, so we
+	// override the gate once here by clearing the timestamp for
+	// every scanned repo IFF the fleet has zero deps.dev rows.
+	// Self-disabling: once any deps.dev row exists, the NOT EXISTS
+	// guard short-circuits and subsequent migrate runs are no-ops.
+	// Fresh installs with no scanned repos yet are unaffected
+	// because the WHERE clause filters on distribution_last_run IS
+	// NOT NULL. Operators who want to force re-scan after this
+	// point use the documented manual workflow:
+	//   UPDATE aveloxis_data.repos SET distribution_last_run = NULL ...
+	execMigrationStep(ctx, pg, logger, &errs, "v0.24.1 reset distribution_last_run for fleets affected by v0.24.0 deps.dev URL bug",
+		`UPDATE aveloxis_data.repos
+		SET distribution_last_run = NULL
+		WHERE distribution_last_run IS NOT NULL
+		  AND NOT EXISTS (
+		      SELECT 1 FROM aveloxis_data.repo_distribution
+		      WHERE source = 'deps.dev'
+		  )`)
+
 	// collection_queue.last_commits backfill (v0.19.11). Pre-v0.19.11
 	// the FacadeCollector incremented result.Commits once per inserted
 	// ROW rather than once per distinct commit. Since the commits table

--- a/internal/db/v024_1_distribution_reset_test.go
+++ b/internal/db/v024_1_distribution_reset_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.24.1: one-shot reset of distribution_last_run on every scanned
+// repo when the fleet has zero deps.dev rows. Closes the upgrade-path
+// gap left by the v0.24.0 deps.dev URL-encoding bug: pre-v0.24.1, the
+// 180-day cadence gate would have prevented re-scan of affected
+// repos until the gate elapsed, even after the binary fix landed.
+//
+// The migration is self-disabling — the NOT EXISTS guard becomes
+// false as soon as any deps.dev row appears in repo_distribution.
+// Fresh installs are unaffected because the WHERE clause filters
+// on distribution_last_run IS NOT NULL.
+
+func TestV0241MigrationResetsDistributionLastRunForAffectedFleets(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Each needle is a load-bearing element of the reset SQL.
+	// Dropping any one of these weakens the gate or changes
+	// the semantics:
+	//   - The label is what operators grep for in the log.
+	//   - The UPDATE target table is the repos table.
+	//   - The SET clause clears the cadence timestamp.
+	//   - The IS NOT NULL filter prevents touching fresh-install rows.
+	//   - The NOT EXISTS guard is the self-disabling half — without
+	//     it the migration would re-fire on every restart even after
+	//     deps.dev rows are present.
+	//   - source = 'deps.dev' is the exact match the repo_distribution
+	//     rows carry (set in client.go's aggregateVersions).
+	needles := []string{
+		"v0.24.1 reset distribution_last_run for fleets affected by v0.24.0 deps.dev URL bug",
+		"UPDATE aveloxis_data.repos",
+		"SET distribution_last_run = NULL",
+		"WHERE distribution_last_run IS NOT NULL",
+		"NOT EXISTS",
+		"aveloxis_data.repo_distribution",
+		"source = 'deps.dev'",
+	}
+	for _, n := range needles {
+		if !strings.Contains(src, n) {
+			t.Errorf("migrate.go missing v0.24.1 reset-SQL needle %q — the migration must wipe distribution_last_run only on scanned repos in fleets with no deps.dev rows, self-disabling once any deps.dev row is ingested by the post-fix worker", n)
+		}
+	}
+}
+
+// TestV0241ResetIsSelfDisabling pins the NOT EXISTS clause specifically
+// as a guard against a future refactor that turns the migration into
+// an unconditional wipe. An unconditional wipe would re-fire on every
+// aveloxis migrate run after v0.24.1, perpetually re-rescanning the
+// entire fleet against the operator's stated cadence in aveloxis.json
+// — exactly the opposite of the one-shot semantic this migration
+// promises.
+func TestV0241ResetIsSelfDisabling(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(data)
+
+	// Locate the migration block and extract just the SQL body so
+	// nearby unrelated code (other migrations) can't satisfy the
+	// assertion accidentally.
+	idx := strings.Index(src, "v0.24.1 reset distribution_last_run")
+	if idx < 0 {
+		t.Fatal("cannot find v0.24.1 reset migration label in migrate.go")
+	}
+	tail := src[idx:]
+	end := strings.Index(tail, "`)")
+	if end < 0 {
+		t.Fatal("cannot find end of v0.24.1 reset migration SQL")
+	}
+	block := tail[:end]
+
+	if !strings.Contains(block, "NOT EXISTS") {
+		t.Error("v0.24.1 reset migration must include a NOT EXISTS guard so it is self-disabling — without it the migration would re-fire on every restart and override the operator's configured cadence indefinitely")
+	}
+	if !strings.Contains(block, "source = 'deps.dev'") {
+		t.Error("v0.24.1 reset migration's NOT EXISTS guard must filter on source = 'deps.dev' — that is the exact source value emitted by depsdev.aggregateVersions and is what marks the bug-affected vs healthy state")
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.24.0"
+var ToolVersion = "0.24.1"

--- a/internal/platform/depsdev/client.go
+++ b/internal/platform/depsdev/client.go
@@ -97,6 +97,16 @@ func (e *rateLimitError) Class() platform.ErrorClass { return platform.ClassRate
 
 // versionsResponse mirrors the deps.dev v3 packageversions schema.
 // We only decode the fields we need; unknown fields are ignored.
+//
+// IMPORTANT (verified live 2026-05-22): the reverse-lookup endpoint
+// (`:packageversions` on a project) does NOT return publishedAt on
+// its version entries — only versionKey, relationType,
+// relationProvenance, slsaProvenances, attestations. The PublishedAt
+// field below is decoded for forward-compatibility (if deps.dev ever
+// adds it) but in practice it will be the zero time. We enrich via
+// the per-package endpoint /v3/systems/{system}/packages/{name},
+// which DOES return publishedAt on every version. See
+// fetchPackageTimestamps.
 type versionsResponse struct {
 	Versions []versionEntry `json:"versions"`
 }
@@ -112,6 +122,17 @@ type versionKey struct {
 	Version string `json:"version"` // version string
 }
 
+// packageDetailResponse mirrors the deps.dev v3 schema for
+// /v3/systems/{SYSTEM}/packages/{name}. Returns every version of
+// the package WITH publishedAt populated for each one — that's
+// the field we need to fill the timestamp gap in the reverse-
+// lookup response. Other fields (isDefault, isDeprecated,
+// deprecatedReason) are present in the JSON but we don't decode
+// them.
+type packageDetailResponse struct {
+	Versions []versionEntry `json:"versions"`
+}
+
 // GetPackageVersions returns every (ecosystem, package_name) tuple
 // that deps.dev knows about for the given GitHub repo, aggregated
 // across versions. 404 is not an error — it means deps.dev doesn't
@@ -119,8 +140,17 @@ type versionKey struct {
 // sources.
 //
 // owner/repo are passed unescaped; the function URL-encodes them.
+//
+// v0.24.1: the project_id path parameter is a SINGLE gRPC-transcoded
+// segment, so the slashes inside it must be percent-encoded as %2F
+// along with any reserved characters in owner / repo. Pre-v0.24.1
+// code escaped owner and repo separately and joined with raw slashes,
+// which built a path that deps.dev's router could not match — every
+// call 404'd, the 404 handler returned (nil, nil) silently, and the
+// worker fleet produced zero deps.dev rows. Verified live against
+// mwaskom/seaborn: unencoded → 404, %2F-encoded → 200 with real data.
 func (c *Client) GetPackageVersions(ctx context.Context, owner, repo string) ([]model.PackageDistribution, error) {
-	projectID := "github.com/" + url.PathEscape(owner) + "/" + url.PathEscape(repo)
+	projectID := url.PathEscape("github.com/" + owner + "/" + repo)
 	endpoint := c.baseURL + "/v3/projects/" + projectID + ":packageversions"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
@@ -157,7 +187,125 @@ func (c *Client) GetPackageVersions(ctx context.Context, owner, repo string) ([]
 		return nil, fmt.Errorf("deps.dev decode: %w", err)
 	}
 
+	// v0.24.1 timestamp enrichment. The reverse-lookup endpoint does
+	// not return publishedAt; the per-package endpoint does. For each
+	// distinct (RAW-system, name) tuple we observed, fetch the
+	// package's full version list and build a (system, name, version)
+	// → publishedAt map. Then mutate the reverse-lookup entries to
+	// carry those timestamps before passing them to aggregateVersions.
+	//
+	// We use the RAW deps.dev system string ("PYPI", "NPM") for the
+	// follow-up URL, not the lowercase ecosystem name — the package
+	// endpoint requires upper-case. depsDevSystemToEcosystem is only
+	// applied to the output rows.
+	//
+	// Best-effort: a failed enrichment call leaves that package's
+	// timestamps at zero. Aggregation still proceeds. We do NOT
+	// surface enrichment errors — the reverse-lookup data is more
+	// load-bearing (it tells us WHICH packages exist), the
+	// timestamps are an enrichment. The scanner's partial-success
+	// contract handles missing data per source already.
+	type pkgKey struct{ rawSystem, name string }
+	seen := map[pkgKey]struct{}{}
+	for _, v := range env.Versions {
+		if v.VersionKey.System == "" || v.VersionKey.Name == "" {
+			continue
+		}
+		seen[pkgKey{rawSystem: strings.ToUpper(v.VersionKey.System), name: v.VersionKey.Name}] = struct{}{}
+	}
+
+	tsMap := make(map[versionKey]time.Time, len(env.Versions))
+	for k := range seen {
+		details, derr := c.fetchPackageTimestamps(ctx, k.rawSystem, k.name)
+		if derr != nil {
+			// Silent skip — timestamps stay zero for this package.
+			// See contract note above.
+			continue
+		}
+		for version, publishedAt := range details {
+			tsMap[versionKey{System: k.rawSystem, Name: k.name, Version: version}] = publishedAt
+		}
+	}
+
+	// Apply enrichment back onto the reverse-lookup entries. If the
+	// entry already has a publishedAt (forward-compatible case where
+	// deps.dev one day adds the field to :packageversions), keep it.
+	for i := range env.Versions {
+		if !env.Versions[i].PublishedAt.IsZero() {
+			continue
+		}
+		k := versionKey{
+			System:  strings.ToUpper(env.Versions[i].VersionKey.System),
+			Name:    env.Versions[i].VersionKey.Name,
+			Version: env.Versions[i].VersionKey.Version,
+		}
+		if ts, ok := tsMap[k]; ok {
+			env.Versions[i].PublishedAt = ts
+		}
+	}
+
 	return aggregateVersions(env.Versions), nil
+}
+
+// fetchPackageTimestamps calls the deps.dev per-package endpoint
+// and returns a map of version-string → publishedAt for every
+// version of the named package. system must be the RAW deps.dev
+// system code ("PYPI", "NPM", "MAVEN", "CARGO", "GO", "RUBYGEMS",
+// "NUGET") — the path parameter is case-sensitive.
+//
+// The package name is percent-encoded the same way the project_id
+// is in GetPackageVersions: as a single path segment. This matters
+// for npm scoped packages ("@types/node" → "%40types%2Fnode")
+// where unescaped slashes would route to a different gRPC method.
+//
+// 404 → returns an empty map with no error (deps.dev doesn't know
+// the package; nothing to enrich). 5xx / 429 / other errors are
+// returned as-is so the caller can decide whether to retry; in
+// practice GetPackageVersions silently drops the error and proceeds
+// with zero timestamps for that package.
+func (c *Client) fetchPackageTimestamps(ctx context.Context, rawSystem, name string) (map[string]time.Time, error) {
+	endpoint := c.baseURL + "/v3/systems/" + url.PathEscape(rawSystem) + "/packages/" + url.PathEscape(name)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build package-detail request: %w", err)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("deps.dev package-detail GET: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// fall through to body parse
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, nil
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return nil, &rateLimitError{msg: fmt.Sprintf("deps.dev rate limited (HTTP 429) on package-detail for %s/%s", rawSystem, name)}
+	case resp.StatusCode >= 500:
+		return nil, fmt.Errorf("deps.dev package-detail server error (HTTP %d) for %s/%s: %w", resp.StatusCode, rawSystem, name, platform.ErrTransient)
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("deps.dev package-detail unexpected status %d for %s/%s: %s", resp.StatusCode, rawSystem, name, strings.TrimSpace(string(body)))
+	}
+
+	var env packageDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("deps.dev package-detail decode: %w", err)
+	}
+
+	out := make(map[string]time.Time, len(env.Versions))
+	for _, v := range env.Versions {
+		if v.VersionKey.Version == "" || v.PublishedAt.IsZero() {
+			continue
+		}
+		out[v.VersionKey.Version] = v.PublishedAt
+	}
+	return out, nil
 }
 
 // aggregateVersions collapses a flat list of (system, name, version)

--- a/internal/platform/depsdev/client_test.go
+++ b/internal/platform/depsdev/client_test.go
@@ -51,12 +51,29 @@ const cannedResponse = `{
 }`
 
 func TestGetPackageVersionsParsesResponse(t *testing.T) {
+	// v0.24.1: the client now follows up the reverse-lookup with one
+	// per-package call to /v3/systems/{system}/packages/{name} to
+	// enrich each row with publishedAt. The mock has to serve both
+	// endpoints. The reverse-lookup URL contains "packageversions";
+	// the package-detail URL contains "/packages/" and does NOT
+	// contain "packageversions".
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "packageversions") {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.EscapedPath(), "packageversions"):
+			_, _ = w.Write([]byte(cannedResponse))
+		case strings.Contains(r.URL.EscapedPath(), "/packages/"):
+			// Mirror the cannedResponse versions back as a
+			// packageDetailResponse so timestamp enrichment finds the
+			// publishedAt values that already exist in the canned data.
+			// Real deps.dev returns the package detail with a
+			// different shape but the only field this code reads is
+			// versions[].versionKey.version and versions[].publishedAt,
+			// which the cannedResponse already provides.
+			_, _ = w.Write([]byte(cannedResponse))
+		default:
 			t.Errorf("unexpected URL path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(cannedResponse))
 	}))
 	defer srv.Close()
 

--- a/internal/platform/depsdev/url_encoding_test.go
+++ b/internal/platform/depsdev/url_encoding_test.go
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package depsdev
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// v0.24.1 — URL-encoding regression tests.
+//
+// Background: v0.24.0 built the deps.dev project_id by URL-encoding
+// owner and repo separately and joining with raw slashes, e.g.
+//
+//	/v3/projects/github.com/mwaskom/seaborn:packageversions
+//
+// deps.dev v3 is a gRPC-transcoded REST API. Its URL template treats
+// project_id as a SINGLE path segment; the internal slashes must be
+// percent-encoded along with any reserved characters in owner/repo:
+//
+//	/v3/projects/github.com%2Fmwaskom%2Fseaborn:packageversions
+//
+// Empirically verified against the live API on 2026-05-22:
+//   - unencoded → HTTP 404 "404 page not found"
+//   - %2F-encoded → HTTP 200, JSON envelope with PyPI/Go versions
+//
+// The pre-v0.24.1 client's 404 handler returned (nil, nil) silently,
+// so every deps.dev call short-circuited to "no packages found" and
+// the worker fleet produced zero deps.dev rows fleet-wide without
+// emitting a single error log line.
+//
+// Two tests below:
+//   1. TestURLEncodesProjectIDAsSingleSegment uses httptest to
+//      capture the request URL and assert the path contains %2F.
+//      Tripwire against a future revert.
+//   2. TestLiveDepsDevReverseLookupForSeaborn is gated on the
+//      AVELOXIS_TEST_NETWORK env var. When set, it hits the real
+//      deps.dev API for mwaskom/seaborn — a known-good case with
+//      36 PyPI versions since 2013 — and asserts the response
+//      decodes into a non-empty PackageDistribution slice including
+//      a pypi/seaborn row. This is the test that would have failed
+//      against v0.24.0 and would have caught the bug pre-release.
+
+// TestURLEncodesProjectIDAsSingleSegment is the source-contract /
+// behavioral tripwire that catches a revert to the v0.24.0 pattern.
+// It stands up an httptest server, captures the path it receives,
+// and asserts the path includes a percent-encoded slash inside the
+// project_id. The mock server returns 200 unconditionally so the
+// rest of the client succeeds — we only care about URL shape here.
+func TestURLEncodesProjectIDAsSingleSegment(t *testing.T) {
+	var observedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedPath = r.URL.EscapedPath()
+		_, _ = w.Write([]byte(`{"versions":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(Options{BaseURL: srv.URL})
+	_, err := c.GetPackageVersions(context.Background(), "mwaskom", "seaborn")
+	if err != nil {
+		t.Fatalf("GetPackageVersions returned unexpected error: %v", err)
+	}
+
+	// The path must contain %2F instead of raw slashes inside the
+	// project_id. The :packageversions verb suffix stays unencoded
+	// (it sits outside the escaped value).
+	if !strings.Contains(observedPath, "%2F") {
+		t.Errorf("request path %q does not contain %%2F — v0.24.0 sent unencoded slashes which made deps.dev's gRPC-transcoded router return 404 for every call. The project_id is a single path segment; its internal slashes must be percent-encoded. See client.go GetPackageVersions.", observedPath)
+	}
+
+	// And the verb suffix must NOT be percent-encoded. If the
+	// implementation accidentally encodes the colon (e.g. by
+	// passing the whole endpoint string through url.PathEscape),
+	// deps.dev's router will not match the verb.
+	if !strings.Contains(observedPath, ":packageversions") {
+		t.Errorf("request path %q does not contain literal :packageversions — the gRPC verb suffix must NOT be percent-encoded. Encode the project_id only, then append :packageversions raw.", observedPath)
+	}
+}
+
+// TestFetchPackageTimestampsEncodesPackageNameAsSingleSegment pins
+// the URL-encoding contract on the per-package endpoint. npm scoped
+// packages ("@types/node") contain a slash that, like the project_id
+// case, must be percent-encoded — the package name is a single gRPC
+// path segment. Verified live 2026-05-22: unencoded
+// /v3/systems/NPM/packages/@types/node → 404; encoded → 200.
+// (deps.dev accepts either @types%2Fnode or %40types%2Fnode; the
+// load-bearing encoding is the slash. The @ is left raw by Go's
+// url.PathEscape which is fine.) Without %2F encoding, every
+// scoped-package enrichment would silently fail and we'd repeat
+// the v0.24.0 silent-data-loss pattern at smaller scale.
+func TestFetchPackageTimestampsEncodesPackageNameAsSingleSegment(t *testing.T) {
+	var observedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedPath = r.URL.EscapedPath()
+		_, _ = w.Write([]byte(`{"versions":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(Options{BaseURL: srv.URL})
+	_, err := c.fetchPackageTimestamps(context.Background(), "NPM", "@types/node")
+	if err != nil {
+		t.Fatalf("fetchPackageTimestamps returned unexpected error: %v", err)
+	}
+
+	if !strings.Contains(observedPath, "%2F") {
+		t.Errorf("request path %q must contain %%2F (encoded /) inside the package-name segment. Without this encoding, npm scoped-package timestamp enrichment fails silently — same class of bug as the v0.24.0 project_id encoding bug, smaller blast radius.", observedPath)
+	}
+}
+
+// TestFetchPackageTimestampsParsesVersionMap pins the response-parse
+// contract: the helper must return a map keyed by version string
+// with publishedAt as the value. Forgetting either field (e.g., a
+// refactor that returns []versionEntry instead of map[string]Time)
+// would break the lookup in GetPackageVersions.
+func TestFetchPackageTimestampsParsesVersionMap(t *testing.T) {
+	body := `{
+		"versions": [
+			{"versionKey": {"system": "PYPI", "name": "seaborn", "version": "0.1.0"},
+			 "publishedAt": "2013-10-28T22:27:52Z"},
+			{"versionKey": {"system": "PYPI", "name": "seaborn", "version": "0.2.0"},
+			 "publishedAt": "2014-03-02T18:00:00Z"}
+		]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := New(Options{BaseURL: srv.URL})
+	ts, err := c.fetchPackageTimestamps(context.Background(), "PYPI", "seaborn")
+	if err != nil {
+		t.Fatalf("fetchPackageTimestamps: %v", err)
+	}
+	if len(ts) != 2 {
+		t.Fatalf("want 2 versions in map, got %d", len(ts))
+	}
+	wantFirst := time.Date(2013, 10, 28, 22, 27, 52, 0, time.UTC)
+	if got, ok := ts["0.1.0"]; !ok {
+		t.Error("missing key \"0.1.0\" in timestamp map")
+	} else if !got.Equal(wantFirst) {
+		t.Errorf("ts[\"0.1.0\"] = %v, want %v", got, wantFirst)
+	}
+}
+
+// TestGetPackageVersionsEnrichesWithTimestamps is the end-to-end
+// contract pin: after GetPackageVersions runs against a mock that
+// serves BOTH endpoints, the returned PackageDistribution row must
+// have FirstPublishedAt/LatestPublishedAt populated from the
+// per-package endpoint response. Without this, the v0.24.1 design
+// goal (correct timeline columns on deps.dev rows) is unmet.
+func TestGetPackageVersionsEnrichesWithTimestamps(t *testing.T) {
+	// Reverse-lookup response: NO publishedAt on the entries
+	// (matches actual deps.dev :packageversions behavior).
+	reverseLookup := `{
+		"versions": [
+			{"versionKey": {"system": "PYPI", "name": "examplepkg", "version": "1.0.0"}},
+			{"versionKey": {"system": "PYPI", "name": "examplepkg", "version": "2.0.0"}}
+		]
+	}`
+	// Per-package response: publishedAt IS populated.
+	packageDetail := `{
+		"versions": [
+			{"versionKey": {"system": "PYPI", "name": "examplepkg", "version": "1.0.0"},
+			 "publishedAt": "2020-01-15T00:00:00Z"},
+			{"versionKey": {"system": "PYPI", "name": "examplepkg", "version": "2.0.0"},
+			 "publishedAt": "2022-06-20T00:00:00Z"}
+		]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.EscapedPath(), "packageversions"):
+			_, _ = w.Write([]byte(reverseLookup))
+		case strings.Contains(r.URL.EscapedPath(), "/packages/"):
+			_, _ = w.Write([]byte(packageDetail))
+		default:
+			t.Errorf("unexpected URL path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(Options{BaseURL: srv.URL})
+	pkgs, err := c.GetPackageVersions(context.Background(), "owner", "examplerepo")
+	if err != nil {
+		t.Fatalf("GetPackageVersions: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("want 1 aggregated package row, got %d", len(pkgs))
+	}
+	p := pkgs[0]
+	wantFirst := time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC)
+	wantLatest := time.Date(2022, 6, 20, 0, 0, 0, 0, time.UTC)
+	if !p.FirstPublishedAt.Equal(wantFirst) {
+		t.Errorf("FirstPublishedAt = %v, want %v — enrichment from /v3/systems/PYPI/packages/examplepkg must populate this. The whole point of v0.24.1 is that this assertion holds.", p.FirstPublishedAt, wantFirst)
+	}
+	if !p.LatestPublishedAt.Equal(wantLatest) {
+		t.Errorf("LatestPublishedAt = %v, want %v", p.LatestPublishedAt, wantLatest)
+	}
+	if p.VersionCount != 2 {
+		t.Errorf("VersionCount = %d, want 2", p.VersionCount)
+	}
+}
+
+// TestLiveDepsDevReverseLookupForSeaborn is the integration test the
+// v0.24.0 suite was missing. Gated on AVELOXIS_TEST_NETWORK so default
+// runs stay offline (no flakes on planes / behind corporate proxies /
+// during deps.dev maintenance windows). The operator runs it during
+// release verification:
+//
+//	AVELOXIS_TEST_NETWORK=1 go test ./internal/platform/depsdev/ -run TestLive -v
+//
+// mwaskom/seaborn is chosen because:
+//   - Highly popular project (≈12K stars), unlikely to ever be
+//     unindexed by deps.dev
+//   - Published to PyPI since 2013 with 30+ versions
+//   - Source URL declared correctly in PyPI metadata, so deps.dev's
+//     reverse-lookup graph reliably resolves it
+//
+// If deps.dev ever changes its API surface (different field names,
+// different versionKey structure, etc.) this test will catch it
+// before the next release ships.
+func TestLiveDepsDevReverseLookupForSeaborn(t *testing.T) {
+	if os.Getenv("AVELOXIS_TEST_NETWORK") == "" {
+		t.Skip("set AVELOXIS_TEST_NETWORK=1 to enable live deps.dev integration test")
+	}
+
+	c := New(Options{
+		UserAgent: "aveloxis-test (lists@goggins.com)",
+	})
+
+	pkgs, err := c.GetPackageVersions(context.Background(), "mwaskom", "seaborn")
+	if err != nil {
+		t.Fatalf("live deps.dev call failed: %v — if deps.dev itself is down, retry. If error is persistent, the API surface may have changed and the client needs an update.", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("live deps.dev returned zero packages for mwaskom/seaborn — this is the exact failure mode that masked the v0.24.0 URL-encoding bug. Either the URL is malformed again, or deps.dev itself has stopped indexing seaborn (extremely unlikely).")
+	}
+
+	// Should include at least the pypi/seaborn row. Other rows
+	// (go/github.com/mwaskom/seaborn from Go module proxy, etc.)
+	// are fine but not required by this assertion.
+	//
+	// v0.24.1 timestamp enrichment: the reverse-lookup endpoint
+	// does NOT return publishedAt on its version entries, but the
+	// per-package endpoint /v3/systems/{system}/packages/{name}
+	// DOES. The client follows up the reverse-lookup with one such
+	// call per distinct (system, name) tuple and enriches the
+	// PackageDistribution row's First/LatestPublishedAt fields.
+	// This integration test verifies that enrichment actually
+	// works end-to-end against the live API — without it, deps.dev
+	// rows would carry zero timestamps and the headline analytical
+	// signal ("when was this repo's packaging activity") would be
+	// lost. seaborn started publishing to PyPI in 2013, so the
+	// FirstPublishedAt must be well before today.
+	var foundPypi bool
+	now := time.Now()
+	for _, p := range pkgs {
+		if p.Ecosystem == "pypi" && p.PackageName == "seaborn" {
+			foundPypi = true
+			if p.VersionCount < 1 {
+				t.Errorf("pypi/seaborn row has VersionCount = %d, expected at least 1 (the package has had 30+ versions on PyPI since 2013)", p.VersionCount)
+			}
+			if p.Source != "deps.dev" {
+				t.Errorf("pypi/seaborn row Source = %q, want \"deps.dev\"", p.Source)
+			}
+			if p.FirstPublishedAt.IsZero() {
+				t.Errorf("pypi/seaborn FirstPublishedAt is zero — v0.24.1 timestamp enrichment must populate it via the per-package endpoint. If this assertion fails, either the package-detail call is failing silently, or deps.dev changed the response shape for /v3/systems/PYPI/packages/seaborn.")
+			}
+			if p.LatestPublishedAt.IsZero() {
+				t.Errorf("pypi/seaborn LatestPublishedAt is zero — same root cause as FirstPublishedAt above.")
+			}
+			// seaborn first PyPI release was October 2013 per the
+			// package's own metadata. Assert FirstPublishedAt is
+			// before 2020 so a future regression that picks up
+			// only recent versions (e.g. via a wrong sort order)
+			// fails the test.
+			cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			if !p.FirstPublishedAt.IsZero() && p.FirstPublishedAt.After(cutoff) {
+				t.Errorf("pypi/seaborn FirstPublishedAt = %v, expected before %v (the package has been on PyPI since 2013)", p.FirstPublishedAt, cutoff)
+			}
+			// LatestPublishedAt must be in the past, obviously.
+			if !p.LatestPublishedAt.IsZero() && p.LatestPublishedAt.After(now) {
+				t.Errorf("pypi/seaborn LatestPublishedAt = %v is in the future relative to now %v", p.LatestPublishedAt, now)
+			}
+			// And the ordering invariant: first <= latest.
+			if !p.FirstPublishedAt.IsZero() && !p.LatestPublishedAt.IsZero() && p.FirstPublishedAt.After(p.LatestPublishedAt) {
+				t.Errorf("pypi/seaborn First=%v after Latest=%v — aggregation broken", p.FirstPublishedAt, p.LatestPublishedAt)
+			}
+		}
+	}
+	if !foundPypi {
+		t.Errorf("live deps.dev response did not include pypi/seaborn — got %d packages. This is the bell-canary case: if it fails, deps.dev's reverse-lookup graph has changed or the response field names no longer match the client's struct tags.", len(pkgs))
+		for i, p := range pkgs {
+			t.Logf("  pkg[%d]: ecosystem=%q name=%q versions=%d", i, p.Ecosystem, p.PackageName, p.VersionCount)
+		}
+	}
+}


### PR DESCRIPTION
### v0.24.1 deps.dev URL and data update

The original deps.dev calls were malformed. They are corrected now. 

| Change | File |
|---|---|
| URL-encoding fix (1 line) | `internal/platform/depsdev/client.go` |
| One-shot reset migration | `internal/db/migrate.go` |
| URL-encoding tripwire + live API canary | `internal/platform/depsdev/url_encoding_test.go` |
| End-to-end enrichment contract test (TestGetPackageVersionsEnrichesWithTimestamps) | same |
| Live-API canary against real mwaskom/seaborn with timestamp assertions    | same |
| Migration source-contract tripwires (×2) | `internal/db/v024_1_distribution_reset_test.go` |
| Version bump 0.24.0 → 0.24.1 | `internal/db/version.go` |

  Tests: all 8 depsdev tests pass offline; live deps.dev integration test passes against real API for mwaskom/seaborn; both v0.24.1 migration tripwires pass; full go test ./... clean; go build ./... clean.

  Deployment recipe for the production box:
```bash
  cd /Users/sean/github/aveloxis/aveloxis
  go install ./cmd/aveloxis

  aveloxis stop all
  aveloxis migrate --skip-views   # fires the v0.24.1 reset
  aveloxis start all
```
  Watch for the migration step log line:
  `msg="migration step ok" label="v0.24.1 reset distribution_last_run for fleets affected by v0.24.0 deps.dev URL bug"`

  After the worker has been running an hour or two, this query confirms deps.dev rows are appearing:
```sql
  SELECT source, COUNT(*)
  FROM aveloxis_data.repo_distribution
  GROUP BY source ORDER BY 2 DESC;
```