### PR TITLE
updated distrobution history table keys

### DIFF
--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -430,6 +430,38 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 		    distribution_last_failed_at = NULL
 		WHERE distribution_failed_attempts > 0`)
 
+	// v0.25.1 — drop the inherited natural-key UNIQUE constraints
+	// on the two distribution history tables. The pre-v0.25.1 schema
+	// declared them via `LIKE parent INCLUDING ALL`, which carried the
+	// parent's UNIQUE constraints into history. History tables are
+	// supposed to hold many snapshots over time per logical key, but
+	// the inherited UNIQUE prevented that — the second rotation of any
+	// repo tripped 23505 in MarkDistributionComplete and rolled back.
+	//
+	// In v0.24.0 the bug was rare (cadence = 180 days). In v0.25.0
+	// distribution_scan_complete=FALSE makes partial-scan repos
+	// immediately re-eligible, so the failure mode became a tight
+	// dispatcher loop: 1 ERROR + 1 burned distribution scan every ~30s
+	// per stuck repo. Operators saw this on 2026-05-23 with repo_id=70:
+	//
+	//   level=ERROR msg="distribution: mark complete failed" repo_id=70
+	//   error="rotate repo_distribution_manifest to history: ERROR:
+	//   duplicate key value violates unique constraint
+	//   \"repo_distribution_manifest_history_repo_id_manifest_path_key\""
+	//
+	// PRIMARY KEY on distribution_id / manifest_id is NOT dropped —
+	// the schema still declares LIKE INCLUDING ALL so the PK survives;
+	// only the natural-key UNIQUE constraints by their auto-generated
+	// names are dropped. IF EXISTS makes the step idempotent for
+	// fresh-install DBs (where schema.sql's own DROP already fired
+	// during the base DDL exec) and for re-runs after the constraints
+	// are gone.
+	execMigrationStep(ctx, pg, logger, &errs, "v0.25.1 drop inherited natural-key UNIQUEs on distribution history tables",
+		`ALTER TABLE aveloxis_data.repo_distribution_history
+		    DROP CONSTRAINT IF EXISTS repo_distribution_history_repo_id_ecosystem_package_name_so_key;
+		ALTER TABLE aveloxis_data.repo_distribution_manifest_history
+		    DROP CONSTRAINT IF EXISTS repo_distribution_manifest_history_repo_id_manifest_path_key;`)
+
 	// collection_queue.last_commits backfill (v0.19.11). Pre-v0.19.11
 	// the FacadeCollector incremented result.Commits once per inserted
 	// ROW rather than once per distinct commit. Since the commits table

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2222,6 +2222,15 @@ CREATE INDEX IF NOT EXISTS idx_repo_distribution_ecosystem
 CREATE TABLE IF NOT EXISTS aveloxis_data.repo_distribution_history (
     LIKE aveloxis_data.repo_distribution INCLUDING ALL
 );
+-- v0.25.1: the parent's UNIQUE (repo_id, ecosystem, package_name,
+-- source) constraint is inherited into the history table by the
+-- preceding LIKE clause, which is wrong: history holds many
+-- snapshots over time per logical key. The PRIMARY KEY on
+-- distribution_id is kept; only the natural-key UNIQUE is dropped.
+-- IF EXISTS makes both fresh installs and v0.24.x→v0.25.1 upgrades
+-- idempotent.
+ALTER TABLE aveloxis_data.repo_distribution_history
+    DROP CONSTRAINT IF EXISTS repo_distribution_history_repo_id_ecosystem_package_name_so_key;
 
 CREATE TABLE IF NOT EXISTS aveloxis_data.repo_distribution_manifest (
     manifest_id           BIGSERIAL PRIMARY KEY,
@@ -2245,6 +2254,12 @@ CREATE INDEX IF NOT EXISTS idx_repo_distribution_manifest_type
 CREATE TABLE IF NOT EXISTS aveloxis_data.repo_distribution_manifest_history (
     LIKE aveloxis_data.repo_distribution_manifest INCLUDING ALL
 );
+-- v0.25.1: same rationale as repo_distribution_history above — drop
+-- the inherited UNIQUE (repo_id, manifest_path) so a re-scan can
+-- rotate the same manifest path into history multiple times without
+-- tripping 23505. The PRIMARY KEY on manifest_id survives.
+ALTER TABLE aveloxis_data.repo_distribution_manifest_history
+    DROP CONSTRAINT IF EXISTS repo_distribution_manifest_history_repo_id_manifest_path_key;
 
 
 -- ============================================================

--- a/internal/db/v025_1_history_unique_drop_test.go
+++ b/internal/db/v025_1_history_unique_drop_test.go
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.25.1 — hotfix for a schema-design bug from v0.24.0 that v0.25.0
+// exposed as a tight dispatcher-loop ERROR every ~30s.
+//
+// The history tables were declared with
+//
+//	CREATE TABLE ... (LIKE parent INCLUDING ALL);
+//
+// `INCLUDING ALL` copies the parent's UNIQUE constraints. So both
+// history tables ended up with:
+//   - repo_distribution_history: UNIQUE (repo_id, ecosystem, package_name, source)
+//   - repo_distribution_manifest_history: UNIQUE (repo_id, manifest_path)
+//
+// But a history table is supposed to hold MANY snapshots over time
+// per logical key (v0.24.0 changelog: "let analysts observe over
+// time when a package first appeared / disappeared"). The inherited
+// UNIQUE prevents that. First rotation works (history is empty);
+// every subsequent rotation hits 23505 on the same logical key
+// that's already in history.
+//
+// In v0.24.0 the bug was rare (cadence = 180 days). In v0.25.0
+// distribution_scan_complete=FALSE makes partial-scan repos
+// immediately re-eligible, so MarkDistributionComplete tries to
+// rotate on every dispatcher tick (~30s) and fails the same way
+// forever — burning API budget and spamming the log.
+//
+// Fix shape (v0.25.1): keep `LIKE ... INCLUDING ALL` (so the PK on
+// distribution_id / manifest_id and the BIGSERIAL behavior + NOT
+// NULLs + comments survive), then explicitly DROP the natural-key
+// UNIQUE constraints by their auto-generated names. The constraint
+// names are the postgres default `<table>_<col1>_..._key` form —
+// confirmed in the live ERROR log line:
+//
+//	violates unique constraint "repo_distribution_manifest_history_repo_id_manifest_path_key"
+
+func TestSchemaDropsHistoryUniqueConstraints(t *testing.T) {
+	data, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatalf("read schema.sql: %v", err)
+	}
+	src := string(data)
+
+	// History tables must still be declared with INCLUDING ALL so the
+	// PRIMARY KEY (distribution_id / manifest_id) and BIGSERIAL
+	// default-from-sequence behavior survive into the history tables.
+	// Dropping INCLUDING ALL entirely would remove the PK, which is
+	// the wrong fix.
+	for _, needle := range []string{
+		"LIKE aveloxis_data.repo_distribution INCLUDING ALL",
+		"LIKE aveloxis_data.repo_distribution_manifest INCLUDING ALL",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("schema.sql must keep %q so the PK on distribution_id / manifest_id survives — v0.25.1's fix is to selectively drop the natural-key UNIQUEs, NOT to drop the entire INCLUDING ALL", needle)
+		}
+	}
+
+	// The natural-key UNIQUEs must be dropped on the history tables
+	// because history holds many snapshots over time per logical key.
+	// Constraint names are postgres's auto-generated `<table>_<cols>_key`,
+	// with NAMEDATALEN-1 = 63 char truncation. The full intended name
+	// for the distribution history constraint would be
+	// `repo_distribution_history_repo_id_ecosystem_package_name_source_key`
+	// (67 chars); postgres truncates the trailing chars before `_key`
+	// to fit, producing `..._so_key`. Verified against the live DB
+	// (PGAPPNAME=psql aveloxis_cascade_test → pg_constraint.conname).
+	// The manifest history constraint (60 chars) is under the limit.
+	for _, needle := range []string{
+		"ALTER TABLE aveloxis_data.repo_distribution_history",
+		"DROP CONSTRAINT IF EXISTS repo_distribution_history_repo_id_ecosystem_package_name_so_key",
+		"ALTER TABLE aveloxis_data.repo_distribution_manifest_history",
+		"DROP CONSTRAINT IF EXISTS repo_distribution_manifest_history_repo_id_manifest_path_key",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("schema.sql must drop the inherited natural-key UNIQUE constraint on history tables. Missing needle: %q. Without this, the second rotation of any repo trips 23505 and MarkDistributionComplete rolls back forever.", needle)
+		}
+	}
+}
+
+func TestMigrationDropsHistoryUniqueConstraintsOnExistingFleets(t *testing.T) {
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	src := string(data)
+
+	// Operators on v0.24.0–v0.25.0 created their history tables with
+	// the inherited UNIQUEs. Schema declarations on subsequent runs
+	// won't re-process those (CREATE TABLE IF NOT EXISTS short-circuits),
+	// so the migration must ALTER the existing tables explicitly.
+	const label = `"v0.25.1 drop inherited natural-key UNIQUEs on distribution history tables"`
+	if !strings.Contains(src, label) {
+		t.Errorf("migrate.go must register a migration step labelled %s — the v0.25.1 fix MUST run on existing v0.24.x/v0.25.0 fleets, not just on fresh installs, otherwise the dispatcher loop persists", label)
+	}
+
+	for _, needle := range []string{
+		// Must use execMigrationStep (fail-closed contract).
+		"execMigrationStep(ctx, pg, logger, &errs",
+		"ALTER TABLE aveloxis_data.repo_distribution_history",
+		"DROP CONSTRAINT IF EXISTS repo_distribution_history_repo_id_ecosystem_package_name_so_key",
+		"ALTER TABLE aveloxis_data.repo_distribution_manifest_history",
+		"DROP CONSTRAINT IF EXISTS repo_distribution_manifest_history_repo_id_manifest_path_key",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go missing v0.25.1 ALTER TABLE needle: %q", needle)
+		}
+	}
+}
+
+func TestV0251MigrationIsIdempotent(t *testing.T) {
+	// The IF EXISTS clauses are the self-disabling guard: once the
+	// constraints are dropped, subsequent runs are no-ops. A future
+	// refactor that "tidies up" by removing IF EXISTS would fail
+	// every migrate run on already-fixed DBs. Pin the guard.
+	data, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	body := string(data)
+
+	const label = "v0.25.1 drop inherited natural-key UNIQUEs on distribution history tables"
+	idx := strings.Index(body, label)
+	if idx < 0 {
+		t.Fatal("cannot find v0.25.1 migration label in migrate.go")
+	}
+	end := idx + 800
+	if end > len(body) {
+		end = len(body)
+	}
+	region := body[idx:end]
+
+	// Both DROP CONSTRAINT statements must carry IF EXISTS within the
+	// v0.25.1 step's SQL region.
+	count := strings.Count(region, "DROP CONSTRAINT IF EXISTS")
+	if count < 2 {
+		t.Errorf("v0.25.1 migration block must contain BOTH DROP CONSTRAINT IF EXISTS clauses (one per history table); found %d. Without IF EXISTS the migration fails on second run after the constraints are gone.", count)
+	}
+}
+
+// TestV0251HistoryRotationAllowsRepeatedKeys is the integration test
+// gated on AVELOXIS_TEST_DB. It runs the v0.25.1-corrected schema
+// against a live Postgres and asserts that the same (repo_id,
+// manifest_path) row can be rotated to history twice without the
+// 23505 we saw in the production log.
+//
+// Without the v0.25.1 fix this test fails with:
+//
+//	duplicate key value violates unique constraint
+//	"repo_distribution_manifest_history_repo_id_manifest_path_key"
+//
+// on the second INSERT. With the fix, both INSERTs succeed.
+func TestV0251HistoryRotationAllowsRepeatedKeys(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.pool.Close()
+
+	pool := store.pool
+
+	// Insert two history rows with the SAME (repo_id, manifest_path).
+	// Pre-v0.25.1 schema fails on the second INSERT.
+	const repoID = 999999
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_id, repo_group_id, platform_id, repo_git, repo_owner, repo_name)
+		VALUES ($1, 1, 1, 'https://example.com/x/y-v0251-test', 'x', 'y-v0251-test')
+		ON CONFLICT (repo_id) DO NOTHING`, repoID); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+	// Clean up any leftover state from a prior failed run.
+	if _, err := pool.Exec(ctx, `DELETE FROM aveloxis_data.repo_distribution_manifest_history WHERE repo_id = $1`, repoID); err != nil {
+		t.Fatalf("cleanup history: %v", err)
+	}
+
+	for i := range 2 {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.repo_distribution_manifest_history
+			    (repo_id, manifest_path, manifest_type, package_name_declared, tool_version)
+			VALUES ($1, 'setup.py', 'pypi', 'foo', 'v0.25.1-test')`, repoID)
+		if err != nil {
+			t.Fatalf("rotate %d failed: %v — v0.25.1 must drop the inherited UNIQUE so history can accumulate multiple snapshots per (repo_id, manifest_path)", i+1, err)
+		}
+	}
+
+	// Same shape on the other history table.
+	if _, err := pool.Exec(ctx, `DELETE FROM aveloxis_data.repo_distribution_history WHERE repo_id = $1`, repoID); err != nil {
+		t.Fatalf("cleanup repo_distribution_history: %v", err)
+	}
+	for i := range 2 {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.repo_distribution_history
+			    (repo_id, ecosystem, package_name, version_count, source, tool_version)
+			VALUES ($1, 'pypi', 'foo', 0, 'deps.dev', 'v0.25.1-test')`, repoID)
+		if err != nil {
+			t.Fatalf("repo_distribution_history rotate %d failed: %v", i+1, err)
+		}
+	}
+
+	// Final cleanup.
+	if _, err := pool.Exec(ctx, `DELETE FROM aveloxis_data.repo_distribution_manifest_history WHERE repo_id = $1`, repoID); err != nil {
+		t.Logf("cleanup history: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM aveloxis_data.repo_distribution_history WHERE repo_id = $1`, repoID); err != nil {
+		t.Logf("cleanup repo_distribution_history: %v", err)
+	}
+}
+
+// v0251Connect is the shared integration-test gate. Mirrors the
+// realignConnect pattern from queue_realign_integration_test.go so
+// we go through NewPostgresStore (which wires up the slog logger
+// migrate.go expects) instead of building a bare PostgresStore that
+// nil-panics inside RunMigrations.
+func v0251Connect(t *testing.T) (*PostgresStore, context.Context) {
+	t.Helper()
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return store, ctx
+}
+
+// TestV0251HistoryTablesStillHavePrimaryKey is the regression guard
+// against my own fix. The original (rejected) shape was to drop
+// `INCLUDING INDEXES` entirely, which would have also lost the PK
+// on distribution_id / manifest_id. Pin that the PKs survive.
+func TestV0251HistoryTablesStillHavePrimaryKey(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.pool.Close()
+	pool := store.pool
+
+	for _, tbl := range []string{
+		"repo_distribution_history",
+		"repo_distribution_manifest_history",
+	} {
+		var hasPK bool
+		err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+			    SELECT 1
+			    FROM information_schema.table_constraints
+			    WHERE table_schema = 'aveloxis_data'
+			      AND table_name = $1
+			      AND constraint_type = 'PRIMARY KEY'
+			)`, tbl).Scan(&hasPK)
+		if err != nil {
+			t.Fatalf("introspect %s: %v", tbl, err)
+		}
+		if !hasPK {
+			t.Errorf("aveloxis_data.%s has no PRIMARY KEY — the v0.25.1 fix must keep INCLUDING ALL and selectively drop only the natural-key UNIQUEs. Dropping INCLUDING ALL or INCLUDING INDEXES would lose the PK.", tbl)
+		}
+	}
+
+	// Inverse check: the natural-key UNIQUEs must be GONE.
+	for _, c := range []struct{ tbl, constraint string }{
+		{"repo_distribution_history", "repo_distribution_history_repo_id_ecosystem_package_name_so_key"},
+		{"repo_distribution_manifest_history", "repo_distribution_manifest_history_repo_id_manifest_path_key"},
+	} {
+		var exists bool
+		err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+			    SELECT 1
+			    FROM information_schema.table_constraints
+			    WHERE table_schema = 'aveloxis_data'
+			      AND table_name = $1
+			      AND constraint_name = $2
+			)`, c.tbl, c.constraint).Scan(&exists)
+		if err != nil {
+			t.Fatalf("introspect %s/%s: %v", c.tbl, c.constraint, err)
+		}
+		if exists {
+			t.Errorf("aveloxis_data.%s still has UNIQUE constraint %q — v0.25.1's whole point is to drop it so history tables can accumulate multiple snapshots per logical key", c.tbl, c.constraint)
+		}
+	}
+}

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.0"
+var ToolVersion = "0.25.1"


### PR DESCRIPTION
### v0.25.1 

  Diagnosis confirmed: LIKE parent INCLUDING ALL on both distribution history tables carried the parent's natural-key UNIQUE constraints into history. v0.24.0 ran into
  this at 180-day intervals (rare); v0.25.0's distribution_scan_complete=FALSE immediate-re-claim turned it into a tight 30s dispatcher loop on every partial-scan repo.

  Fix shape: keep LIKE … INCLUDING ALL (so the PRIMARY KEY on distribution_id/manifest_id survives), add ALTER TABLE … DROP CONSTRAINT IF EXISTS for the auto-named
  natural-key UNIQUEs only. Schema + migration are idempotent via IF EXISTS.

  Gotcha caught by integration test: postgres truncates auto-generated constraint names to 63 chars, so repo_distribution_history_repo_id_ecosystem_package_name_source_key (67 chars) actually exists as …_so_key. Source-contract tests would have missed it; the live-DB
  integration test caught it on the first run.

  Tests: 5 new (3 source-contract + 2 integration against aveloxis_cascade_test). Full go test ./... green. v0.25.0 → v0.25.1 in version.go. 

   Memory written to project_v0251_hotfix.md + indexed.

  Deploy when ready:
```bash
  go install ./cmd/aveloxis
  aveloxis stop all
  aveloxis migrate --skip-views   # runs the v0.25.1 DROP CONSTRAINT step
  aveloxis start all
```
