### PR TITLE
fixing small command line thing that only really will ever affect me

### DIFF
--- a/internal/db/email_message_store.go
+++ b/internal/db/email_message_store.go
@@ -202,24 +202,41 @@ func (s *PostgresStore) ResolveMirrorLink(ctx context.Context, owner, repo, kind
 // Pattern-A signal where Apache bulk-imported Jira history into GitHub
 // issues. Idempotent (only fills empty keys). Returns rows updated.
 //
-// Conflict-safe: skips an issue whose derived key is ALREADY held by another
-// issue in the same repo (the UNIQUE idx_issues_external_key forbids two). That
-// collision arises when mailing-list projection minted a synthetic issue that
-// squats the key before this backfill ran (the missed-LINK shadow surfaced by
-// `mailing-list-stats`). Without the NOT EXISTS guard the whole UPDATE fails
-// with 23505; with it, the shadowed native issue is simply left key-less for
-// the operator to merge.
+// Conflict-safe against BOTH collision shapes the UNIQUE idx_issues_external_key
+// (repo_id, external_key) can hit:
+//
+//  1. Two empty-key issues in the same repo whose titles derive the SAME key
+//     (common in Apache Jira→GitHub imports — renamed/duplicate titles). A
+//     blind UPDATE would set both to the same value and fail 23505 WITHIN the
+//     statement. `DISTINCT ON (repo_id, key)` picks exactly one winner (lowest
+//     issue_id) per (repo, key) so only one row is keyed.
+//  2. A sibling that ALREADY holds the key (e.g. a synthetic issue minted by
+//     mailing-list projection that squats it — the missed-LINK shadow surfaced
+//     by `mailing-list-stats`). The NOT EXISTS guard skips those.
+//
+// In both cases the loser/shadowed issue is left key-less rather than erroring.
+// Idempotent. Returns the number of issues keyed.
 func (s *PostgresStore) BackfillIssueExternalKeys(ctx context.Context) (int64, error) {
 	tag, err := s.pool.Exec(ctx, `
+		WITH derived AS (
+		    SELECT issue_id, repo_id,
+		           substring(issue_title from '\[([A-Z][A-Z0-9]+-[0-9]+)\]') AS k
+		    FROM aveloxis_data.issues
+		    WHERE COALESCE(external_key, '') = ''
+		      AND issue_title ~ '\[[A-Z][A-Z0-9]+-[0-9]+\]'
+		),
+		pick AS (
+		    SELECT DISTINCT ON (repo_id, k) issue_id, repo_id, k
+		    FROM derived
+		    ORDER BY repo_id, k, issue_id
+		)
 		UPDATE aveloxis_data.issues i
-		SET external_key = substring(i.issue_title from '\[([A-Z][A-Z0-9]+-[0-9]+)\]')
-		WHERE COALESCE(i.external_key, '') = ''
-		  AND i.issue_title ~ '\[[A-Z][A-Z0-9]+-[0-9]+\]'
+		SET external_key = p.k
+		FROM pick p
+		WHERE i.issue_id = p.issue_id
 		  AND NOT EXISTS (
 		      SELECT 1 FROM aveloxis_data.issues j
-		      WHERE j.repo_id = i.repo_id
-		        AND j.issue_id <> i.issue_id
-		        AND j.external_key = substring(i.issue_title from '\[([A-Z][A-Z0-9]+-[0-9]+)\]')
+		      WHERE j.repo_id = p.repo_id AND j.issue_id <> p.issue_id AND j.external_key = p.k
 		  )`)
 	if err != nil {
 		return 0, fmt.Errorf("backfill issue external keys: %w", err)

--- a/internal/db/mailinglist_projection_store_test.go
+++ b/internal/db/mailinglist_projection_store_test.go
@@ -249,3 +249,37 @@ func TestBackfillExternalKeysConflictSafe(t *testing.T) {
 		t.Errorf("shadowed native issue must stay key-less (synthetic owns RT-1); got %q", nativeKey)
 	}
 }
+
+// TestBackfillExternalKeysSameStatementDup pins the harder collision the first
+// fix missed: TWO empty-key issues in one repo whose titles derive the SAME
+// key. A blind UPDATE sets both → 23505 within the statement. The DISTINCT ON
+// winner-per-(repo,key) fix must key exactly one and not error.
+func TestBackfillExternalKeysSameStatementDup(t *testing.T) {
+	store, ctx := emConnect(t)
+	defer store.Close()
+
+	const repoGit = "https://github.com/_av_ssd/repo"
+	clean := func() {
+		store.pool.Exec(ctx, `DELETE FROM aveloxis_data.issues WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git=$1)`, repoGit)
+		store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_git=$1`, repoGit)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	var repoID int64
+	store.pool.QueryRow(ctx, `INSERT INTO aveloxis_data.repos (platform_id, repo_git, repo_owner, repo_name) VALUES (1,$1,'_av_ssd','repo') RETURNING repo_id`, repoGit).Scan(&repoID)
+	// Two native issues, same repo, same bracketed key, both empty external_key.
+	store.pool.Exec(ctx, `INSERT INTO aveloxis_data.issues (repo_id, platform_issue_id, issue_number, external_key, issue_title) VALUES
+		($1, 8810001, 1, '', 'add thing [XDUP-1]'),
+		($1, 8810002, 2, '', 'Re: add thing [XDUP-1]')`, repoID)
+
+	if _, err := store.BackfillIssueExternalKeys(ctx); err != nil {
+		t.Fatalf("must not 23505 on two empty-key issues with the same derived key; got %v", err)
+	}
+	// Exactly one issue got the key (the lowest issue_id wins).
+	var keyed int
+	store.pool.QueryRow(ctx, `SELECT count(*) FROM aveloxis_data.issues WHERE repo_id=$1 AND external_key='XDUP-1'`, repoID).Scan(&keyed)
+	if keyed != 1 {
+		t.Errorf("exactly one issue must be keyed XDUP-1, got %d", keyed)
+	}
+}

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -220,8 +220,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// forge-less kernel [PATCH] threads as PR-equivalents without polluting
 	// pull_requests).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.18"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.18\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.19"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.19\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.18"
+var ToolVersion = "0.25.19"


### PR DESCRIPTION
0.25.19 — backfill-issue-external-keys is now fully conflict-safe: when two issues in a repo derive the same [KEY-N] from their titles, it keys one (lowest issue_id) instead of failing with a duplicate-key error. (0.25.18's guard only handled collisions with an already-assigned key.) ... This would only have affected the developer as a practical matter, but its fixed. 