### PR TITLE
Julia and R library manifests were dropping. Fixed.

### DIFF
--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -55,7 +55,8 @@
     "distribution_tracking_workers": 4,
     "distribution_tracking_start_interval_s": 30,
     "distribution_tracking_polite_email": "",
-    "distribution_tracking_user_agent": ""
+    "distribution_tracking_user_agent": "",
+    "distribution_tracking_cross_check_sources": true
   },
   "web": {
     "addr": ":8082",

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -201,12 +201,13 @@ func runServe(cfgPath, monitorAddr string, workers int, useAugurKeys bool) error
 		// v0.24.0 — DistributionWorker config. Off by default; the
 		// boolean gate prevents the worker from spawning at all when
 		// the operator hasn't opted in.
-		DistributionTrackingEnabled:       cfg.Collection.DistributionTrackingEnabled,
-		DistributionTrackingInterval:      cfg.Collection.DistributionTrackingInterval(),
-		DistributionTrackingWorkers:       cfg.Collection.DistributionTrackingWorkersOrDefault(),
-		DistributionTrackingStartInterval: cfg.Collection.DistributionTrackingStartInterval(),
-		DistributionTrackingPoliteEmail:   cfg.Collection.DistributionTrackingPoliteEmail,
-		DistributionTrackingUserAgent:     cfg.Collection.DistributionTrackingUserAgent,
+		DistributionTrackingEnabled:           cfg.Collection.DistributionTrackingEnabled,
+		DistributionTrackingInterval:          cfg.Collection.DistributionTrackingInterval(),
+		DistributionTrackingWorkers:           cfg.Collection.DistributionTrackingWorkersOrDefault(),
+		DistributionTrackingStartInterval:     cfg.Collection.DistributionTrackingStartInterval(),
+		DistributionTrackingPoliteEmail:       cfg.Collection.DistributionTrackingPoliteEmail,
+		DistributionTrackingUserAgent:         cfg.Collection.DistributionTrackingUserAgent,
+		DistributionTrackingCrossCheckSources: cfg.Collection.DistributionTrackingCrossCheckSourcesValue(),
 	})
 	go sched.Run(ctx)
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -87,7 +87,8 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "distribution_tracking_workers": 4,
     "distribution_tracking_start_interval_s": 30,
     "distribution_tracking_polite_email": "",
-    "distribution_tracking_user_agent": ""
+    "distribution_tracking_user_agent": "",
+    "distribution_tracking_cross_check_sources": true
   },
   "web": {
     "addr": ":8082",
@@ -209,6 +210,7 @@ The scancode per-file license + copyright + package scan is run by a dedicated `
 | `collection.distribution_tracking_start_interval_s` | integer | `30` | v0.24.0. Minimum seconds between successful CLAIM operations. With default 4 workers and a 30s ticker, steady-state throughput is ~120 repos/hour — comfortably under any known external rate limit. Same minimum-gap pacing primitive as scancode (post-v0.21.3); not a throughput cap. |
 | `collection.distribution_tracking_polite_email` | string | `""` | v0.24.0. Value sent in the `From:` HTTP request header to ecosyste.ms so the operator's traffic lands in their "polite pool" priority queue. Optional but recommended: ecosyste.ms documents the polite-pool contract at https://ecosyste.ms — provide a real email address so they can contact you should rate-limit discussions be needed. Missing value falls back to the lower-priority "common pool". |
 | `collection.distribution_tracking_user_agent` | string | `""` | v0.24.0. Overrides the User-Agent header sent to deps.dev / ecosyste.ms / GitHub. When empty the client uses `aveloxis/<tool_version>`. Operators behind shared egress IPs may want a more identifying string so registry operators can route diagnostics. |
+| `collection.distribution_tracking_cross_check_sources` | bool | `true` | v0.25.0. When true (the default), guarantees BOTH deps.dev AND ecosyste.ms are queried for every repo even when one returns non-empty data. Each source persists its own rows into `repo_distribution` (UNIQUE constraint includes the `source` column so two rows for the same package coexist). The trade-off is ~2× external-registry API calls per scan, but at 180-day cadence the absolute budget is tiny (~5K calls/hour on a 100K-repo fleet). Operator-mandated lock-in for v0.25.0 — set to false only when you explicitly want to halve registry traffic at the cost of single-source-of-truth dependence. The field is a JSON boolean; when omitted from `aveloxis.json`, the v0.25.0 default of `true` applies (pointer-to-bool internally so the decoder distinguishes "absent" from "explicit false"). |
 
 **Force-rerun cookbook** — to invalidate the cadence gate and trigger a fresh scan on the next worker tick, set `scancode_last_run` back to NULL:
 

--- a/internal/collector/distribution/manifest_parser.go
+++ b/internal/collector/distribution/manifest_parser.go
@@ -53,6 +53,18 @@ func ParseManifestName(filename, content string) string {
 		return parsePomXMLName(content)
 	case "go.mod":
 		return parseGoModName(content)
+	case "project.toml", "juliaproject.toml":
+		// Julia: top-level `name = "..."` outside any [section].
+		return parseJuliaProjectName(content)
+	case "description":
+		// R/CRAN: `Package: <name>` as the first or near-first
+		// header in a Debian-control-style file.
+		return parseRDescriptionName(content)
+	case "meta.yaml", "recipe.yaml":
+		// conda: `package:\n  name: <value>` near the top of the
+		// recipe. YAML proper, but we hand-roll a minimal scanner
+		// to avoid pulling a YAML dependency.
+		return parseCondaRecipeName(content)
 	}
 
 	// Suffix-based matching for *.gemspec / *.csproj / *.podspec etc.
@@ -207,6 +219,120 @@ func parseGoModName(content string) string {
 			// Strip optional quotes
 			rest = strings.Trim(rest, `"`)
 			return rest
+		}
+	}
+	return ""
+}
+
+// ---- Project.toml (Julia) --------------------------------------------
+
+// parseJuliaProjectName extracts the top-level `name = "..."` line
+// from a Julia Project.toml. Julia's Pkg.jl writes `name` and `uuid`
+// at the FILE TOP outside any [section] header (unlike Cargo or
+// pyproject which scope name inside [package] / [project]). Our
+// TOML scanner needs a "top-level" mode where inSection==true
+// initially and flips to false when the first [...] header is seen.
+//
+// Example shape:
+//
+//	name = "Drifters"
+//	uuid = "..."
+//	authors = ["..."]
+//	version = "0.5.0"
+//	[deps]
+//	...
+func parseJuliaProjectName(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Stop at the first section header; `name` past that is
+		// scoped to a different table (e.g. [deps].name would be a
+		// dependency name, not the package name).
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			return ""
+		}
+		if name := extractKVString(trimmed, "name"); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+// ---- DESCRIPTION (R / CRAN / Bioconductor) ---------------------------
+
+// parseRDescriptionName extracts the `Package: <name>` header from
+// an R DESCRIPTION file. DESCRIPTION uses RFC 822 / Debian-control
+// style: case-sensitive header keys, colon-separated, optional
+// folded continuations on indented lines. We only need `Package:`
+// which by convention appears as the first field.
+//
+// Conservative scan: the header is matched at line start (after
+// trimming leading whitespace) with the exact key `Package:` (R
+// is case-sensitive on this field). Values are trimmed; continuation
+// lines (rare for the Package field) are not followed.
+func parseRDescriptionName(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		// DESCRIPTION lines are NOT trimmed of leading whitespace
+		// for header matching — folded continuations are indented,
+		// new headers are not.
+		if strings.HasPrefix(line, "Package:") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, "Package:"))
+			// Strip any trailing comment (R DESCRIPTION doesn't
+			// formally allow comments but some files include #-prefixed
+			// notes; be defensive).
+			if idx := strings.Index(val, "#"); idx >= 0 {
+				val = strings.TrimSpace(val[:idx])
+			}
+			return val
+		}
+	}
+	return ""
+}
+
+// ---- meta.yaml / recipe.yaml (conda) ---------------------------------
+
+// parseCondaRecipeName extracts `package:\n  name: <value>` from a
+// conda-build meta.yaml or rattler-build recipe.yaml. We avoid
+// pulling a YAML dependency for this single field — the structure
+// is shallow and the key positions are predictable.
+//
+// Example meta.yaml shape:
+//
+//	package:
+//	  name: numpy
+//	  version: 1.26.0
+//	source:
+//	  url: ...
+//
+// Templating ({{ name|lower }}) is left as-is — we return the raw
+// string. Operator workflow that wants resolved names should
+// snapshot the rendered recipe instead.
+func parseCondaRecipeName(content string) string {
+	inPackage := false
+	for _, line := range strings.Split(content, "\n") {
+		// A top-level key (no leading indent) ends the package: block.
+		if len(line) > 0 && (line[0] != ' ' && line[0] != '\t') {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "package:") {
+				inPackage = true
+				continue
+			}
+			// Any other top-level key exits the package: block.
+			inPackage = false
+			continue
+		}
+		if !inPackage {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "name:") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
+			// Strip surrounding quotes if present.
+			val = strings.Trim(val, `"'`)
+			// Strip trailing YAML comment.
+			if idx := strings.Index(val, "#"); idx >= 0 {
+				val = strings.TrimSpace(val[:idx])
+			}
+			return val
 		}
 	}
 	return ""

--- a/internal/collector/distribution/manifest_parser_test.go
+++ b/internal/collector/distribution/manifest_parser_test.go
@@ -229,9 +229,161 @@ func TestParseManifestNameEmptyContentReturnsEmpty(t *testing.T) {
 		"package.json", "Cargo.toml", "pyproject.toml",
 		"setup.py", "setup.cfg", "pom.xml", "go.mod",
 		"my.gemspec", "composer.json",
+		// v0.25.0 additions:
+		"Project.toml", "JuliaProject.toml", "DESCRIPTION",
+		"meta.yaml", "recipe.yaml",
 	} {
 		if got := ParseManifestName(filename, ""); got != "" {
 			t.Errorf("%s empty content = %q, want empty", filename, got)
 		}
+	}
+}
+
+// ---- v0.25.0 — Julia / R / conda manifest tests ----------------------
+
+func TestParseManifestNameJuliaProjectToml(t *testing.T) {
+	// Real-world Julia Project.toml shape (from JuliaClimate/Drifters.jl):
+	content := `name = "Drifters"
+uuid = "82e88c0e-f6cf-11e8-23e1-3bdc60a1f37c"
+authors = ["JuliaClimate contributors"]
+version = "0.5.6"
+
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
+[compat]
+julia = "1.6"
+`
+	if got := ParseManifestName("Project.toml", content); got != "Drifters" {
+		t.Errorf("Project.toml name = %q, want %q", got, "Drifters")
+	}
+	// JuliaProject.toml is an alias — same parser, same result.
+	if got := ParseManifestName("JuliaProject.toml", content); got != "Drifters" {
+		t.Errorf("JuliaProject.toml name = %q, want %q", got, "Drifters")
+	}
+}
+
+func TestParseManifestNameJuliaProjectTomlIgnoresSectionedName(t *testing.T) {
+	// If `name` only appears AFTER a [section] header, it's NOT the
+	// package name (it's a dep name or compat key). Conservative: return "".
+	content := `[deps]
+name = "this-is-a-dep-key-not-the-package"
+`
+	if got := ParseManifestName("Project.toml", content); got != "" {
+		t.Errorf("sectioned-only name = %q, want empty", got)
+	}
+}
+
+func TestParseManifestNameJuliaProjectTomlNoName(t *testing.T) {
+	// Some Julia repos (notably apps not registered with General)
+	// omit the name field. Parser must return "" not panic.
+	content := `uuid = "82e88c0e-f6cf-11e8-23e1-3bdc60a1f37c"
+version = "0.1.0"
+[deps]
+`
+	if got := ParseManifestName("Project.toml", content); got != "" {
+		t.Errorf("no-name Project.toml = %q, want empty", got)
+	}
+}
+
+func TestParseManifestNameRDescription(t *testing.T) {
+	// Real-world R DESCRIPTION shape (from a typical CRAN/Bioconductor package).
+	// DESCRIPTION uses RFC 822 / Debian-control style: case-sensitive
+	// keys, colon-separated values, optional folded continuations.
+	content := `Package: genefilter
+Title: genefilter: methods for filtering genes from high-throughput experiments
+Version: 1.84.0
+Author: R. Gentleman, V. Carey, W. Huber, F. Hahne
+Description: Some basic functions for filtering genes.
+License: Artistic-2.0
+Depends: R (>= 4.0.0), methods
+`
+	if got := ParseManifestName("DESCRIPTION", content); got != "genefilter" {
+		t.Errorf("DESCRIPTION name = %q, want %q", got, "genefilter")
+	}
+}
+
+func TestParseManifestNameRDescriptionCaseSensitive(t *testing.T) {
+	// R is case-sensitive on the `Package:` key. A lower-cased
+	// `package:` is NOT a valid R DESCRIPTION header.
+	content := `package: not-the-right-key
+`
+	if got := ParseManifestName("DESCRIPTION", content); got != "" {
+		t.Errorf("lowercase 'package:' = %q, want empty (R is case-sensitive)", got)
+	}
+}
+
+func TestParseManifestNameRDescriptionNoPackageField(t *testing.T) {
+	// Malformed DESCRIPTION with no Package: header — return "".
+	content := `Title: Just a title
+Version: 1.0.0
+`
+	if got := ParseManifestName("DESCRIPTION", content); got != "" {
+		t.Errorf("no Package: header = %q, want empty", got)
+	}
+}
+
+func TestParseManifestNameCondaRecipeMetaYaml(t *testing.T) {
+	// Real conda-build meta.yaml shape.
+	content := `package:
+  name: numpy
+  version: 1.26.0
+
+source:
+  url: https://github.com/numpy/numpy/archive/v1.26.0.tar.gz
+
+build:
+  number: 0
+`
+	if got := ParseManifestName("meta.yaml", content); got != "numpy" {
+		t.Errorf("meta.yaml name = %q, want %q", got, "numpy")
+	}
+}
+
+func TestParseManifestNameCondaRecipeYaml(t *testing.T) {
+	// rattler-build recipe.yaml shape (newer conda variant).
+	content := `package:
+  name: scipy
+  version: 1.11.4
+`
+	if got := ParseManifestName("recipe.yaml", content); got != "scipy" {
+		t.Errorf("recipe.yaml name = %q, want %q", got, "scipy")
+	}
+}
+
+func TestParseManifestNameCondaIgnoresNameOutsidePackageBlock(t *testing.T) {
+	// `name:` keys can appear in OTHER top-level YAML blocks
+	// (source.name, build.name, etc.). Only the package: block's
+	// name is the package name. The parser must scope correctly.
+	content := `source:
+  name: should-be-ignored
+  url: https://example.com
+
+package:
+  name: realname
+`
+	if got := ParseManifestName("meta.yaml", content); got != "realname" {
+		t.Errorf("scoped-name = %q, want %q", got, "realname")
+	}
+}
+
+func TestParseManifestNameCondaStripsQuotes(t *testing.T) {
+	// YAML lets you quote scalar values; the parser must strip
+	// double or single quotes.
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"double quotes", "package:\n  name: \"pyqt\"\n", "pyqt"},
+		{"single quotes", "package:\n  name: 'matplotlib'\n", "matplotlib"},
+		{"no quotes", "package:\n  name: pandas\n", "pandas"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseManifestName("meta.yaml", tt.content); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/collector/distribution/scan_complete_test.go
+++ b/internal/collector/distribution/scan_complete_test.go
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package distribution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/aveloxis/aveloxis/internal/platform"
+	"github.com/aveloxis/aveloxis/internal/platform/depsdev"
+	"github.com/aveloxis/aveloxis/internal/platform/ecosystems"
+	"github.com/aveloxis/aveloxis/internal/platform/github"
+)
+
+// v0.25.0 — scan completeness + dispatcher pause tests.
+//
+// These tests cover the contract pieces that protect the 10-repo
+// cohort that trips the ecosyste.ms circuit breaker:
+//   - Scan returns complete=false when an external source had a
+//     transient error or was skipped due to an open breaker.
+//   - Worker passes complete to MarkDistributionComplete.
+//   - Dispatcher pauses when scanner.Healthy() returns false.
+//
+// The combination ensures that during a 1-hour ecosyste.ms outage
+// (a) the breaker-tripping cohort still scans but gets marked
+// incomplete so it re-collects on the next dispatch cycle, and
+// (b) no further repos get dispatched during the pause — so they
+// don't get permanent "complete scan" stamps with missing data.
+
+// ---- source-contract tests -------------------------------------------
+
+func TestScannerInterfaceRequiresHealthy(t *testing.T) {
+	// Source-contract pin: the Scanner interface in worker.go must
+	// declare a Healthy() method so the dispatcher can pause when
+	// an external source is unavailable.
+	body := readFile(t, "worker.go")
+	if !strings.Contains(body, "Healthy() bool") {
+		t.Fatal("Scanner interface must declare Healthy() bool — dispatcher pause depends on it")
+	}
+}
+
+func TestScannerInterfaceScanReturnsComplete(t *testing.T) {
+	// Pin the 4-return signature of Scan. The third return (before
+	// the error) is the complete bool.
+	body := readFile(t, "worker.go")
+	if !strings.Contains(body, "complete bool") {
+		t.Error("Scanner.Scan must return a complete bool (third return value) so partial scans can be distinguished from full scans for the distribution_scan_complete column")
+	}
+}
+
+func TestCompositeScannerImplementsHealthy(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	// Function definition (not just the doc).
+	if !strings.Contains(body, "func (s *CompositeScanner) Healthy() bool") {
+		t.Error("CompositeScanner must implement Healthy() bool")
+	}
+	// Must check ecosyste.ms breaker state.
+	if !strings.Contains(body, "IsCircuitOpen()") {
+		t.Error("CompositeScanner.Healthy() must consult ecosystems.IsCircuitOpen()")
+	}
+}
+
+func TestScannerTracksIncompleteOnTransientExternalError(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	// Pin the tracker variable.
+	if !strings.Contains(body, "scanIncomplete") {
+		t.Error("Scan must declare a scanIncomplete tracker so transient external errors mark the scan partial")
+	}
+	// Pin that the tracker gets set on ClassTransient/ClassRateLimit.
+	if !strings.Contains(body, "ClassTransient") || !strings.Contains(body, "ClassRateLimit") {
+		t.Error("scanIncomplete must be set when external source returns ClassTransient or ClassRateLimit")
+	}
+}
+
+func TestScannerHandlesErrCircuitOpenAsIncompleteSkip(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	// Pin: ErrCircuitOpen is identified specifically and sets
+	// scanIncomplete WITHOUT incrementing erroredSources.
+	if !strings.Contains(body, "ecosystems.ErrCircuitOpen") {
+		t.Error("Scan must check errors.Is(err, ecosystems.ErrCircuitOpen) so circuit-open skips mark the scan incomplete WITHOUT incrementing erroredSources (otherwise the failure-counter path would fire on every repo during an outage)")
+	}
+}
+
+func TestWorkerDispatcherPausesWhenUnhealthy(t *testing.T) {
+	body := readFile(t, "worker.go")
+	// Pin: the dispatcher calls scanner.Healthy().
+	if !strings.Contains(body, "scanner.Healthy()") && !strings.Contains(body, "w.scanner.Healthy()") {
+		t.Error("dispatcher must call w.scanner.Healthy() before each claim — without this, repos dispatched during an ecosyste.ms outage get permanent 'complete scan' stamps with missing data")
+	}
+	// Pin: there's an unhealthy-pause log message.
+	if !strings.Contains(body, "scanner unhealthy") {
+		t.Error("dispatcher must log when entering the unhealthy-pause state — operator visibility")
+	}
+}
+
+func TestWorkerProcessJobPassesScanCompleteToStore(t *testing.T) {
+	body := readFile(t, "worker.go")
+	// Pin: scanComplete is captured from Scan and passed through.
+	if !strings.Contains(body, "scanComplete") {
+		t.Error("processJob must capture scanComplete from Scan's return and pass it to MarkDistributionComplete")
+	}
+	if !strings.Contains(body, "MarkDistributionComplete(completionCtx, job, distributions, manifests, scanComplete)") {
+		t.Error("MarkDistributionComplete call must thread scanComplete through")
+	}
+}
+
+// ---- behavioral tests ------------------------------------------------
+
+// TestCompositeScannerReturnsIncompleteOnEcosystemsTransient pins
+// the headline v0.25.0 partial-scan behavior. When ecosyste.ms 500s
+// (the dominant chaoss.tv failure mode), the scanner returns
+// complete=false so the store stamps distribution_scan_complete=
+// FALSE and the row re-claims on the next dispatch cycle.
+func TestCompositeScannerReturnsIncompleteOnEcosystemsTransient(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":[]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true)
+
+	_, _, complete, err := scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+	if err != nil {
+		t.Fatalf("scan must NOT fail when only ecosyste.ms 500s and other sources are clean — got err=%v", err)
+	}
+	if complete {
+		t.Error("scan with ecosyste.ms 500 must return complete=false so the row gets re-collected when ecosyste.ms recovers — without this, the partial-scan rows would be stamped with the cadence gate and locked out for 180 days")
+	}
+}
+
+// TestCompositeScannerReturnsCompleteOnCleanScan pins the success
+// path: every external source completed cleanly → complete=true,
+// row gets normal cadence treatment.
+func TestCompositeScannerReturnsCompleteOnCleanScan(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":[]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true)
+
+	_, _, complete, err := scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+	if err != nil {
+		t.Fatalf("scan must not fail on clean responses: %v", err)
+	}
+	if !complete {
+		t.Error("scan with every source returning clean empty must return complete=true — operator wants the cadence gate to apply normally for genuinely-no-evidence repos")
+	}
+}
+
+// TestCompositeScannerReturnsIncompleteOnEcosystemsCircuitOpen pins
+// the breaker-open path: when ecosyste.ms's circuit is already open
+// (LookupPackages short-circuits with ErrCircuitOpen), the scan
+// gets marked incomplete WITHOUT erroredSources incrementing.
+func TestCompositeScannerReturnsIncompleteOnEcosystemsCircuitOpen(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":[]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	// Build an ecosystems client and trip its breaker manually.
+	ecoClient := ecosystems.New(ecosystems.Options{BaseURL: "http://does-not-matter"})
+	// Trip via direct state mutation — same pattern as the
+	// circuit-breaker tests in the ecosystems package.
+	tripBreakerManually(t, ecoClient)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	logger := slog.Default()
+	depsClient := depsdev.New(depsdev.Options{BaseURL: depsServer.URL})
+	keys := platform.NewKeyPool([]string{"test"}, logger)
+	ghClient := github.New(ghServer.URL, keys, logger)
+
+	scanner := &CompositeScanner{
+		DepsDev:           depsClient,
+		Ecosystems:        ecoClient,
+		GitHub:            ghClient,
+		Logger:            logger,
+		CrossCheckSources: true,
+	}
+
+	_, _, complete, err := scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+	if err != nil {
+		t.Fatalf("circuit-open path must not produce an error: %v", err)
+	}
+	if complete {
+		t.Error("scan with ecosyste.ms circuit open must return complete=false — the source was not consulted; row must re-collect when breaker closes")
+	}
+	if !scanner.Healthy() {
+		// Healthy() should also report false while the breaker is open.
+		// (Asserted separately, but confirm here for completeness.)
+	}
+	if scanner.Healthy() {
+		t.Error("Healthy() must return false while ecosyste.ms breaker is open")
+	}
+}
+
+// tripBreakerManually mutates the ecosystems Client's internal
+// state to open the circuit. Uses the same direct-mutation pattern
+// as circuit_breaker_test.go in the ecosystems package. We import
+// nothing extra: ecosystems.Client's cb* fields aren't accessible
+// from this package (different package, lowercase fields), so we
+// drive the trip via 10 real failing calls to a 500-returning
+// httptest server.
+func tripBreakerManually(t *testing.T, c *ecosystems.Client) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	// We can't redirect the client's baseURL post-construction.
+	// Drive the trip via the public LookupPackages path — but the
+	// constructed client points at "http://does-not-matter" which
+	// will fail at the transport layer (which also counts as a
+	// transient failure per noteTransientFailure in client.go).
+	for i := 0; i < ecosystems.CircuitBreakerThreshold; i++ {
+		_, _ = c.LookupPackages(context.Background(), "https://github.com/x/y")
+	}
+	if !c.IsCircuitOpen() {
+		t.Fatal("expected breaker to be open after threshold failures; check ecosystems CircuitBreakerThreshold constant + tripBreakerManually helper")
+	}
+}
+
+// TestWorkerDispatcherPausesAndResumes confirms the dispatcher
+// actually halts when scanner.Healthy()=false and resumes when it
+// flips back to true. Uses the fakeScanner.unhealthy atomic.
+func TestWorkerDispatcherPausesAndResumes(t *testing.T) {
+	scanner := &fakeScanner{
+		results: map[int64]scanResult{},
+	}
+	// Mark unhealthy before any claim fires.
+	scanner.unhealthy.Store(true)
+
+	// Three jobs in the queue.
+	store := &fakeStore{
+		queue: []*db.DistributionJob{
+			{RepoID: 1, RepoOwner: "x", RepoName: "y", RepoGit: "https://github.com/x/y"},
+			{RepoID: 2, RepoOwner: "x", RepoName: "z", RepoGit: "https://github.com/x/z"},
+			{RepoID: 3, RepoOwner: "x", RepoName: "w", RepoGit: "https://github.com/x/w"},
+		},
+	}
+
+	worker := NewWorker(WorkerOptions{
+		Store:         store,
+		Scanner:       scanner,
+		Workers:       1,
+		StartInterval: 0,
+		Cadence:       180 * 24 * time.Hour,
+		Logger:        testLogger(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(doneCh)
+	}()
+
+	// Sleep briefly to confirm no claims fire while unhealthy. The
+	// dispatcher's healthCheckInterval is 60s; in test-time this
+	// just means it sleeps in its first health-check branch.
+	time.Sleep(200 * time.Millisecond)
+	marks, _ := store.snapshot()
+	if len(marks) != 0 {
+		t.Errorf("dispatcher must NOT process any jobs while scanner is unhealthy — got %d marks", len(marks))
+	}
+
+	// Flip healthy. Dispatcher should pick up after the next
+	// healthCheckInterval. To avoid waiting the full 60s in the
+	// test, we patch worker.healthCheckInterval... but we can't,
+	// it's a package constant. So we use the worker_test.go
+	// pattern of canceling ctx and starting fresh.
+	cancel()
+	<-doneCh
+
+	// Restart with scanner healthy and verify jobs flow.
+	scanner.unhealthy.Store(false)
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	doneCh2 := make(chan struct{})
+	go func() {
+		worker.Run(ctx2)
+		close(doneCh2)
+	}()
+	// Give it time to process all three.
+	time.Sleep(500 * time.Millisecond)
+	cancel2()
+	<-doneCh2
+
+	marks, _ = store.snapshot()
+	if len(marks) != 3 {
+		t.Errorf("expected 3 marks once scanner became healthy, got %d", len(marks))
+	}
+}
+
+// TestWorkerProcessJobPassesIncompleteScanToStore confirms that a
+// scanner returning complete=false routes through to the store as
+// scanComplete=false on MarkDistributionComplete.
+func TestWorkerProcessJobPassesIncompleteScanToStore(t *testing.T) {
+	scanner := &fakeScanner{
+		results: map[int64]scanResult{
+			42: {partial: true}, // → Scan returns complete=false
+		},
+	}
+	store := &fakeStore{
+		queue: []*db.DistributionJob{
+			{RepoID: 42, RepoOwner: "x", RepoName: "y", RepoGit: "https://github.com/x/y"},
+		},
+	}
+	worker := NewWorker(WorkerOptions{
+		Store:   store,
+		Scanner: scanner,
+		Workers: 1,
+		Logger:  testLogger(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(doneCh)
+	}()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-doneCh
+
+	marks, _ := store.snapshot()
+	if len(marks) != 1 {
+		t.Fatalf("expected 1 mark, got %d", len(marks))
+	}
+	if marks[0].scanComplete {
+		t.Errorf("partial scan must propagate as scanComplete=false to MarkDistributionComplete — without this the distribution_scan_complete column stays TRUE and the row gets locked out for 180 days")
+	}
+}
+
+// silence unused import warnings if any util doesn't fire in this file
+var _ = errors.New
+var _ = fmt.Sprintf
+var _ = atomic.AddInt32
+var _ = os.Stat

--- a/internal/collector/distribution/scanner.go
+++ b/internal/collector/distribution/scanner.go
@@ -19,14 +19,52 @@ import (
 // CompositeScanner composes the five v0.24.0 distribution sources
 // into a single Scanner. Each source runs sequentially; per-source
 // failures are aggregated best-effort rather than aborting the whole
-// scan. The scan as a whole only fails when EVERY source failed
-// AND zero evidence was collected — that's the signal worth a
-// RecordDistributionFailure.
+// scan.
+//
+// v0.25.0 — failure contract loosened. Pre-v0.25.0 the gate
+// `len(errsList) > 0 && zero data` failed the scan whenever ANY
+// source errored and no other source produced data, conflating two
+// distinct situations:
+//
+//   - "Repo legitimately doesn't publish anywhere we can see"
+//     (success, stamp last_run, do not retry for 180 days), and
+//   - "Sources we needed had transient failures"
+//     (failure, quadratic backoff, retry sooner).
+//
+// The diagnostic that surfaced this: every chaoss.tv distribution
+// failure on 2026-05-22/23 was a Julia or R repo where ecosyste.ms
+// 500'd and every other source legitimately had nothing. The
+// pre-v0.25.0 contract recorded these as failures, walked the
+// backoff to the 10-strike sideline, and locked them out for 6
+// months — even though the working sources had returned clean
+// "no data" responses.
+//
+// New contract: fail only when EVERY enabled source actually
+// errored AND no evidence was collected. At least one clean
+// completion = scan succeeded (the empty-truth answer).
+//
+// Per-source-class diagnostic logging: external package-registry
+// sources (deps.dev + ecosyste.ms) get distinct treatment from
+// GitHub sources. When BOTH external sources fail in the same
+// scan, the composite emits an ERROR-level log entry with each
+// source's error labeled as its own slog key — never aggregated
+// or swallowed — so operators can see per-source what failed
+// while we build confidence the error classification is right.
 type CompositeScanner struct {
 	DepsDev    *depsdev.Client
 	Ecosystems *ecosystems.Client
 	GitHub     *github.Client
 	Logger     *slog.Logger
+
+	// CrossCheckSources, when true, ensures BOTH deps.dev and
+	// ecosyste.ms are always queried for every repo even if one
+	// has already returned non-empty data. Each source persists
+	// its own rows into repo_distribution (source column
+	// distinguishes them; UNIQUE constraint includes source so
+	// both can coexist). Default in production: true. Set false
+	// only when an operator wants to halve registry traffic at
+	// the cost of single-source-of-truth dependence. v0.25.0.
+	CrossCheckSources bool
 }
 
 // NewCompositeScanner constructs a Scanner with the standard
@@ -41,10 +79,11 @@ func NewCompositeScanner(
 		logger = slog.Default()
 	}
 	return &CompositeScanner{
-		DepsDev:    depsDev,
-		Ecosystems: eco,
-		GitHub:     gh,
-		Logger:     logger,
+		DepsDev:           depsDev,
+		Ecosystems:        eco,
+		GitHub:            gh,
+		Logger:            logger,
+		CrossCheckSources: true, // v0.25.0 default; see field doc
 	}
 }
 
@@ -74,62 +113,112 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 	var (
 		distributions []model.PackageDistribution
 		manifests     []model.DistributionManifest
-		errsList      []error
+
+		// Per-class error tracking (v0.25.0). External-registry
+		// errors get distinct treatment from GitHub errors per
+		// operator direction: we want explicit per-source visibility
+		// when both external sources fail until we have confidence
+		// the classification is right.
+		depsDevErr     error
+		ecosystemsErr  error
+		githubErrs     []error // ListReleaseAssetExtensions, ListRepoPackages, ListRootManifests
+		enabledSources int     // total number of sources actually attempted
+		erroredSources int     // count of sources that returned non-nil err
 	)
 
-	// Source 1: deps.dev
+	// Source 1: deps.dev (external package registry, primary)
 	if s.DepsDev != nil {
+		enabledSources++
 		dd, err := s.DepsDev.GetPackageVersions(ctx, owner, repo)
 		if err != nil {
+			erroredSources++
+			depsDevErr = err
 			class := platform.ClassifyError(err)
 			s.Logger.Warn("distribution: deps.dev fetch failed",
-				"repo_id", repoID, "class", class.String(), "error", err)
-			errsList = append(errsList, err)
+				"repo_id", repoID, "owner", owner, "repo", repo,
+				"class", class.String(), "error", err)
 		} else {
 			distributions = append(distributions, dd...)
 		}
 	}
 
-	// Source 2: ecosyste.ms
-	if s.Ecosystems != nil {
+	// Source 2: ecosyste.ms (external package registry, long-tail).
+	//
+	// CrossCheckSources gating: when false AND deps.dev returned
+	// non-empty data, skip ecosyste.ms. Default true → always
+	// query both so each writes its own (source-distinguished)
+	// rows. The UNIQUE (repo_id, ecosystem, package_name, source)
+	// constraint in repo_distribution makes two-source rows for the
+	// same package legal — and useful for cross-checking.
+	skipEcosystems := !s.CrossCheckSources && len(distributions) > 0
+	if s.Ecosystems != nil && !skipEcosystems {
+		enabledSources++
 		em, err := s.Ecosystems.LookupPackages(ctx, repoGit)
 		if err != nil {
+			erroredSources++
+			ecosystemsErr = err
+			class := platform.ClassifyError(err)
 			s.Logger.Warn("distribution: ecosyste.ms fetch failed",
-				"repo_id", repoID, "class", platform.ClassifyError(err).String(), "error", err)
-			errsList = append(errsList, err)
+				"repo_id", repoID, "owner", owner, "repo", repo,
+				"class", class.String(), "error", err)
 		} else {
 			distributions = append(distributions, em...)
 		}
 	}
 
-	// Sources 3, 4, 5: GitHub
+	// When BOTH external registries failed in the same scan, emit
+	// an ERROR-level log line with each source's error labeled as
+	// its own slog key (NOT joined / aggregated). This is the
+	// operator-mandated diagnostic visibility: per-source errors
+	// while we build confidence the classification is right.
+	bothExternalAttempted := s.DepsDev != nil && s.Ecosystems != nil && !skipEcosystems
+	if bothExternalAttempted && depsDevErr != nil && ecosystemsErr != nil {
+		s.Logger.Error("distribution: BOTH external registries failed (per-source detail follows)",
+			"repo_id", repoID, "owner", owner, "repo", repo,
+			"repo_git", repoGit,
+			"deps_dev_class", platform.ClassifyError(depsDevErr).String(),
+			"deps_dev_error", depsDevErr.Error(),
+			"ecosystems_class", platform.ClassifyError(ecosystemsErr).String(),
+			"ecosystems_error", ecosystemsErr.Error())
+	}
+
+	// Sources 3, 4, 5: GitHub (release assets, packages, manifests).
+	// Errors here keep WARN level — these are platform-of-record
+	// signals where 403/404/304 are common (private repos, missing
+	// OAuth scope, archived/empty repos) and routinely benign.
 	if s.GitHub != nil {
 		// Release assets
+		enabledSources++
 		assets, err := s.GitHub.ListReleaseAssetExtensions(ctx, owner, repo)
 		if err != nil {
+			erroredSources++
+			githubErrs = append(githubErrs, err)
 			s.Logger.Warn("distribution: github release assets failed",
-				"repo_id", repoID, "error", err)
-			errsList = append(errsList, err)
+				"repo_id", repoID, "owner", owner, "repo", repo, "error", err)
 		} else {
 			distributions = append(distributions, assets...)
 		}
 
 		// GitHub Packages (best-effort)
+		enabledSources++
 		pkgs, err := s.GitHub.ListRepoPackages(ctx, owner, repo)
 		if err != nil {
+			erroredSources++
+			githubErrs = append(githubErrs, err)
 			s.Logger.Warn("distribution: github packages failed",
-				"repo_id", repoID, "error", err)
-			errsList = append(errsList, err)
+				"repo_id", repoID, "owner", owner, "repo", repo, "error", err)
 		} else {
 			distributions = append(distributions, pkgs...)
 		}
 
 		// Manifests + declared-name parsing
+		enabledSources++
 		rawManifests, err := s.GitHub.ListRootManifests(ctx, owner, repo)
 		if err != nil {
+			erroredSources++
+			githubErrs = append(githubErrs, err)
 			s.Logger.Warn("distribution: github manifests failed",
-				"repo_id", repoID, "error", err)
-			errsList = append(errsList, err)
+				"repo_id", repoID, "owner", owner, "repo", repo, "error", err)
 		} else {
 			for _, m := range rawManifests {
 				// Best-effort: fetch content and parse declared
@@ -148,18 +237,26 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 		}
 	}
 
-	// Decide overall success/failure.
-	//
-	// Contract: if EVERY source failed AND no evidence was
-	// collected, the scan failed (caller routes to
-	// RecordDistributionFailure). Otherwise — even partial
-	// evidence — the scan succeeded.
-	//
-	// This matches v0.20.8 Fix C / v0.20.9 partial-results
-	// philosophy: collect what we can; only count it as failure
-	// when nothing succeeded.
-	if len(errsList) > 0 && len(distributions) == 0 && len(manifests) == 0 {
-		return nil, nil, errors.Join(errsList...)
+	// v0.25.0 contract: fail the scan ONLY when EVERY enabled
+	// source actually errored AND no evidence was collected. Empty-
+	// but-clean responses from at least one source represent the
+	// truthful "this repo doesn't publish anywhere we can see"
+	// answer — that's a success, last_run gets stamped, no
+	// backoff, no 180-day sideline. The pre-v0.25.0 contract
+	// (`len(errsList) > 0 && zero data` = failure) conflated this
+	// with "sources we needed had transient failures" and stuck
+	// legitimate-no-data repos in an indefinite retry loop until
+	// the 10-strike sideline.
+	if enabledSources > 0 && erroredSources == enabledSources && len(distributions) == 0 && len(manifests) == 0 {
+		allErrs := make([]error, 0, 2+len(githubErrs))
+		if depsDevErr != nil {
+			allErrs = append(allErrs, depsDevErr)
+		}
+		if ecosystemsErr != nil {
+			allErrs = append(allErrs, ecosystemsErr)
+		}
+		allErrs = append(allErrs, githubErrs...)
+		return nil, nil, errors.Join(allErrs...)
 	}
 
 	return distributions, manifests, nil

--- a/internal/collector/distribution/scanner.go
+++ b/internal/collector/distribution/scanner.go
@@ -100,14 +100,17 @@ func NewCompositeScanner(
 // error (the operator's design decision recorded in CLAUDE.md).
 // Future work could add a GitLab path here without changing the
 // outer Worker contract.
-func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) ([]model.PackageDistribution, []model.DistributionManifest, error) {
+func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) ([]model.PackageDistribution, []model.DistributionManifest, bool, error) {
 	// Platform gate: deps.dev expects github.com URLs; ecosyste.ms
 	// can lookup gitlab.com too but the GitHub Contents API doesn't
 	// work for GitLab. Easiest to opt in only for github.com hosts.
+	//
+	// A non-GitHub repo is a "complete scan with no evidence" —
+	// stamp it complete=true so the cadence gate applies normally.
 	if !strings.Contains(strings.ToLower(repoGit), "github.com") {
 		s.Logger.Debug("distribution scanner: non-GitHub repo, skipping",
 			"repo_id", repoID, "repo_git", repoGit)
-		return nil, nil, nil
+		return nil, nil, true, nil
 	}
 
 	var (
@@ -124,6 +127,22 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 		githubErrs     []error // ListReleaseAssetExtensions, ListRepoPackages, ListRootManifests
 		enabledSources int     // total number of sources actually attempted
 		erroredSources int     // count of sources that returned non-nil err
+
+		// scanIncomplete tracks whether ANY enabled external source
+		// (deps.dev or ecosyste.ms) had a transient error or was
+		// skipped due to an open circuit breaker. When true, the
+		// store stamps distribution_scan_complete=FALSE on this
+		// row, which makes the claim query treat it as immediately
+		// re-eligible (bypassing the cadence gate). The 10 repos
+		// that trip the ecosyste.ms breaker get full re-scans this
+		// way; their partial-scan rows rotate to history on the
+		// next snapshot replace.
+		//
+		// GitHub source errors do NOT set scanIncomplete — 403/404/
+		// 304 from those endpoints are routinely benign (private
+		// repos, missing OAuth scope, archived/empty repos) and
+		// shouldn't force a re-scan.
+		scanIncomplete bool
 	)
 
 	// Source 1: deps.dev (external package registry, primary)
@@ -134,6 +153,12 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 			erroredSources++
 			depsDevErr = err
 			class := platform.ClassifyError(err)
+			// Transient/rate-limit class from an external registry
+			// marks the scan incomplete so the row gets re-collected
+			// once the source recovers (v0.25.0).
+			if class == platform.ClassTransient || class == platform.ClassRateLimit {
+				scanIncomplete = true
+			}
 			s.Logger.Warn("distribution: deps.dev fetch failed",
 				"repo_id", repoID, "owner", owner, "repo", repo,
 				"class", class.String(), "error", err)
@@ -155,12 +180,31 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 		enabledSources++
 		em, err := s.Ecosystems.LookupPackages(ctx, repoGit)
 		if err != nil {
-			erroredSources++
-			ecosystemsErr = err
-			class := platform.ClassifyError(err)
-			s.Logger.Warn("distribution: ecosyste.ms fetch failed",
-				"repo_id", repoID, "owner", owner, "repo", repo,
-				"class", class.String(), "error", err)
+			// v0.25.0: ErrCircuitOpen is a typed sentinel from the
+			// ecosystems client indicating the source-level circuit
+			// breaker is currently tripped and the call short-
+			// circuited without consulting upstream. Treat it as a
+			// "source unavailable" skip (NOT an error) — but mark
+			// the scan incomplete so the row gets re-collected once
+			// the breaker closes. The 10 repos that trip the breaker
+			// in the first place ALSO go through this path on their
+			// second attempt (the partial-scan rows get rotated to
+			// history on the re-collection).
+			if errors.Is(err, ecosystems.ErrCircuitOpen) {
+				scanIncomplete = true
+				s.Logger.Debug("distribution: ecosyste.ms skipped — circuit open, scan marked incomplete",
+					"repo_id", repoID, "owner", owner, "repo", repo)
+			} else {
+				erroredSources++
+				ecosystemsErr = err
+				class := platform.ClassifyError(err)
+				if class == platform.ClassTransient || class == platform.ClassRateLimit {
+					scanIncomplete = true
+				}
+				s.Logger.Warn("distribution: ecosyste.ms fetch failed",
+					"repo_id", repoID, "owner", owner, "repo", repo,
+					"class", class.String(), "error", err)
+			}
 		} else {
 			distributions = append(distributions, em...)
 		}
@@ -256,8 +300,33 @@ func (s *CompositeScanner) Scan(ctx context.Context, repoID int64, owner, repo, 
 			allErrs = append(allErrs, ecosystemsErr)
 		}
 		allErrs = append(allErrs, githubErrs...)
-		return nil, nil, errors.Join(allErrs...)
+		// Failed scan: complete is moot — the worker routes to
+		// RecordDistributionFailure and doesn't touch
+		// distribution_scan_complete. Return false defensively.
+		return nil, nil, false, errors.Join(allErrs...)
 	}
 
-	return distributions, manifests, nil
+	// Success path. complete = !scanIncomplete. The store stamps
+	// distribution_scan_complete with this value; the claim query
+	// treats scan_complete=FALSE as immediately re-eligible.
+	return distributions, manifests, !scanIncomplete, nil
+}
+
+// Healthy reports whether the CompositeScanner's external sources
+// are currently in a healthy state. Returns false when ecosyste.ms
+// is enabled AND its source-level circuit breaker is currently open
+// — the DistributionWorker's dispatcher consults this before each
+// claim and pauses while unhealthy, so we don't dispatch new repos
+// into a known-bad upstream and end up stamping their cadence with
+// partial-scan data.
+//
+// deps.dev does not (yet) have a source-level circuit breaker; if
+// one is added in the future, OR its IsCircuitOpen() in here.
+//
+// v0.25.0.
+func (s *CompositeScanner) Healthy() bool {
+	if s.Ecosystems != nil && s.Ecosystems.IsCircuitOpen() {
+		return false
+	}
+	return true
 }

--- a/internal/collector/distribution/scanner_test.go
+++ b/internal/collector/distribution/scanner_test.go
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package distribution
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/aveloxis/aveloxis/internal/platform"
+	"github.com/aveloxis/aveloxis/internal/platform/depsdev"
+	"github.com/aveloxis/aveloxis/internal/platform/ecosystems"
+	"github.com/aveloxis/aveloxis/internal/platform/github"
+)
+
+// v0.25.0 — scanner contract tests.
+//
+// The contract loosening surfaced by the 2026-05-22/23 production
+// diagnostic on the chaoss.tv aveloxis DB: every distribution-scan
+// failure during the ecosyste.ms outage was a Julia or R repo
+// where ecosyste.ms 500'd and every other source legitimately
+// returned "no data." The pre-v0.25.0 contract recorded these as
+// failures (any error + zero data = failure), driving the 10-strike
+// sideline path and locking the affected cohort out for 6 months.
+// The v0.25.0 contract distinguishes "this repo legitimately
+// publishes nothing we can see" (success, no retry) from "sources
+// we needed had transient failures" (failure, retry sooner).
+
+// ---- Source-contract tests (pin design invariants) -------------------
+
+func TestCompositeScannerHasCrossCheckSourcesField(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	if !strings.Contains(body, "CrossCheckSources bool") {
+		t.Fatal("CompositeScanner must declare CrossCheckSources bool field for the v0.25.0 cross-check guarantee — operator wants both external sources queried per repo")
+	}
+}
+
+func TestNewCompositeScannerDefaultsCrossCheckSourcesTrue(t *testing.T) {
+	cs := NewCompositeScanner(nil, nil, nil, nil)
+	if !cs.CrossCheckSources {
+		t.Error("NewCompositeScanner must default CrossCheckSources=true per v0.25.0 — operator explicitly asked for both deps.dev AND ecosyste.ms queried per repo, with separate rows per source")
+	}
+}
+
+func TestScannerTracksEnabledAndErroredSources(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	if !strings.Contains(body, "enabledSources") {
+		t.Error("Scan must track enabledSources counter to compare against erroredSources for the v0.25.0 loosened contract")
+	}
+	if !strings.Contains(body, "erroredSources") {
+		t.Error("Scan must track erroredSources counter for the v0.25.0 loosened contract")
+	}
+	// Pin the actual gating condition.
+	if !strings.Contains(body, "erroredSources == enabledSources") {
+		t.Error("Scan must fail ONLY when every enabled source actually errored (erroredSources == enabledSources). The pre-v0.25.0 'any error' gate caused legitimate-no-data repos to be sidelined for 180 days.")
+	}
+}
+
+func TestScannerEmitsErrorLogWhenBothExternalSourcesFail(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	// Per operator direction: when BOTH external registries fail in
+	// the same scan, emit a distinct ERROR-level log line with each
+	// source's error labeled as its own slog key — never joined or
+	// swallowed.
+	if !strings.Contains(body, "BOTH external registries failed") {
+		t.Error("Scan must emit a distinct log message when both external registries fail — operator wants per-source visibility while building confidence in the error classification")
+	}
+	if !strings.Contains(body, "Logger.Error") && !strings.Contains(body, ".Error(") {
+		t.Error("The both-external-failed log entry must be at ERROR level (not WARN) per operator direction")
+	}
+	for _, requiredKey := range []string{
+		"deps_dev_class",
+		"deps_dev_error",
+		"ecosystems_class",
+		"ecosystems_error",
+	} {
+		if !strings.Contains(body, requiredKey) {
+			t.Errorf("both-external-failed log must include slog key %q so per-source errors are visible labeled (not aggregated via errors.Join)", requiredKey)
+		}
+	}
+}
+
+func TestScannerGitHubErrorsStayWarnLevel(t *testing.T) {
+	body := readFile(t, "scanner.go")
+	// GitHub source error logs should remain WARN — 403/404/304 from
+	// GitHub on these endpoints are common and benign.
+	for _, expected := range []string{
+		`"distribution: github release assets failed"`,
+		`"distribution: github packages failed"`,
+		`"distribution: github manifests failed"`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("GitHub source error log %q must remain in source as a WARN-level entry — pre-v0.25.0 log shape preserved", expected)
+		}
+	}
+}
+
+// ---- Behavioral tests ------------------------------------------------
+
+// TestScannerSucceedsWhenLegitimateNoDataAcrossWorkingSources pins
+// the headline v0.25.0 fix: a repo where ecosyste.ms returns 500
+// but every other source legitimately returns empty must record a
+// successful scan (no error), NOT trip the 10-strike sideline.
+//
+// This is the Julia/R diagnostic case from 2026-05-22/23: deps.dev
+// doesn't index Julia/CRAN, ecosyste.ms was 500-storming, and the
+// pre-v0.25.0 contract locked these repos out of recollection for
+// 180 days.
+func TestScannerSucceedsWhenLegitimateNoDataAcrossWorkingSources(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// deps.dev returns empty for this repo (Julia/R aren't indexed).
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":[]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// ecosyste.ms 500: classic outage.
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// All GitHub sources return empty arrays. Legitimate "this
+		// repo doesn't publish via release assets / GitHub Packages,
+		// and has no recognized manifests at the root."
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true /*crossCheck*/)
+
+	dists, manifests, err := scanner.Scan(context.Background(), 999, "julialang", "Project.jl", "https://github.com/julialang/Project.jl")
+
+	// Empty-but-clean from working sources = success in the v0.25.0 contract.
+	if err != nil {
+		t.Fatalf("Julia-style repo (deps.dev empty + ecosyste.ms 500 + github empty) must NOT fail the scan under the v0.25.0 contract — got err=%v", err)
+	}
+	if len(dists) != 0 || len(manifests) != 0 {
+		t.Errorf("expected zero evidence (all sources empty), got %d dists, %d manifests", len(dists), len(manifests))
+	}
+}
+
+// TestScannerFailsOnlyWhenEveryEnabledSourceErrored pins the strict
+// half of the contract: if NOTHING completed cleanly, the scan
+// genuinely failed (caller routes to RecordDistributionFailure).
+//
+// We use 401 Unauthorized (not 500) so the GitHub HTTPClient
+// retry loop fails fast instead of burning 10 retries × exponential
+// backoff per call. The contract decision is the same regardless of
+// which transient/fatal class the GitHub side returns — what we're
+// pinning here is "every-source-errored produces non-nil err".
+func TestScannerFailsOnlyWhenEveryEnabledSourceErrored(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "deps.dev down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "ecosyste.ms down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	// GitHub 401 → ClassAuth → ClassFatal-ish, returned immediately
+	// (no retry budget burned). Combined with deps.dev/ecosyste.ms
+	// 500s, every enabled source errors → the contract must fail.
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true)
+
+	// Short ctx so even if a path retries we don't hang the test
+	// suite. The contract decision happens at the end of Scan
+	// regardless of how the errors propagated.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err := scanner.Scan(ctx, 1, "x", "y", "https://github.com/x/y")
+	if err == nil {
+		t.Fatal("when EVERY source errors, scan must return non-nil error so RecordDistributionFailure runs and backoff applies")
+	}
+}
+
+// TestScannerEmitsErrorLogOnDoubleExternalFailure pins the
+// per-source visibility behavior. When both deps.dev and ecosyste.ms
+// fail in the same scan, an ERROR-level log line must surface each
+// source's error labeled as its own key — for operator confidence
+// in the classification while we build out the fleet.
+func TestScannerEmitsErrorLogOnDoubleExternalFailure(t *testing.T) {
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "deps.dev outage", http.StatusInternalServerError)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "ecosyste.ms outage", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`) // GitHub sources clean.
+	}))
+	t.Cleanup(ghServer.Close)
+
+	// Capture slog output into a buffer.
+	buf := &bytes.Buffer{}
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(handler)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true)
+	scanner.Logger = logger
+
+	_, _, _ = scanner.Scan(context.Background(), 42, "owner", "repo", "https://github.com/owner/repo")
+
+	logs := buf.String()
+	if !strings.Contains(logs, "BOTH external registries failed") {
+		t.Errorf("expected ERROR log entry 'BOTH external registries failed' when both deps.dev and ecosyste.ms fail; got logs: %s", logs)
+	}
+	// Verify the per-source key labeling is present.
+	for _, key := range []string{
+		`"deps_dev_class"`,
+		`"deps_dev_error"`,
+		`"ecosystems_class"`,
+		`"ecosystems_error"`,
+	} {
+		if !strings.Contains(logs, key) {
+			t.Errorf("expected per-source key %s in the both-failed log entry; got logs: %s", key, logs)
+		}
+	}
+	// Verify the level is ERROR (or higher), not WARN.
+	if !strings.Contains(logs, `"level":"ERROR"`) {
+		t.Errorf("both-external-failed log entry must be at ERROR level; got: %s", logs)
+	}
+}
+
+// TestScannerCrossCheckTrueQueriesBothExternalSources pins that
+// with CrossCheckSources=true (default) both deps.dev AND
+// ecosyste.ms are queried for every repo even when one returns data.
+func TestScannerCrossCheckTrueQueriesBothExternalSources(t *testing.T) {
+	var depsHits, ecoHits atomic.Int64
+
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		depsHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Return one package so the first-source-succeeded short
+		// circuit would fire under CrossCheckSources=false.
+		_, _ = io.WriteString(w, `{"versions":[{"versionKey":{"system":"PYPI","name":"x","version":"1"}}]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ecoHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true /*crossCheck*/)
+	_, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+
+	if depsHits.Load() == 0 {
+		t.Error("deps.dev must be queried when CrossCheckSources=true")
+	}
+	if ecoHits.Load() == 0 {
+		t.Error("ecosyste.ms MUST be queried even when deps.dev returned data — CrossCheckSources=true is the operator's lock-in for two-source cross-checking")
+	}
+}
+
+// TestScannerCrossCheckFalseSkipsEcosystemsAfterDepsSuccess pins the
+// opt-out behavior: with CrossCheckSources=false, ecosyste.ms is
+// skipped when deps.dev already returned data. This is the API-
+// budget-conscious mode.
+func TestScannerCrossCheckFalseSkipsEcosystemsAfterDepsSuccess(t *testing.T) {
+	var ecoHits atomic.Int64
+
+	depsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":[{"versionKey":{"system":"PYPI","name":"x","version":"1"}}]}`)
+	}))
+	t.Cleanup(depsServer.Close)
+
+	ecoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ecoHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ecoServer.Close)
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(ghServer.Close)
+
+	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, false /*crossCheck off*/)
+	_, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+
+	if ecoHits.Load() != 0 {
+		t.Errorf("with CrossCheckSources=false, ecosyste.ms must NOT be queried after deps.dev returned data — got %d hits", ecoHits.Load())
+	}
+}
+
+// ---- helpers ---------------------------------------------------------
+
+func readFile(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(data)
+}
+
+// buildTestScanner wires up real depsdev/ecosystems/github clients
+// pointed at the supplied test-server URLs. The github client gets
+// its baseURL via the existing httpclient pattern (KeyPool + token).
+func buildTestScanner(t *testing.T, depsURL, ecoURL, ghURL string, crossCheck bool) *CompositeScanner {
+	t.Helper()
+	logger := slog.Default()
+
+	depsClient := depsdev.New(depsdev.Options{BaseURL: depsURL})
+	ecoClient := ecosystems.New(ecosystems.Options{BaseURL: ecoURL})
+
+	keys := platform.NewKeyPool([]string{"test-token"}, logger)
+	ghClient := github.New(ghURL, keys, logger)
+
+	return &CompositeScanner{
+		DepsDev:           depsClient,
+		Ecosystems:        ecoClient,
+		GitHub:            ghClient,
+		Logger:            logger,
+		CrossCheckSources: crossCheck,
+	}
+}
+
+// silence "imported and not used" for db / json which appear in
+// sibling files we may end up cross-importing. Defensive against
+// linter complaints in CI.
+var _ = db.ToolVersion
+var _ json.Decoder

--- a/internal/collector/distribution/scanner_test.go
+++ b/internal/collector/distribution/scanner_test.go
@@ -142,7 +142,8 @@ func TestScannerSucceedsWhenLegitimateNoDataAcrossWorkingSources(t *testing.T) {
 
 	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true /*crossCheck*/)
 
-	dists, manifests, err := scanner.Scan(context.Background(), 999, "julialang", "Project.jl", "https://github.com/julialang/Project.jl")
+	dists, manifests, complete, err := scanner.Scan(context.Background(), 999, "julialang", "Project.jl", "https://github.com/julialang/Project.jl")
+	_ = complete // v0.25.0 signature; this test focuses on the err+data check, see TestScannerMarksScanIncompleteOnTransientExternalError for the complete-flag-specific test.
 
 	// Empty-but-clean from working sources = success in the v0.25.0 contract.
 	if err != nil {
@@ -189,7 +190,7 @@ func TestScannerFailsOnlyWhenEveryEnabledSourceErrored(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, _, err := scanner.Scan(ctx, 1, "x", "y", "https://github.com/x/y")
+	_, _, _, err := scanner.Scan(ctx, 1, "x", "y", "https://github.com/x/y")
 	if err == nil {
 		t.Fatal("when EVERY source errors, scan must return non-nil error so RecordDistributionFailure runs and backoff applies")
 	}
@@ -225,7 +226,7 @@ func TestScannerEmitsErrorLogOnDoubleExternalFailure(t *testing.T) {
 	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true)
 	scanner.Logger = logger
 
-	_, _, _ = scanner.Scan(context.Background(), 42, "owner", "repo", "https://github.com/owner/repo")
+	_, _, _, _ = scanner.Scan(context.Background(), 42, "owner", "repo", "https://github.com/owner/repo")
 
 	logs := buf.String()
 	if !strings.Contains(logs, "BOTH external registries failed") {
@@ -277,7 +278,7 @@ func TestScannerCrossCheckTrueQueriesBothExternalSources(t *testing.T) {
 	t.Cleanup(ghServer.Close)
 
 	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, true /*crossCheck*/)
-	_, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+	_, _, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
 
 	if depsHits.Load() == 0 {
 		t.Error("deps.dev must be queried when CrossCheckSources=true")
@@ -314,7 +315,7 @@ func TestScannerCrossCheckFalseSkipsEcosystemsAfterDepsSuccess(t *testing.T) {
 	t.Cleanup(ghServer.Close)
 
 	scanner := buildTestScanner(t, depsServer.URL, ecoServer.URL, ghServer.URL, false /*crossCheck off*/)
-	_, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
+	_, _, _, _ = scanner.Scan(context.Background(), 1, "x", "y", "https://github.com/x/y")
 
 	if ecoHits.Load() != 0 {
 		t.Errorf("with CrossCheckSources=false, ecosyste.ms must NOT be queried after deps.dev returned data — got %d hits", ecoHits.Load())

--- a/internal/collector/distribution/worker.go
+++ b/internal/collector/distribution/worker.go
@@ -35,7 +35,7 @@ import (
 type Store interface {
 	ClaimNextDistributionRepo(ctx context.Context, cadence time.Duration) (*db.DistributionJob, error)
 	MarkDistributionComplete(ctx context.Context, job *db.DistributionJob,
-		distributions []model.PackageDistribution, manifests []model.DistributionManifest) error
+		distributions []model.PackageDistribution, manifests []model.DistributionManifest, scanComplete bool) error
 	RecordDistributionFailure(ctx context.Context, job *db.DistributionJob) error
 }
 
@@ -51,8 +51,23 @@ type Store interface {
 // individual fetcher failures inside the scan are aggregated
 // best-effort by the implementation, not bubbled here. The worker
 // does not interpret the error beyond "success vs. failure".
+//
+// v0.25.0: the third return value `complete bool` indicates
+// whether all enabled external sources were consulted successfully.
+// FALSE means at least one external source had a transient error
+// (or was skipped due to an open circuit breaker) so the scan
+// data is partial — the store records this in
+// distribution_scan_complete so the claim query treats the row as
+// immediately re-eligible (bypassing the cadence gate).
+//
+// v0.25.0: Healthy() returns false when a critical external source
+// is unavailable (currently: ecosyste.ms circuit breaker is open).
+// The Worker dispatcher checks this before each claim and pauses
+// when unhealthy, so we don't dispatch new repos into a known-bad
+// upstream and end up stamping their cadence with partial scans.
 type Scanner interface {
-	Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) ([]model.PackageDistribution, []model.DistributionManifest, error)
+	Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) (distributions []model.PackageDistribution, manifests []model.DistributionManifest, complete bool, err error)
+	Healthy() bool
 }
 
 // WorkerOptions configures NewWorker.
@@ -128,12 +143,26 @@ func (w *Worker) Run(ctx context.Context) {
 	w.logger.Info("distribution worker stopped")
 }
 
+// healthCheckInterval is the dispatcher's sleep between unhealthy
+// re-checks. 60 seconds is small enough to resume promptly when the
+// breaker (1-hour pause) closes, large enough to avoid spinning the
+// CPU. v0.25.0.
+const healthCheckInterval = 60 * time.Second
+
 // dispatcher polls the store for new claims and forwards them to
 // the runners via the jobs channel. Minimum-gap pacing means
 // nextStartAllowed is stamped AFTER each successful start, so the
 // dispatcher loops as fast as the runtime allows when jobs are
 // available; the gate only fires to prevent claim bursts on
 // fresh startup.
+//
+// v0.25.0: also checks scanner.Healthy() before each claim and
+// pauses entirely when the scanner reports unhealthy (currently:
+// ecosyste.ms circuit breaker open). This prevents dispatching new
+// repos into a known-bad upstream — without this, every repo
+// dispatched during the breaker's 1-hour pause would get a
+// "complete" scan stamped with no ecosyste.ms data, losing
+// ecosyste.ms coverage for 180 days.
 //
 // Three exit conditions:
 //   - ctx canceled (graceful shutdown)
@@ -145,12 +174,37 @@ func (w *Worker) dispatcher(ctx context.Context, jobs chan<- *db.DistributionJob
 	// starts. Initialized to time.Now() so the first claim fires
 	// immediately.
 	nextStartAllowed := time.Now()
+	// unhealthyLogged ensures we emit the "scanner unhealthy" WARN
+	// once per outage rather than once per check (1-hour outage at
+	// 60s checks would otherwise produce 60 identical log lines).
+	unhealthyLogged := false
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
+		}
+
+		// v0.25.0 health gate. Re-checked on every loop iteration so
+		// recovery is observed within healthCheckInterval of the
+		// breaker reopening.
+		if !w.scanner.Healthy() {
+			if !unhealthyLogged {
+				w.logger.Warn("distribution dispatcher: scanner unhealthy — pausing dispatch until source recovers",
+					"check_interval", healthCheckInterval)
+				unhealthyLogged = true
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(healthCheckInterval):
+			}
+			continue
+		}
+		if unhealthyLogged {
+			w.logger.Info("distribution dispatcher: scanner healthy again — resuming dispatch")
+			unhealthyLogged = false
 		}
 
 		// Wait until we're past nextStartAllowed.
@@ -221,7 +275,7 @@ func (w *Worker) runner(ctx context.Context, jobs <-chan *db.DistributionJob, do
 // completion call so we still persist results even if the parent
 // ctx was canceled mid-scan.
 func (w *Worker) processJob(ctx context.Context, job *db.DistributionJob) {
-	distributions, manifests, scanErr := w.scanner.Scan(ctx, job.RepoID, job.RepoOwner, job.RepoName, job.RepoGit)
+	distributions, manifests, scanComplete, scanErr := w.scanner.Scan(ctx, job.RepoID, job.RepoOwner, job.RepoName, job.RepoGit)
 
 	// completionCtx: short window for the DB write to finish even
 	// if the parent ctx is canceling. Without this, a shutdown
@@ -240,7 +294,17 @@ func (w *Worker) processJob(ctx context.Context, job *db.DistributionJob) {
 		return
 	}
 
-	if err := w.store.MarkDistributionComplete(completionCtx, job, distributions, manifests); err != nil {
+	// v0.25.0: scanComplete is stamped into distribution_scan_complete
+	// so the claim query can treat partial scans as immediately
+	// re-eligible. Partial-scan rows still rotate to history on the
+	// next full re-scan via the snapshot-replace path.
+	if !scanComplete {
+		w.logger.Info("distribution scan partial — will be re-collected once source recovers",
+			"repo_id", job.RepoID, "owner", job.RepoOwner, "repo", job.RepoName,
+			"distributions", len(distributions), "manifests", len(manifests))
+	}
+
+	if err := w.store.MarkDistributionComplete(completionCtx, job, distributions, manifests, scanComplete); err != nil {
 		w.logger.Error("distribution: mark complete failed",
 			"repo_id", job.RepoID, "error", err)
 		return

--- a/internal/collector/distribution/worker_test.go
+++ b/internal/collector/distribution/worker_test.go
@@ -42,6 +42,7 @@ type markCall struct {
 	repoID        int64
 	distributions []model.PackageDistribution
 	manifests     []model.DistributionManifest
+	scanComplete  bool
 }
 
 func (f *fakeStore) ClaimNextDistributionRepo(ctx context.Context, cadence time.Duration) (*db.DistributionJob, error) {
@@ -59,10 +60,10 @@ func (f *fakeStore) ClaimNextDistributionRepo(ctx context.Context, cadence time.
 }
 
 func (f *fakeStore) MarkDistributionComplete(ctx context.Context, job *db.DistributionJob,
-	distributions []model.PackageDistribution, manifests []model.DistributionManifest) error {
+	distributions []model.PackageDistribution, manifests []model.DistributionManifest, scanComplete bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.marks = append(f.marks, markCall{job.RepoID, distributions, manifests})
+	f.marks = append(f.marks, markCall{job.RepoID, distributions, manifests, scanComplete})
 	f.releasedJobIDs = append(f.releasedJobIDs, job.RepoID)
 	return nil
 }
@@ -83,34 +84,53 @@ func (f *fakeStore) snapshot() (marks []markCall, failures []int64) {
 
 // fakeScanner returns canned data and/or canned errors.
 type fakeScanner struct {
-	mu       sync.Mutex
-	calls    int32
-	results  map[int64]scanResult
-	scanErr  error
-	scanWait time.Duration
+	mu        sync.Mutex
+	calls     int32
+	results   map[int64]scanResult
+	scanErr   error
+	scanWait  time.Duration
+	unhealthy atomic.Bool // v0.25.0: when true, Healthy() returns false
 }
 
 type scanResult struct {
 	distributions []model.PackageDistribution
 	manifests     []model.DistributionManifest
+	// partial=true → Scan returns complete=false (the v0.25.0
+	// partial-scan path). Default false preserves pre-v0.25.0
+	// "scan returns complete=true" semantics for legacy tests.
+	partial bool
 }
 
-func (f *fakeScanner) Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) ([]model.PackageDistribution, []model.DistributionManifest, error) {
+func (f *fakeScanner) Scan(ctx context.Context, repoID int64, owner, repo, repoGit string) ([]model.PackageDistribution, []model.DistributionManifest, bool, error) {
 	atomic.AddInt32(&f.calls, 1)
 	if f.scanWait > 0 {
 		select {
 		case <-time.After(f.scanWait):
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, false, ctx.Err()
 		}
 	}
 	if f.scanErr != nil {
-		return nil, nil, f.scanErr
+		return nil, nil, false, f.scanErr
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	r := f.results[repoID]
-	return r.distributions, r.manifests, nil
+	r, ok := f.results[repoID]
+	if !ok {
+		// No canned result → empty-but-complete success.
+		return nil, nil, true, nil
+	}
+	// scanResult.complete defaults to false (zero value of bool).
+	// Pre-v0.25.0 tests didn't set this field; flip the default so
+	// they continue to assert "complete success" without churn.
+	// Tests that want to exercise partial-scan behavior set
+	// complete:false explicitly when constructing scanResult.
+	return r.distributions, r.manifests, !r.partial, nil
+}
+
+// Healthy implements distribution.Scanner.
+func (f *fakeScanner) Healthy() bool {
+	return !f.unhealthy.Load()
 }
 
 func testLogger() *slog.Logger {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -514,6 +514,31 @@ type CollectionConfig struct {
 	// IPs may want a more identifying string so registry operators
 	// can route diagnostics to the right person.
 	DistributionTrackingUserAgent string `json:"distribution_tracking_user_agent"`
+
+	// DistributionTrackingCrossCheckSources, when true (the default
+	// in v0.25.0), guarantees BOTH deps.dev AND ecosyste.ms are
+	// queried for every repo even when one returns non-empty data.
+	// Each source persists its own rows into repo_distribution; the
+	// UNIQUE constraint includes the source column so two-source
+	// rows for the same package coexist.
+	//
+	// Rationale (operator direction, 2026-05-23): operators want
+	// explicit lock-in that we don't optimize one external registry
+	// away. The trade-off is roughly 2× external-registry API calls
+	// per scan; at 180-day cadence the absolute budget is tiny
+	// (~5K calls/hour fleet-wide on a 100K-repo cohort), and the
+	// signal value of cross-checking — being able to see when
+	// deps.dev and ecosyste.ms disagree about which packages are
+	// indexed for a repo — is worth it.
+	//
+	// Set to false only when an operator needs to halve registry
+	// traffic at the cost of single-source-of-truth dependence.
+	// Pointer-to-bool (not bare bool) so the JSON decoder can
+	// distinguish "absent" (use v0.25.0 default = true) from
+	// "explicitly false." A bare bool would default to false on
+	// missing-key, silently breaking the lock-in guarantee for
+	// every aveloxis.json that pre-dates v0.25.0.
+	DistributionTrackingCrossCheckSources *bool `json:"distribution_tracking_cross_check_sources,omitempty"`
 }
 
 // PhaseWatchdogDuration returns the v0.22.4 long-jobs watchdog
@@ -626,6 +651,17 @@ func (c *CollectionConfig) DistributionTrackingStartInterval() time.Duration {
 		return 30 * time.Second
 	}
 	return time.Duration(c.DistributionTrackingStartIntervalSec) * time.Second
+}
+
+// DistributionTrackingCrossCheckSourcesValue returns the effective
+// cross-check setting, defaulting to true when the JSON field is
+// absent. v0.25.0 default. See the field doc on
+// DistributionTrackingCrossCheckSources for the rationale.
+func (c *CollectionConfig) DistributionTrackingCrossCheckSourcesValue() bool {
+	if c.DistributionTrackingCrossCheckSources == nil {
+		return true
+	}
+	return *c.DistributionTrackingCrossCheckSources
 }
 
 // defaultScancodeCloneDir returns the default scancode clone parent

--- a/internal/config/distribution_cross_check_test.go
+++ b/internal/config/distribution_cross_check_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// v0.25.0 — cross-check-sources flag for distribution tracking.
+//
+// Operator-mandated: an aveloxis.json knob that guarantees BOTH
+// deps.dev AND ecosyste.ms are queried per repo, with separate
+// rows persisted per source. Default true (lock in v0.24.0
+// behavior) so existing deployments keep cross-checking even if
+// they don't update their config files.
+
+func TestCollectionConfigHasCrossCheckSourcesField(t *testing.T) {
+	// JSON-tag pin via marshaling. omitempty means an unset field
+	// won't appear in the output, so we set the value first.
+	val := true
+	cfg := &CollectionConfig{
+		DistributionTrackingCrossCheckSources: &val,
+	}
+	blob, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !contains(string(blob), `"distribution_tracking_cross_check_sources"`) {
+		t.Errorf("CollectionConfig must declare JSON field 'distribution_tracking_cross_check_sources' — operator direction v0.25.0")
+	}
+}
+
+func TestDistributionTrackingCrossCheckSourcesDefaultsTrueWhenAbsent(t *testing.T) {
+	// Pointer-to-bool: nil means "field absent from aveloxis.json,
+	// use the v0.25.0 default which is true." A bare bool would
+	// default to false and silently break the lock-in.
+	cfg := &CollectionConfig{}
+	if cfg.DistributionTrackingCrossCheckSources != nil {
+		t.Fatalf("expected nil (field absent), got %v", *cfg.DistributionTrackingCrossCheckSources)
+	}
+	if !cfg.DistributionTrackingCrossCheckSourcesValue() {
+		t.Error("DistributionTrackingCrossCheckSourcesValue() must default to true when JSON field is absent — v0.25.0 lock-in guarantee for existing aveloxis.json deployments")
+	}
+}
+
+func TestDistributionTrackingCrossCheckSourcesRespectsExplicitFalse(t *testing.T) {
+	f := false
+	cfg := &CollectionConfig{
+		DistributionTrackingCrossCheckSources: &f,
+	}
+	if cfg.DistributionTrackingCrossCheckSourcesValue() {
+		t.Error("explicit false in aveloxis.json must produce false from accessor — operator opt-out path")
+	}
+}
+
+func TestDistributionTrackingCrossCheckSourcesRespectsExplicitTrue(t *testing.T) {
+	tr := true
+	cfg := &CollectionConfig{
+		DistributionTrackingCrossCheckSources: &tr,
+	}
+	if !cfg.DistributionTrackingCrossCheckSourcesValue() {
+		t.Error("explicit true in aveloxis.json must produce true from accessor")
+	}
+}
+
+func TestDistributionTrackingCrossCheckSourcesParsesFromJSON(t *testing.T) {
+	// Round-trip: a JSON config with the field set to false should
+	// produce a nil-checked-false from the accessor.
+	src := `{"distribution_tracking_cross_check_sources": false}`
+	var cfg CollectionConfig
+	if err := json.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.DistributionTrackingCrossCheckSources == nil {
+		t.Fatal("expected non-nil pointer after parsing explicit false")
+	}
+	if *cfg.DistributionTrackingCrossCheckSources {
+		t.Error("expected false after parsing 'false', got true")
+	}
+	if cfg.DistributionTrackingCrossCheckSourcesValue() {
+		t.Error("accessor must reflect parsed-false")
+	}
+}
+
+// contains is a stdlib-strings.Contains alias to avoid an import
+// dance with the existing config tests (they already cover the
+// same import surface in distribution_knobs_test.go).
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/distribution_store.go
+++ b/internal/db/distribution_store.go
@@ -96,6 +96,12 @@ func (s *PostgresStore) ClaimNextDistributionRepo(ctx context.Context, cadence t
 	// Backoff base is sourced from the named constant so the schedule
 	// stays documented in one place. Plain Sprintf is safe here: the
 	// only substitution is an integer constant, not user input.
+	// v0.25.0: distribution_scan_complete=FALSE bypasses the cadence
+	// gate. A partial scan (an external source had a transient error
+	// or was skipped due to an open circuit breaker) becomes
+	// immediately re-eligible on the next dispatch cycle, so once
+	// the source recovers the row gets a full re-collection that
+	// rotates the partial-scan rows to history.
 	claimSQL := fmt.Sprintf(`
 		WITH candidate AS (
 		    SELECT r.repo_id
@@ -104,12 +110,18 @@ func (s *PostgresStore) ClaimNextDistributionRepo(ctx context.Context, cadence t
 		    WHERE q.last_collected IS NOT NULL
 		      AND COALESCE(r.repo_archived, FALSE) = FALSE
 		      AND (r.distribution_last_run IS NULL
+		           OR COALESCE(r.distribution_scan_complete, TRUE) = FALSE
 		           OR r.distribution_last_run < NOW() - $1::interval)
 		      AND (r.distribution_last_failed_at IS NULL
 		           OR r.distribution_last_failed_at < NOW() - make_interval(
 		               secs => %d * GREATEST(COALESCE(r.distribution_failed_attempts, 0), 1)
 		                          * GREATEST(COALESCE(r.distribution_failed_attempts, 0), 1)))
-		    ORDER BY r.distribution_last_run NULLS FIRST, r.repo_id
+		    ORDER BY
+		        -- Partial scans get priority (after NULLs) so they
+		        -- re-collect ahead of routine cadence-elapsed rows.
+		        COALESCE(r.distribution_scan_complete, TRUE) ASC,
+		        r.distribution_last_run NULLS FIRST,
+		        r.repo_id
 		    LIMIT 1
 		    FOR UPDATE SKIP LOCKED
 		)
@@ -140,8 +152,18 @@ func (s *PostgresStore) ClaimNextDistributionRepo(ctx context.Context, cadence t
 // observation ("we scanned this repo and found no packaging
 // evidence"). The empty result is still a successful scan; the
 // cadence gate prevents re-scanning for the full interval.
+//
+// v0.25.0: scanComplete distinguishes a complete scan (every
+// external source consulted successfully) from a partial scan (an
+// external source had a transient error or was skipped due to an
+// open circuit breaker). Partial scans still rotate rows to history
+// + insert fresh observations, but stamp
+// distribution_scan_complete = FALSE so the claim query treats the
+// row as immediately re-eligible (bypassing the cadence gate). On
+// the next dispatch cycle after the source recovers, the row gets
+// a full re-collection; its partial-scan rows rotate to history.
 func (s *PostgresStore) MarkDistributionComplete(ctx context.Context, job *DistributionJob,
-	distributions []model.PackageDistribution, manifests []model.DistributionManifest) (retErr error) {
+	distributions []model.PackageDistribution, manifests []model.DistributionManifest, scanComplete bool) (retErr error) {
 	if job == nil || job.tx == nil {
 		return fmt.Errorf("MarkDistributionComplete: nil job or tx")
 	}
@@ -222,12 +244,17 @@ func (s *PostgresStore) MarkDistributionComplete(ctx context.Context, job *Distr
 	}
 
 	// Stamp success on repos row + reset failure counters.
+	// v0.25.0: also stamp distribution_scan_complete with the
+	// caller's signal. FALSE makes the row immediately re-eligible
+	// on the next dispatch cycle (the claim query treats it like
+	// distribution_last_run IS NULL).
 	if _, err := tx.Exec(ctx, `
 		UPDATE aveloxis_data.repos
 		SET distribution_last_run = NOW(),
 		    distribution_failed_attempts = 0,
-		    distribution_last_failed_at = NULL
-		WHERE repo_id = $1`, job.RepoID); err != nil {
+		    distribution_last_failed_at = NULL,
+		    distribution_scan_complete = $2
+		WHERE repo_id = $1`, job.RepoID, scanComplete); err != nil {
 		return fmt.Errorf("stamp distribution_last_run: %w", err)
 	}
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -375,6 +375,46 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		      WHERE source = 'deps.dev'
 		  )`)
 
+	// v0.25.0 — one-shot reset for the Julia/R/conda cohort and any
+	// repo sidelined by the pre-v0.25.0 strict scanner contract.
+	//
+	// Two compounding issues drove this on chaoss.tv 2026-05-22/23:
+	//
+	//   1. The pre-v0.25.0 GitHub manifest classifier didn't recognize
+	//      Project.toml (Julia), DESCRIPTION (R/CRAN/Bioconductor),
+	//      meta.yaml / recipe.yaml (conda). For these ecosystems the
+	//      ONLY working distribution source was ecosyste.ms; when it
+	//      went into a 500-storm, every Julia/R/conda repo accumulated
+	//      failures under the strict-contract "any error + zero data
+	//      = failure" rule, eventually hitting the 10-strike sideline
+	//      that stamps distribution_last_run = NOW() to lock the row
+	//      out for 180 days.
+	//
+	//   2. The v0.25.0 loosened scanner contract treats empty-but-
+	//      clean responses as success (not failure). Without resetting
+	//      the sidelined cohort, those repos stay out of rotation
+	//      until their artificial last_run elapses ~6 months later.
+	//
+	// Reset criterion: distribution_failed_attempts > 0. Specific
+	// (only touches repos with failure history), idempotent (a
+	// successful subsequent scan zeros the counter; re-running the
+	// migration finds nothing to reset), and fresh-install-safe (no
+	// repos have failures yet on a clean install).
+	//
+	// Operators who want to also re-scan repos that scanned to "zero
+	// evidence" under the old contract — common for Julia/R repos
+	// where ecosyste.ms was the only viable source AND they got NO
+	// failure record because the scan technically succeeded — use the
+	// documented manual workflow:
+	//   UPDATE aveloxis_data.repos SET distribution_last_run = NULL
+	//   WHERE repo_id IN (...);
+	execMigrationStep(ctx, pg, logger, &errs, "v0.25.0 reset distribution state for cohort sidelined under pre-v0.25.0 strict scanner contract",
+		`UPDATE aveloxis_data.repos
+		SET distribution_last_run = NULL,
+		    distribution_failed_attempts = 0,
+		    distribution_last_failed_at = NULL
+		WHERE distribution_failed_attempts > 0`)
+
 	// collection_queue.last_commits backfill (v0.19.11). Pre-v0.19.11
 	// the FacadeCollector incremented result.Commits once per inserted
 	// ROW rather than once per distinct commit. Since the commits table

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -247,6 +247,21 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "distribution_failed_attempts", "INTEGER DEFAULT 0")
 	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "distribution_last_failed_at", "TIMESTAMPTZ")
 
+	// v0.25.0: distribution_scan_complete tracks whether the most-
+	// recent distribution scan was complete (all external sources
+	// consulted successfully) or partial (some external source had
+	// a transient error or was skipped due to an open circuit
+	// breaker). The claim query treats scan_complete=FALSE as
+	// immediately re-eligible (bypassing the cadence gate) so the
+	// ~10 repos that trip the ecosyste.ms breaker get fully
+	// re-collected on the next dispatch cycle after the breaker
+	// closes — rotating their partial-scan rows to history.
+	//
+	// Default TRUE so existing rows (pre-v0.25.0 installs that have
+	// already scanned) are not treated as incomplete on first
+	// startup. Only NEW scans under v0.25.0+ can mark this false.
+	addColumnIfMissing(ctx, pg, logger, &errs, "aveloxis_data.repos", "distribution_scan_complete", "BOOLEAN DEFAULT TRUE")
+
 	// Commits: deduplicate and add unique index (added in v0.7.5).
 	// Previous versions had no ON CONFLICT on commits INSERT, so re-collection
 	// created duplicate rows. Clean up first, then create the unique index.

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -107,7 +107,16 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     -- distribution_last_failed_at for the backoff window math.
     distribution_last_run        TIMESTAMPTZ,
     distribution_failed_attempts INTEGER DEFAULT 0,
-    distribution_last_failed_at  TIMESTAMPTZ
+    distribution_last_failed_at  TIMESTAMPTZ,
+    -- v0.25.0: distribution_scan_complete tracks whether the most-
+    -- recent scan saw any transient external-source errors or had
+    -- ecosyste.ms skipped due to an open circuit breaker. The claim
+    -- query treats FALSE as immediately re-eligible (bypassing the
+    -- cadence gate) so partial-scan repos get re-collected as soon
+    -- as the source recovers — rotating partial rows to history.
+    -- Default TRUE so pre-v0.25.0 scans aren't retroactively marked
+    -- incomplete.
+    distribution_scan_complete   BOOLEAN DEFAULT TRUE
 );
 
 -- ============================================================

--- a/internal/db/v025_0_distribution_reset_test.go
+++ b/internal/db/v025_0_distribution_reset_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.25.0 — one-shot reset migration for the cohort sidelined by
+// the pre-v0.25.0 strict scanner contract.
+//
+// Two compounding issues drove this:
+//   1. Pre-v0.25.0 GitHub manifest classifier didn't recognize
+//      Project.toml / DESCRIPTION / meta.yaml — Julia/R/conda repos
+//      had no GitHub-side evidence, depending entirely on
+//      ecosyste.ms, which had an outage.
+//   2. Strict contract treated "any error + zero data" as failure,
+//      accumulating 10-strike sidelines on the affected cohort.
+//
+// The v0.25.0 reset clears distribution_failed_attempts > 0 repos
+// so they re-enter the queue under the v0.25.0 loosened contract.
+// Self-disabling once a successful scan zeroes the counter.
+
+func TestV0250MigrationResetsDistributionStateForSidelinedCohort(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	body := string(data)
+
+	// Pin the migration label so the v0.20.12 fail-closed contract
+	// surfaces the right step in operator logs.
+	needles := []string{
+		`"v0.25.0 reset distribution state for cohort sidelined under pre-v0.25.0 strict scanner contract"`,
+		// SQL shape: must update all three failure-tracking columns
+		// AND filter on the failure counter so the reset is specific.
+		`UPDATE aveloxis_data.repos`,
+		`distribution_last_run = NULL`,
+		`distribution_failed_attempts = 0`,
+		`distribution_last_failed_at = NULL`,
+		`WHERE distribution_failed_attempts > 0`,
+	}
+	for _, n := range needles {
+		if !strings.Contains(body, n) {
+			t.Errorf("migrate.go missing v0.25.0 reset SQL needle %q — the migration must clear all three failure-tracking columns AND filter on the counter so the reset is specific to the affected cohort", n)
+		}
+	}
+}
+
+func TestV0250ResetIsSelfDisabling(t *testing.T) {
+	// The WHERE clause `distribution_failed_attempts > 0` is the
+	// self-disabling guard: once a successful scan zeroes the counter
+	// (via MarkDistributionComplete), the row no longer matches the
+	// WHERE clause and the migration is a no-op. A future refactor
+	// that drops the WHERE clause OR relaxes it (e.g., to >= 0) would
+	// silently override the operator's cadence config on every
+	// restart indefinitely — exactly the opposite of one-shot
+	// semantics. Pin the guard explicitly.
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	body := string(data)
+
+	// Find the v0.25.0 migration block.
+	const label = "v0.25.0 reset distribution state for cohort sidelined under pre-v0.25.0 strict scanner contract"
+	idx := strings.Index(body, label)
+	if idx < 0 {
+		t.Fatal("cannot find v0.25.0 reset migration label in migrate.go")
+	}
+	// Look at the next ~600 bytes which should contain the SQL.
+	end := idx + 600
+	if end > len(body) {
+		end = len(body)
+	}
+	region := body[idx:end]
+
+	if !strings.Contains(region, "WHERE distribution_failed_attempts > 0") {
+		t.Errorf("v0.25.0 reset block must contain the self-disabling guard 'WHERE distribution_failed_attempts > 0' — without it the migration would re-fire on every aveloxis migrate run, overriding the operator's cadence config indefinitely")
+	}
+}
+
+func TestV0241ResetPreservedAlongsideV0250Reset(t *testing.T) {
+	// The v0.24.1 reset migration must NOT be removed when the
+	// v0.25.0 reset lands. The two predicates are orthogonal:
+	// v0.24.1 fires on fleets with zero deps.dev rows; v0.25.0
+	// fires on repos with failure history. Operators upgrading
+	// from v0.24.0 directly to v0.25.0+ must get BOTH resets.
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "v0.24.1 reset distribution_last_run for fleets affected by v0.24.0 deps.dev URL bug") {
+		t.Error("v0.24.1 reset migration was removed — must be preserved alongside v0.25.0. Operators upgrading from v0.24.0 still need the v0.24.1 reset to catch the deps.dev URL bug cohort.")
+	}
+	if !strings.Contains(body, "v0.25.0 reset distribution state for cohort sidelined under pre-v0.25.0 strict scanner contract") {
+		t.Error("v0.25.0 reset migration missing")
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.24.1"
+var ToolVersion = "0.25.0"

--- a/internal/platform/ecosystems/circuit_breaker_test.go
+++ b/internal/platform/ecosystems/circuit_breaker_test.go
@@ -5,6 +5,7 @@ package ecosystems
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -62,10 +63,15 @@ func TestCircuitBreakerTripsAfterThresholdConsecutive5xx(t *testing.T) {
 		t.Fatalf("expected %d hits before trip, got %d", CircuitBreakerThreshold, hitsAtTrip)
 	}
 
-	// Next call: breaker must short-circuit (no upstream hit, no error).
+	// Next call: breaker must short-circuit (no upstream hit) and
+	// return the typed ErrCircuitOpen sentinel. Classifies as
+	// ClassSkip via the ClassifiedError interface so callers in
+	// legacy error-handling paths treat it like a 404; the
+	// CompositeScanner (the only caller that cares) identifies it
+	// specifically via errors.Is to mark the scan incomplete.
 	dists, err := c.LookupPackages(context.Background(), "https://github.com/x/y")
-	if err != nil {
-		t.Errorf("post-trip call must return nil err (treated by scanner as no-data), got %v", err)
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("post-trip call must return ErrCircuitOpen sentinel so the scanner can mark the scan incomplete (distribution_scan_complete=FALSE) and re-collect when the breaker closes — without the sentinel, the partial-scan cohort would be stamped with the full 180-day cadence. Got: %v", err)
 	}
 	if len(dists) != 0 {
 		t.Errorf("post-trip call must return zero distributions, got %d", len(dists))

--- a/internal/platform/ecosystems/circuit_breaker_test.go
+++ b/internal/platform/ecosystems/circuit_breaker_test.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package ecosystems
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// v0.25.0 — source-level circuit breaker on the ecosyste.ms client.
+//
+// Mirrors the v0.22.12 BreadthWorker circuit breaker. Trips after
+// CircuitBreakerThreshold consecutive transient (5xx or transport)
+// failures across distinct calls; pauses the source for
+// CircuitBreakerPause; reopens for probing afterward.
+//
+// Per the v0.25.0 scanner contract: when the breaker is open,
+// LookupPackages returns (nil, nil) — treated by CompositeScanner
+// as "source returned no data" rather than "source errored." So
+// the rest of the scan proceeds, last_run gets stamped, and the
+// fleet stops generating one ERROR log line per repo against a
+// broken upstream.
+
+func TestCircuitBreakerThresholdConstantsExist(t *testing.T) {
+	if CircuitBreakerThreshold <= 0 {
+		t.Errorf("CircuitBreakerThreshold must be positive, got %d", CircuitBreakerThreshold)
+	}
+	if CircuitBreakerPause <= 0 {
+		t.Errorf("CircuitBreakerPause must be positive, got %v", CircuitBreakerPause)
+	}
+}
+
+// TestCircuitBreakerTripsAfterThresholdConsecutive5xx pins the trip
+// behavior. We point the client at a server that always returns
+// 500. After CircuitBreakerThreshold calls each returning a 5xx
+// error, the next call should short-circuit with (nil, nil) and
+// the upstream server should NOT receive that probe.
+func TestCircuitBreakerTripsAfterThresholdConsecutive5xx(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	c := New(Options{BaseURL: server.URL})
+
+	// Burn exactly CircuitBreakerThreshold failures.
+	for i := 0; i < CircuitBreakerThreshold; i++ {
+		_, err := c.LookupPackages(context.Background(), "https://github.com/x/y")
+		if err == nil {
+			t.Fatalf("call %d: expected error from 5xx, got nil", i+1)
+		}
+	}
+	hitsAtTrip := hits.Load()
+	if hitsAtTrip != int64(CircuitBreakerThreshold) {
+		t.Fatalf("expected %d hits before trip, got %d", CircuitBreakerThreshold, hitsAtTrip)
+	}
+
+	// Next call: breaker must short-circuit (no upstream hit, no error).
+	dists, err := c.LookupPackages(context.Background(), "https://github.com/x/y")
+	if err != nil {
+		t.Errorf("post-trip call must return nil err (treated by scanner as no-data), got %v", err)
+	}
+	if len(dists) != 0 {
+		t.Errorf("post-trip call must return zero distributions, got %d", len(dists))
+	}
+	if hits.Load() != hitsAtTrip {
+		t.Errorf("post-trip call must NOT hit upstream — fleet-wide pullback. Got %d total hits, expected %d", hits.Load(), hitsAtTrip)
+	}
+}
+
+// TestCircuitBreakerResetsOnSuccess pins that a successful response
+// (or 404) clears the consecutive-failure counter so a flaky upstream
+// can't slowly accumulate enough failures to trip the breaker over
+// the course of hours.
+func TestCircuitBreakerResetsOnSuccess(t *testing.T) {
+	var hitNum atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hitNum.Add(1)
+		// Pattern: alternate 500 / 200. Counter never reaches threshold.
+		if n%2 == 1 {
+			http.Error(w, "down", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := New(Options{BaseURL: server.URL})
+
+	// Run 4× threshold calls — half error, half succeed. Breaker
+	// must NOT trip because consecutive failures never reach the
+	// threshold.
+	for i := 0; i < 4*CircuitBreakerThreshold; i++ {
+		_, _ = c.LookupPackages(context.Background(), "https://github.com/x/y")
+	}
+
+	// Final assertion: breaker is not open (a fresh call would
+	// reach the upstream and we'd see an extra hit).
+	preFinal := hitNum.Load()
+	_, _ = c.LookupPackages(context.Background(), "https://github.com/x/y")
+	if hitNum.Load() == preFinal {
+		t.Error("breaker tripped under alternating success/fail pattern — must reset counter on each success so consecutive-failure semantics are preserved")
+	}
+}
+
+// TestCircuitBreakerProbesAfterPauseElapses pins the reopen
+// behavior. We set CircuitBreakerPause via the package var, trip
+// the breaker, fast-forward by setting cbOpenUntil to a past time,
+// and confirm the next call reaches the upstream.
+//
+// Without a clock-injection layer the test directly munges client
+// state — the alternative (sleeping for an hour) is intolerable in
+// CI, and adding a Clock interface for one test is overkill.
+func TestCircuitBreakerProbesAfterPauseElapses(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := New(Options{BaseURL: server.URL})
+
+	// Manually open the breaker into the past (simulating elapsed pause).
+	c.cbMu.Lock()
+	c.cbConsecutive5xx = CircuitBreakerThreshold
+	c.cbOpenUntil = time.Now().Add(-time.Minute)
+	c.cbMu.Unlock()
+
+	preCall := hits.Load()
+	_, err := c.LookupPackages(context.Background(), "https://github.com/x/y")
+	if err != nil {
+		t.Fatalf("post-pause call: %v", err)
+	}
+	if hits.Load() != preCall+1 {
+		t.Errorf("post-pause call must reach upstream (breaker reopened) — got %d hits, expected %d", hits.Load(), preCall+1)
+	}
+
+	// State should be reset after the probe.
+	c.cbMu.Lock()
+	openUntil := c.cbOpenUntil
+	consecutive := c.cbConsecutive5xx
+	c.cbMu.Unlock()
+	if !openUntil.IsZero() {
+		t.Errorf("cbOpenUntil must be zero after successful probe, got %v", openUntil)
+	}
+	if consecutive != 0 {
+		t.Errorf("cbConsecutive5xx must be zero after successful probe, got %d", consecutive)
+	}
+}
+
+// TestCircuitBreaker429DoesNotTripBreaker pins that 429 (rate limit)
+// is handled by per-call retry policy, NOT by the source-level
+// breaker. The upstream is healthy when it 429s; it's just asking
+// us to slow down for this specific call.
+func TestCircuitBreaker429DoesNotTripBreaker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	c := New(Options{BaseURL: server.URL})
+
+	// Burn 2× threshold calls with 429. Breaker must NOT trip.
+	for i := 0; i < 2*CircuitBreakerThreshold; i++ {
+		_, _ = c.LookupPackages(context.Background(), "https://github.com/x/y")
+	}
+
+	c.cbMu.Lock()
+	openUntil := c.cbOpenUntil
+	consecutive := c.cbConsecutive5xx
+	c.cbMu.Unlock()
+
+	if !openUntil.IsZero() {
+		t.Errorf("429 must NOT trip the breaker (upstream is healthy, just throttling) — got cbOpenUntil=%v", openUntil)
+	}
+	if consecutive != 0 {
+		t.Errorf("429 must NOT increment the consecutive-failure counter — got %d", consecutive)
+	}
+}
+
+// TestCircuitBreakerTransportErrorsCountToward429 pins that
+// connection-level errors (DNS, ECONNREFUSED, TLS) DO count as
+// transient failures and trip the breaker. The upstream is
+// effectively unreachable — same operational signal as 5xx.
+func TestCircuitBreakerTransportErrorsTripBreaker(t *testing.T) {
+	// Point the client at an unreachable port. http.Get will fail
+	// at the transport layer.
+	c := New(Options{
+		BaseURL: "http://127.0.0.1:1", // port 1 typically refuses connections
+		HTTPClient: &http.Client{
+			Timeout: 100 * time.Millisecond, // fast-fail
+		},
+	})
+
+	for i := 0; i < CircuitBreakerThreshold; i++ {
+		_, _ = c.LookupPackages(context.Background(), "https://github.com/x/y")
+	}
+
+	c.cbMu.Lock()
+	openUntil := c.cbOpenUntil
+	c.cbMu.Unlock()
+
+	if openUntil.IsZero() {
+		t.Error("transport-level errors must trip the circuit breaker — upstream is unreachable, same signal as 5xx")
+	}
+}

--- a/internal/platform/ecosystems/client.go
+++ b/internal/platform/ecosystems/client.go
@@ -25,9 +25,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aveloxis/aveloxis/internal/db"
@@ -38,6 +40,30 @@ import (
 const (
 	defaultBaseURL = "https://packages.ecosyste.ms"
 	defaultTimeout = 30 * time.Second
+
+	// CircuitBreakerThreshold is the consecutive-transient-error
+	// count that trips the source-level pause. v0.25.0 (mirrors the
+	// v0.22.12 breadth-worker pattern).
+	//
+	// 2026-05-22/23 production diagnostic: when ecosyste.ms enters
+	// a 500-storm (every repo lookup returns HTTP 500 for hours),
+	// the DistributionWorker's per-repo quadratic backoff was still
+	// firing correctly per repo — but the fleet kept dispatching
+	// new repos into the broken upstream, generating one ERROR-
+	// level log line per repo. The circuit breaker pauses the
+	// source globally so the rest of the fleet stops hammering and
+	// proceeds with whatever evidence the OTHER sources can
+	// gather. Scans during the pause are still recorded as
+	// successful (per the v0.25.0 scanner contract) — they just
+	// don't include ecosyste.ms rows for the pause window.
+	CircuitBreakerThreshold = 10
+
+	// CircuitBreakerPause is how long the pause lasts before the
+	// breaker reopens for probing. 1 hour matches the v0.22.12
+	// breadth-worker pattern. Tunable; if production observation
+	// shows ecosyste.ms outages typically resolve faster or
+	// slower, adjust accordingly.
+	CircuitBreakerPause = 1 * time.Hour
 )
 
 // Options configures an ecosyste.ms Client.
@@ -56,6 +82,10 @@ type Options struct {
 
 	// HTTPClient lets callers inject a custom *http.Client.
 	HTTPClient *http.Client
+
+	// Logger receives circuit-breaker state-transition log entries.
+	// Optional; defaults to slog.Default().
+	Logger *slog.Logger
 }
 
 // Client is the ecosyste.ms reverse-lookup wrapper.
@@ -64,6 +94,21 @@ type Client struct {
 	userAgent   string
 	politeEmail string
 	http        *http.Client
+	logger      *slog.Logger
+
+	// Source-level circuit-breaker state (v0.25.0). Mirrors the
+	// v0.22.12 BreadthWorker pattern: track consecutive transient
+	// failures across calls (i.e., distinct repos), and after
+	// CircuitBreakerThreshold trip the breaker for
+	// CircuitBreakerPause. While open, LookupPackages short-
+	// circuits with (nil, nil) so the scanner treats it as
+	// "source returned no data" rather than "source errored" —
+	// the rest of the scan proceeds normally and the v0.25.0
+	// loosened contract stamps last_run as long as at least one
+	// other source completed cleanly.
+	cbMu             sync.Mutex
+	cbConsecutive5xx int
+	cbOpenUntil      time.Time
 }
 
 // New constructs a Client.
@@ -73,6 +118,7 @@ func New(opts Options) *Client {
 		userAgent:   opts.UserAgent,
 		politeEmail: opts.PoliteEmail,
 		http:        opts.HTTPClient,
+		logger:      opts.Logger,
 	}
 	if c.baseURL == "" {
 		c.baseURL = defaultBaseURL
@@ -84,7 +130,53 @@ func New(opts Options) *Client {
 	if c.http == nil {
 		c.http = &http.Client{Timeout: defaultTimeout}
 	}
+	if c.logger == nil {
+		c.logger = slog.Default()
+	}
 	return c
+}
+
+// circuitOpen returns true if the breaker is currently tripped.
+// As a side effect, it resets the breaker state when the pause
+// window has elapsed so the NEXT call probes the upstream.
+func (c *Client) circuitOpen() bool {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+	if c.cbOpenUntil.IsZero() {
+		return false
+	}
+	if time.Now().Before(c.cbOpenUntil) {
+		return true
+	}
+	// Pause elapsed — reset state. The next call probes.
+	c.logger.Info("ecosyste.ms circuit breaker: pause elapsed, probing on next call",
+		"consecutive_5xx_at_trip", c.cbConsecutive5xx)
+	c.cbConsecutive5xx = 0
+	c.cbOpenUntil = time.Time{}
+	return false
+}
+
+// noteTransientFailure increments the consecutive-failure counter
+// and trips the breaker when threshold is reached.
+func (c *Client) noteTransientFailure() {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+	c.cbConsecutive5xx++
+	if c.cbConsecutive5xx >= CircuitBreakerThreshold && c.cbOpenUntil.IsZero() {
+		c.cbOpenUntil = time.Now().Add(CircuitBreakerPause)
+		c.logger.Warn("ecosyste.ms circuit breaker: tripped — pausing source",
+			"consecutive_5xx", c.cbConsecutive5xx,
+			"threshold", CircuitBreakerThreshold,
+			"pause", CircuitBreakerPause,
+			"reopen_at", c.cbOpenUntil)
+	}
+}
+
+// noteSuccess resets the consecutive-failure counter.
+func (c *Client) noteSuccess() {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+	c.cbConsecutive5xx = 0
 }
 
 // rateLimitError is the typed error returned for HTTP 429 so
@@ -116,7 +208,26 @@ type registryRef struct {
 // and returns every (ecosystem, package_name) tuple the service
 // associates with the repo. 404 is not an error — the contract is
 // "no packages indexed for this repo" rather than "API failure".
+//
+// v0.25.0: source-level circuit breaker — when ecosyste.ms returns
+// HTTP 5xx (or transport-level errors) for CircuitBreakerThreshold
+// consecutive calls in a row, subsequent calls short-circuit with
+// (nil, nil) for CircuitBreakerPause. The scanner treats the
+// (nil, nil) like a 404 (clean miss), so the rest of the scan
+// proceeds and last_run is stamped normally. Once the pause
+// elapses, the breaker reopens and the next call probes the
+// upstream.
 func (c *Client) LookupPackages(ctx context.Context, repositoryURL string) ([]model.PackageDistribution, error) {
+	// Circuit-breaker probe: when open, treat ecosyste.ms as
+	// "source absent for this scan" — no error, no data. Operator
+	// sees the source-level pause once (at trip time) in a single
+	// WARN log; per-call DEBUG keeps the steady-state quiet.
+	if c.circuitOpen() {
+		c.logger.Debug("ecosyste.ms LookupPackages: circuit open, skipping",
+			"repository_url", repositoryURL)
+		return nil, nil
+	}
+
 	u, err := url.Parse(c.baseURL + "/api/v1/packages/lookup")
 	if err != nil {
 		return nil, fmt.Errorf("parse baseURL: %w", err)
@@ -137,18 +248,30 @@ func (c *Client) LookupPackages(ctx context.Context, repositoryURL string) ([]mo
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		// Transport-level errors (connection refused, DNS, TLS
+		// handshake failure, context cancellation while reading) all
+		// count toward the breaker — they're symptoms of the source
+		// being unreachable, same operational signal as a 5xx.
+		c.noteTransientFailure()
 		return nil, fmt.Errorf("ecosyste.ms GET: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	switch {
 	case resp.StatusCode == http.StatusOK:
-		// fall through
+		// fall through (success → noteSuccess after decode)
 	case resp.StatusCode == http.StatusNotFound:
+		c.noteSuccess()
 		return nil, nil
 	case resp.StatusCode == http.StatusTooManyRequests:
+		// 429 — service is up but throttling us. NOT a circuit-
+		// breaker signal (the upstream is healthy, we're just
+		// being rate-limited). Let it bubble as a rate-limit
+		// class error; the DistributionWorker's quadratic backoff
+		// handles it per-repo.
 		return nil, &rateLimitError{msg: fmt.Sprintf("ecosyste.ms rate limited (HTTP 429) for %s", repositoryURL)}
 	case resp.StatusCode >= 500:
+		c.noteTransientFailure()
 		return nil, fmt.Errorf("ecosyste.ms server error (HTTP %d): %w", resp.StatusCode, platform.ErrTransient)
 	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
@@ -159,6 +282,7 @@ func (c *Client) LookupPackages(ctx context.Context, repositoryURL string) ([]mo
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
 		return nil, fmt.Errorf("ecosyste.ms decode: %w", err)
 	}
+	c.noteSuccess()
 
 	out := make([]model.PackageDistribution, 0, len(entries))
 	for _, e := range entries {

--- a/internal/platform/ecosystems/client.go
+++ b/internal/platform/ecosystems/client.go
@@ -37,6 +37,38 @@ import (
 	"github.com/aveloxis/aveloxis/internal/platform"
 )
 
+// circuitOpenError is the concrete type behind ErrCircuitOpen. It
+// implements platform.ClassifiedError so ClassifyError routes it to
+// ClassSkip without the platform package needing to know about the
+// ecosystems sentinel (avoiding a circular import).
+type circuitOpenError struct{}
+
+func (circuitOpenError) Error() string {
+	return "ecosyste.ms circuit breaker is open"
+}
+
+// Class implements platform.ClassifiedError. ClassSkip semantics
+// mean the scanner treats this as "source unavailable" (analogous
+// to a 404 from the upstream) — does NOT route to the failure-
+// counter path. The distinguishing signal that this is a circuit-
+// open skip rather than a real 404 is the sentinel-identity match
+// via errors.Is(err, ErrCircuitOpen), which the CompositeScanner
+// uses to mark the scan as incomplete.
+func (circuitOpenError) Class() platform.ErrorClass {
+	return platform.ClassSkip
+}
+
+// ErrCircuitOpen is returned by LookupPackages when the source-level
+// circuit breaker is currently open. Classifies as ClassSkip via
+// the ClassifiedError interface so existing error paths treat it
+// like a 404, but the CompositeScanner identifies it specifically
+// (via errors.Is) to mark the scan as incomplete
+// (distribution_scan_complete = FALSE) so the affected repo
+// becomes immediately re-eligible once the breaker closes.
+//
+// v0.25.0.
+var ErrCircuitOpen error = circuitOpenError{}
+
 const (
 	defaultBaseURL = "https://packages.ecosyste.ms"
 	defaultTimeout = 30 * time.Second
@@ -156,6 +188,24 @@ func (c *Client) circuitOpen() bool {
 	return false
 }
 
+// IsCircuitOpen reports whether the source-level circuit breaker is
+// currently tripped. Read-only: does NOT have the side effect of
+// resetting state when the pause has elapsed (use circuitOpen
+// internally for that). Callers (typically the CompositeScanner's
+// Healthy() check from the DistributionWorker dispatcher) want a
+// pure read so the dispatcher can sleep without inadvertently
+// closing the breaker on a stale post-deadline read.
+//
+// v0.25.0.
+func (c *Client) IsCircuitOpen() bool {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+	if c.cbOpenUntil.IsZero() {
+		return false
+	}
+	return time.Now().Before(c.cbOpenUntil)
+}
+
 // noteTransientFailure increments the consecutive-failure counter
 // and trips the breaker when threshold is reached.
 func (c *Client) noteTransientFailure() {
@@ -218,14 +268,17 @@ type registryRef struct {
 // elapses, the breaker reopens and the next call probes the
 // upstream.
 func (c *Client) LookupPackages(ctx context.Context, repositoryURL string) ([]model.PackageDistribution, error) {
-	// Circuit-breaker probe: when open, treat ecosyste.ms as
-	// "source absent for this scan" — no error, no data. Operator
-	// sees the source-level pause once (at trip time) in a single
-	// WARN log; per-call DEBUG keeps the steady-state quiet.
+	// Circuit-breaker probe: when open, short-circuit with a typed
+	// sentinel error (ErrCircuitOpen) that classifies as ClassSkip.
+	// The scanner uses this to mark the scan as incomplete
+	// (distribution_scan_complete = FALSE) so the affected repo
+	// becomes immediately re-eligible once the breaker closes.
+	// Operator sees the source-level pause once (at trip time) in a
+	// single WARN log; per-call DEBUG keeps the steady-state quiet.
 	if c.circuitOpen() {
 		c.logger.Debug("ecosyste.ms LookupPackages: circuit open, skipping",
 			"repository_url", repositoryURL)
-		return nil, nil
+		return nil, ErrCircuitOpen
 	}
 
 	u, err := url.Parse(c.baseURL + "/api/v1/packages/lookup")

--- a/internal/platform/github/distribution.go
+++ b/internal/platform/github/distribution.go
@@ -78,11 +78,23 @@ type ghReleaseAsset struct {
 // even if PyPI itself doesn't carry the package.
 //
 // Optional endpoint: 404 / 403 / 410 → empty result, not error.
+//
+// v0.25.0: routes through platform.WithoutETag(ctx) to suppress the
+// HTTPClient's If-None-Match conditional layer. A 304 response from
+// the distribution path would otherwise silently delete prior rows
+// via the v0.24.0 snapshot-replace semantics in
+// MarkDistributionComplete — see WithoutETag's docstring for the
+// silent-data-loss rationale.
 func (c *Client) ListReleaseAssetExtensions(ctx context.Context, owner, repo string) ([]model.PackageDistribution, error) {
+	ctx = platform.WithoutETag(ctx)
 	path := fmt.Sprintf("/repos/%s/%s/releases?per_page=100", owner, repo)
 	var releases []ghRelease
 	if err := c.http.GetJSON(ctx, path, &releases); err != nil {
-		if platform.ClassifyError(err) == platform.ClassSkip {
+		// ClassNotModified treated like ClassSkip as defense-in-depth.
+		// With WithoutETag we should never receive 304, but if some
+		// future refactor leaks an ETag into the cache for this path,
+		// the defensive branch keeps us out of the failure loop.
+		if class := platform.ClassifyError(err); class == platform.ClassSkip || class == platform.ClassNotModified {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("list releases for %s/%s: %w", owner, repo, err)
@@ -170,6 +182,9 @@ func gitHubPackageTypeToEcosystem(pt string) string {
 // GitHub does not support a repository-name query parameter on these
 // endpoints.
 func (c *Client) ListRepoPackages(ctx context.Context, owner, repo string) ([]model.PackageDistribution, error) {
+	// v0.25.0: bypass ETag so 304 cannot trigger the silent-data-loss
+	// path under snapshot-replace. See WithoutETag docstring.
+	ctx = platform.WithoutETag(ctx)
 	var out []model.PackageDistribution
 
 	for _, pt := range supportedPackageTypes {
@@ -180,20 +195,21 @@ func (c *Client) ListRepoPackages(ctx context.Context, owner, repo string) ([]mo
 		err := c.http.GetJSON(ctx, userPath, &pkgs)
 		if err != nil {
 			class := platform.ClassifyError(err)
-			if class == platform.ClassSkip {
+			// ClassNotModified treated like ClassSkip (defense in depth).
+			if class == platform.ClassSkip || class == platform.ClassNotModified {
 				// 404 on user endpoint: try org endpoint.
 				if errors.Is(err, platform.ErrNotFound) {
 					orgPath := fmt.Sprintf("/orgs/%s/packages?package_type=%s&per_page=100",
 						url.PathEscape(owner), url.QueryEscape(pt))
 					if err := c.http.GetJSON(ctx, orgPath, &pkgs); err != nil {
-						// org endpoint also skipped: nothing to do for this package_type
-						if platform.ClassifyError(err) == platform.ClassSkip {
+						orgClass := platform.ClassifyError(err)
+						if orgClass == platform.ClassSkip || orgClass == platform.ClassNotModified {
 							continue
 						}
 						return nil, fmt.Errorf("list org packages for %s (type=%s): %w", owner, pt, err)
 					}
 				} else {
-					// 403/410 — likely scope or visibility issue. Skip.
+					// 403/410/304 — scope, visibility, or cached-empty. Skip.
 					continue
 				}
 			} else {
@@ -228,23 +244,38 @@ type ghContentsEntry struct {
 // wellKnownManifests maps the basename (or extension) of a manifest
 // file to its normalized manifest_type. Used by ListRootManifests
 // to identify which files in a contents listing are package manifests.
+//
+// v0.25.0 added Julia (Project.toml, JuliaProject.toml), R/CRAN
+// (DESCRIPTION), and conda (meta.yaml) recognition after a
+// 2026-05-23 production diagnostic showed every distribution-scan
+// failure on the chaoss.tv aveloxis fleet was a Julia or R repo —
+// repos whose manifests existed in the GitHub Contents listing but
+// were dropped on the floor because classifyManifestFilename
+// returned "" for them. Pre-v0.25.0 these ecosystems had no working
+// source whenever ecosyste.ms had an outage (deps.dev doesn't index
+// Julia or CRAN/Bioconductor).
 var wellKnownManifests = map[string]string{
-	"package.json":     "npm",
-	"setup.py":         "pypi",
-	"setup.cfg":        "pypi",
-	"pyproject.toml":   "pypi",
-	"cargo.toml":       "cargo",
-	"go.mod":           "go",
-	"pom.xml":          "maven",
-	"build.gradle":     "maven",
-	"build.gradle.kts": "maven",
-	"gemfile":          "rubygems",
-	"composer.json":    "composer",
-	"mix.exs":          "elixir",
-	"package.swift":    "swift",
-	"pubspec.yaml":     "dart",
-	"conanfile.txt":    "cpp",
-	"conanfile.py":     "cpp",
+	"package.json":      "npm",
+	"setup.py":          "pypi",
+	"setup.cfg":         "pypi",
+	"pyproject.toml":    "pypi",
+	"cargo.toml":        "cargo",
+	"go.mod":            "go",
+	"pom.xml":           "maven",
+	"build.gradle":      "maven",
+	"build.gradle.kts":  "maven",
+	"gemfile":           "rubygems",
+	"composer.json":     "composer",
+	"mix.exs":           "elixir",
+	"package.swift":     "swift",
+	"pubspec.yaml":      "dart",
+	"conanfile.txt":     "cpp",
+	"conanfile.py":      "cpp",
+	"project.toml":      "julia", // Julia primary manifest
+	"juliaproject.toml": "julia", // Julia secondary (used in some monorepos)
+	"description":       "cran",  // R/CRAN/Bioconductor — no extension by convention
+	"meta.yaml":         "conda", // conda-build recipe
+	"recipe.yaml":       "conda", // rattler-build recipe (newer conda variant)
 }
 
 // suffixManifests lists file SUFFIXES (case-insensitive) that map to a
@@ -287,10 +318,16 @@ func classifyManifestFilename(name string) string {
 //
 // Optional endpoint: 404 on contents (empty repo, archived
 // generic-git) → empty result + nil error.
+//
+// v0.25.0: ctx wrapped in platform.WithoutETag so 304 responses
+// (which would otherwise propagate as a fatal error in the
+// pre-v0.25.0 code and trigger the silent-data-loss path via
+// snapshot-replace in MarkDistributionComplete) can't fire.
 func (c *Client) ListRootManifests(ctx context.Context, owner, repo string) ([]model.DistributionManifest, error) {
+	ctx = platform.WithoutETag(ctx)
 	rootEntries, err := c.fetchContentsDir(ctx, owner, repo, "")
 	if err != nil {
-		if platform.ClassifyError(err) == platform.ClassSkip {
+		if class := platform.ClassifyError(err); class == platform.ClassSkip || class == platform.ClassNotModified {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("list root contents for %s/%s: %w", owner, repo, err)
@@ -327,7 +364,7 @@ func (c *Client) ListRootManifests(ctx context.Context, owner, repo string) ([]m
 	for _, dir := range firstLevelDirs {
 		entries, err := c.fetchContentsDir(ctx, owner, repo, dir)
 		if err != nil {
-			if platform.ClassifyError(err) == platform.ClassSkip {
+			if class := platform.ClassifyError(err); class == platform.ClassSkip || class == platform.ClassNotModified {
 				continue
 			}
 			// One bad dir doesn't sink the whole list; log via the
@@ -370,13 +407,15 @@ func (c *Client) fetchContentsDir(ctx context.Context, owner, repo, dirPath stri
 // under 1MB and absent for larger files — we treat both cases as
 // "no content available" rather than retrying with the blobs API).
 func (c *Client) FetchManifestContent(ctx context.Context, owner, repo, filePath string) (string, error) {
+	// v0.25.0: bypass ETag — same rationale as ListRootManifests.
+	ctx = platform.WithoutETag(ctx)
 	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, path.Clean(filePath))
 	var entry struct {
 		Content  string `json:"content"`
 		Encoding string `json:"encoding"`
 	}
 	if err := c.http.GetJSON(ctx, apiPath, &entry); err != nil {
-		if platform.ClassifyError(err) == platform.ClassSkip {
+		if class := platform.ClassifyError(err); class == platform.ClassSkip || class == platform.ClassNotModified {
 			return "", nil
 		}
 		return "", fmt.Errorf("fetch manifest %s: %w", filePath, err)

--- a/internal/platform/github/distribution_test.go
+++ b/internal/platform/github/distribution_test.go
@@ -5,9 +5,13 @@ package github
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/aveloxis/aveloxis/internal/platform"
 )
 
 // v0.24.0 — GitHub-side fetchers for the DistributionWorker.
@@ -299,6 +303,107 @@ func TestListRootManifests(t *testing.T) {
 		if got := gotTypes[typ]; got != path {
 			t.Errorf("expected manifest type %s at %s, got %q", typ, path, got)
 		}
+	}
+}
+
+// TestListRootManifestsRecognizesJuliaRCondaManifests pins the v0.25.0
+// additions to wellKnownManifests. Pre-v0.25.0 chaoss.tv operator
+// diagnostic showed every distribution-scan failure was a Julia or R
+// repo whose manifest existed in the GitHub Contents listing but was
+// dropped on the floor because classifyManifestFilename returned ""
+// for it. Without recognizing these manifests, the only viable
+// distribution source for Julia/CRAN/Bioconductor was ecosyste.ms,
+// so any ecosyste.ms outage stranded the entire cohort.
+func TestListRootManifestsRecognizesJuliaRCondaManifests(t *testing.T) {
+	contentsResp := `[
+        {"name": "Project.toml", "path": "Project.toml", "type": "file"},
+        {"name": "DESCRIPTION", "path": "DESCRIPTION", "type": "file"},
+        {"name": "meta.yaml", "path": "meta.yaml", "type": "file"},
+        {"name": "recipe.yaml", "path": "recipe.yaml", "type": "file"},
+        {"name": "JuliaProject.toml", "path": "JuliaProject.toml", "type": "file"},
+        {"name": "README.md", "path": "README.md", "type": "file"}
+    ]`
+	client := testGHClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/repos/x/y/contents/" || r.URL.Path == "/repos/x/y/contents" {
+			_, _ = w.Write([]byte(contentsResp))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	manifests, err := client.ListRootManifests(context.Background(), "x", "y")
+	if err != nil {
+		t.Fatalf("ListRootManifests: %v", err)
+	}
+
+	gotTypes := make(map[string][]string) // type -> paths
+	for _, m := range manifests {
+		gotTypes[m.ManifestType] = append(gotTypes[m.ManifestType], m.ManifestPath)
+	}
+
+	// Both Project.toml and JuliaProject.toml map to "julia"
+	if len(gotTypes["julia"]) != 2 {
+		t.Errorf("expected 2 julia manifests (Project.toml + JuliaProject.toml), got %v", gotTypes["julia"])
+	}
+	if len(gotTypes["cran"]) != 1 || gotTypes["cran"][0] != "DESCRIPTION" {
+		t.Errorf("expected DESCRIPTION → cran, got %v", gotTypes["cran"])
+	}
+	// Both meta.yaml and recipe.yaml map to "conda"
+	if len(gotTypes["conda"]) != 2 {
+		t.Errorf("expected 2 conda manifests (meta.yaml + recipe.yaml), got %v", gotTypes["conda"])
+	}
+}
+
+// TestDistributionCallsBypassETagConditionals pins the v0.25.0
+// silent-data-loss fix. The four distribution-related GitHub
+// functions must call platform.WithoutETag(ctx) at entry so the
+// HTTPClient does NOT send If-None-Match — a 304 response under
+// snapshot-replace semantics would otherwise delete prior rows
+// without ever reinserting them.
+//
+// Behavioral test: drive each function twice through the same test
+// server. If ETag were active, the second call would carry If-None-
+// Match. Assert that no request EVER carries that header.
+func TestDistributionCallsBypassETagConditionals(t *testing.T) {
+	var sawIfNoneMatch int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != "" {
+			sawIfNoneMatch++
+		}
+		// Always return a stable ETag so the HTTPClient would cache it
+		// (if ETag were active) and send If-None-Match on the next call.
+		w.Header().Set("ETag", `"stable-etag-v1"`)
+		w.Header().Set("Content-Type", "application/json")
+		// Choose a response shape that satisfies every endpoint we
+		// test against. An empty JSON array works for releases,
+		// packages, and contents listings; an empty object works for
+		// FetchManifestContent.
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/contents/foo"):
+			_, _ = w.Write([]byte(`{"content":"","encoding":"base64"}`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	logger := slog.Default()
+	keys := platform.NewKeyPool([]string{"test-token"}, logger)
+	httpClient := platform.NewHTTPClient(server.URL, keys, logger, platform.AuthGitHub)
+	client := &Client{http: httpClient, logger: logger}
+
+	ctx := context.Background()
+	// Each function called twice so a leaking ETag would surface.
+	for i := 0; i < 2; i++ {
+		_, _ = client.ListReleaseAssetExtensions(ctx, "x", "y")
+		_, _ = client.ListRepoPackages(ctx, "x", "y")
+		_, _ = client.ListRootManifests(ctx, "x", "y")
+		_, _ = client.FetchManifestContent(ctx, "x", "y", "foo")
+	}
+
+	if sawIfNoneMatch != 0 {
+		t.Errorf("distribution calls leaked %d If-None-Match headers; ETag MUST be bypassed for these paths to avoid the v0.24.0 snapshot-replace silent-data-loss bug", sawIfNoneMatch)
 	}
 }
 

--- a/internal/platform/httpclient.go
+++ b/internal/platform/httpclient.go
@@ -56,23 +56,40 @@ var ErrGone = errors.New("gone")
 // unique repos = ~5.3h of wasted wall-clock per cycle.
 var ErrNoContent = errors.New("no content (204)")
 
-// ErrTransient marks the "exhausted N retries" errors that
-// HTTPClient.Get and HTTPClient.GraphQL emit after their inner
-// retry loops give up. Added v0.20.19 (Fix J). Pre-fix these
-// errors were plain fmt.Errorf strings with no sentinel, so
-// platform.ClassifyError fell through to ClassFatal — making
-// the v0.20.8 sub-batch retry path (fetchPRBatchWithSubdivide
-// in internal/platform/github/graphql_pr_batch.go) bypass
-// subdivision entirely on the dominant production failure
-// mode. Production diagnostic on 2026-05-13: 6 of 7 stuck
-// repos had last_error starting with "graphql PR batch:
-// graphql: exhausted 10 retries for https://api.github.com/
-// graphql" and were looping indefinitely via v0.20.5's
-// force_full_collect path. With the sentinel, ClassifyError
-// returns ClassTransient and Fix C's subdivision actually
-// fires — halving the batch until it's small enough to fit
-// inside what GitHub will serve.
-var ErrTransient = errors.New("transient (retries exhausted)")
+// ErrTransient marks transient-class errors that should route
+// to ClassTransient via platform.ClassifyError. Originally added
+// v0.20.19 (Fix J) for "exhausted N retries" wrappers in
+// HTTPClient.Get and HTTPClient.GraphQL; v0.25.0 also wraps it
+// around single-attempt 5xx responses from the ecosyste.ms /
+// deps.dev clients (which do NOT have an inner retry loop).
+//
+// Message rationale (v0.25.0): the sentinel text is intentionally
+// generic ("transient") rather than the pre-v0.25.0
+// "transient (retries exhausted)" so single-attempt wrappers
+// don't claim retries that never happened. Retry-loop callers
+// (httpclient.go:exhausted-N-retries wrapper, graphql.go's
+// exhausted-N-retries wrapper) already prepend an explicit
+// "exhausted N retries for URL: " prefix, so they continue to
+// communicate the retry-loop semantics in their error string.
+// Source-contract pin in transient_retry_test.go protects the
+// %w-wrapping contract that callers depend on.
+//
+// Production diagnostic on 2026-05-13: 6 of 7 stuck repos had
+// last_error starting with "graphql PR batch: graphql:
+// exhausted 10 retries for https://api.github.com/graphql" and
+// were looping indefinitely via v0.20.5's force_full_collect
+// path. With the sentinel, ClassifyError returns ClassTransient
+// and Fix C's subdivision actually fires — halving the batch
+// until it's small enough to fit inside what GitHub will serve.
+//
+// Subsequent diagnostic on 2026-05-23: the v0.24.0 ecosyste.ms
+// client wrapped 5xx into ErrTransient on a SINGLE call (no
+// retry budget). With the pre-v0.25.0 sentinel text, every
+// production log line read "transient (retries exhausted)" and
+// operators reasonably concluded we were over-retrying — when
+// in fact the ecosyste.ms client doesn't retry at all. The
+// message change makes the log line accurate.
+var ErrTransient = errors.New("transient")
 
 // ErrPaginationLimitExceeded marks GitHub's hard cap on
 // certain endpoints' result count (notably /releases). Past
@@ -205,6 +222,34 @@ func (c *HTTPClient) OnPermanentRedirect(hook func(from, to string)) {
 
 const maxRetries = 10
 
+// ctxKeyBypassETag is a context value key used by WithoutETag to
+// suppress the ETag conditional layer on a single Get call. Distinct
+// type per Go context-key convention so other packages can't collide
+// on the key.
+type ctxKeyBypassETag struct{}
+
+// WithoutETag returns a derived context that suppresses both the
+// If-None-Match send and the ETag cache write for any Get/GetJSON
+// call made with it. Use this for endpoints where 304 responses
+// would silently destroy data via snapshot-replace semantics — the
+// v0.24.0 DistributionWorker is the canonical case: on 304 the
+// scanner gets back empty data, MarkDistributionComplete rotates
+// the prior rows to history and never reinserts them, so the
+// repo's distribution evidence quietly disappears even though
+// GitHub politely told us "you already have this."
+//
+// At 180-day distribution cadence the wasted GitHub API budget
+// from disabling ETag is ~1.6% of the pool — well worth the
+// silent-data-loss avoidance.
+func WithoutETag(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyBypassETag{}, true)
+}
+
+func bypassETag(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxKeyBypassETag{}).(bool)
+	return v
+}
+
 // Get performs a single authenticated GET request with retries and rate-limit handling.
 func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, error) {
 	url := c.baseURL + path
@@ -212,6 +257,7 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 	// attempts so a rename-then-rate-limited chain doesn't prematurely
 	// exhaust the retry budget, and a loop doesn't run forever.
 	redirectHops := 0
+	skipETag := bypassETag(ctx)
 
 	for attempt := range maxRetries {
 		key, err := c.keys.GetKey(ctx)
@@ -236,11 +282,15 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 
 		// Conditional request: send If-None-Match when we have a cached ETag.
 		// GitHub does not count 304 responses against the rate limit.
-		c.etagMu.RLock()
-		if etag, ok := c.etagCache[path]; ok {
-			req.Header.Set("If-None-Match", etag)
+		// Skipped when the caller used WithoutETag(ctx) — see v0.25.0
+		// docstring on WithoutETag for the silent-data-loss rationale.
+		if !skipETag {
+			c.etagMu.RLock()
+			if etag, ok := c.etagCache[path]; ok {
+				req.Header.Set("If-None-Match", etag)
+			}
+			c.etagMu.RUnlock()
 		}
-		c.etagMu.RUnlock()
 
 		resp, err := c.inner.Do(req)
 		if err != nil {
@@ -272,10 +322,15 @@ func (c *HTTPClient) Get(ctx context.Context, path string) (*http.Response, erro
 		}
 
 		// Cache ETag from successful responses for future conditional requests.
-		if etag := resp.Header.Get("ETag"); etag != "" && resp.StatusCode == http.StatusOK {
-			c.etagMu.Lock()
-			c.etagCache[path] = etag
-			c.etagMu.Unlock()
+		// Skipped when the caller opted into WithoutETag — we don't want to
+		// poison the cache for OTHER callers that might use the same path
+		// without the bypass.
+		if !skipETag {
+			if etag := resp.Header.Get("ETag"); etag != "" && resp.StatusCode == http.StatusOK {
+				c.etagMu.Lock()
+				c.etagCache[path] = etag
+				c.etagMu.Unlock()
+			}
 		}
 
 		switch {

--- a/internal/scheduler/distribution_wiring.go
+++ b/internal/scheduler/distribution_wiring.go
@@ -71,6 +71,11 @@ func (s *Scheduler) spawnDistributionWorker(ctx context.Context) {
 	}
 
 	scanner := distribution.NewCompositeScanner(depsDevClient, ecoClient, ghClient, s.logger)
+	// v0.25.0: honor the operator's cross-check setting.
+	// NewCompositeScanner defaults to true; we only override when
+	// the operator explicitly set it (the cfg field is plumbed
+	// through from CollectionConfig.DistributionTrackingCrossCheckSourcesValue()).
+	scanner.CrossCheckSources = s.cfg.DistributionTrackingCrossCheckSources
 
 	worker := distribution.NewWorker(distribution.WorkerOptions{
 		Store:         s.store,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -85,12 +85,13 @@ type Config struct {
 	// ecosyste.ms, GitHub Packages, GitHub release assets) plus
 	// in-repo manifest evidence. Off by default; opt-in via
 	// collection.distribution_tracking_enabled.
-	DistributionTrackingEnabled       bool          // master switch (off by default)
-	DistributionTrackingInterval      time.Duration // per-repo cadence (default 180d)
-	DistributionTrackingWorkers       int           // concurrent runners (default 4)
-	DistributionTrackingStartInterval time.Duration // minimum gap between successful claims (default 30s)
-	DistributionTrackingPoliteEmail   string        // ecosyste.ms polite-pool From: header
-	DistributionTrackingUserAgent     string        // overrides "aveloxis/<version>" UA
+	DistributionTrackingEnabled           bool          // master switch (off by default)
+	DistributionTrackingInterval          time.Duration // per-repo cadence (default 180d)
+	DistributionTrackingWorkers           int           // concurrent runners (default 4)
+	DistributionTrackingStartInterval     time.Duration // minimum gap between successful claims (default 30s)
+	DistributionTrackingPoliteEmail       string        // ecosyste.ms polite-pool From: header
+	DistributionTrackingUserAgent         string        // overrides "aveloxis/<version>" UA
+	DistributionTrackingCrossCheckSources bool          // v0.25.0: always query both deps.dev AND ecosyste.ms (default true)
 }
 
 // Scheduler polls the Postgres-backed queue and dispatches collection workers.


### PR DESCRIPTION
### v0.25.0 

  Eight coupled changes for the Julia/R cohort failure + the architectural follow-up:

  1. Julia/R/conda manifest recognition — added Project.toml, JuliaProject.toml, DESCRIPTION, meta.yaml, recipe.yaml to wellKnownManifests plus three new parsers.
  2. Loosened scanner contract with per-source-class error tracking — fail only when every enabled source errored. When both external registries fail, dedicated ERROR log with each source's error labeled (deps_dev_class/deps_dev_error/ecosystems_class/ecosystems_error).
  3. 304 silent-data-loss fix — platform.WithoutETag(ctx) bypasses ETag conditionals for distribution paths.
  4. ecosyste.ms source-level circuit breaker — trips after 10 consecutive 5xx/transport errors, 1h pause, ErrCircuitOpen typed sentinel returned to callers.
  5. ErrTransient message fixed — no longer claims "retries exhausted".
  6. distribution_tracking_cross_check_sources flag — pointer-to-bool, defaults true, operator lock-in.
  7. Dispatcher pause on unhealthy scanner — Scanner interface gains Healthy() bool; CompositeScanner.Healthy() returns false when ecosyste.ms circuit is open; Worker.dispatcher checks before each claim and sleeps 60s on unhealthy (single WARN at entry, INFO at exit). Prevents the ~480 repos/hour throughput from being permanently stamped with incomplete scans during an outage.
  8. distribution_scan_complete column + immediate re-claim — new BOOLEAN DEFAULT TRUE on aveloxis_data.repos. Scanner.Scan returns (dists, manifests, complete, err). scanIncomplete is set when an external source returns transient/rate-limit OR the new ecosystems.ErrCircuitOpen sentinel. MarkDistributionComplete stamps the column; ClaimNextDistributionRepo treats scan_complete=FALSE as immediately re-eligible AND sorts those rows ahead of cadence-elapsed ones. The ~10 threshold cohort that trips the breaker gets a full re-collection on the next dispatch cycle — partial-scan rows rotate to history per normal snapshot semantics.

  v0.25.0 reset migration preserves v0.24.1; resets the pre-v0.25.0 strict-contract cohort via WHERE distribution_failed_attempts > 0. Self-disabling. Tripwire test TestV0241ResetPreservedAlongsideV0250Reset.

  40+ new tests across 7 files. Full go test ./... green. 

  Operator deployment when ready:
```bash
  cd $HOME/<<github_home>>/aveloxis/aveloxis
  go install ./cmd/aveloxis
  aveloxis stop all
  aveloxis migrate --skip-views   # adds distribution_scan_complete + runs both resets
  aveloxis start all
```
  
#### Watch for these new log lines after deploy:
  - "distribution dispatcher: scanner unhealthy — pausing dispatch until source recovers" (WARN, once per outage)
  - "distribution dispatcher: scanner healthy again — resuming dispatch" (INFO, once per recovery)
  - "distribution scan partial — will be re-collected once source recovers" (INFO, per threshold-cohort repo)