### PR TITLE
indexes for speed

### DIFF
--- a/internal/db/mailinglist_projection_store.go
+++ b/internal/db/mailinglist_projection_store.go
@@ -73,30 +73,42 @@ func (s *PostgresStore) LinkOrCreateIssueFromEmail(ctx context.Context, repoID i
 		return 0, false, fmt.Errorf("link-or-create issue: empty external_key")
 	}
 
-	// LINK: an existing issue for this key. Two ways it can present:
-	//  1. external_key column already set (backfill-issue-external-keys ran, or
-	//     a prior synthetic) — the exact-match case.
-	//  2. a native GitHub issue whose external_key is still EMPTY but whose
-	//     title carries the bracketed key (e.g. "lock files [LUCENE-1]") — the
-	//     Apache Jira→GitHub import shape. Matching this PREVENTS the
-	//     missed-LINK duplicate (#2): without it, projection-before-backfill
-	//     would mint a synthetic that squats the key (the UNIQUE index then
-	//     blocks the native issue from ever getting it). Exact-key matches sort
-	//     first so a real key always wins over a title heuristic.
+	// LINK: an existing issue for this key. Done as TWO queries so the common
+	// case is an indexed point-lookup, not a sequential scan:
+	//
+	//  1. EXACT external_key match (idx_issues_external_key) — fast. Covers
+	//     issues that already carry the key (backfill-issue-external-keys ran,
+	//     or a prior synthetic).
+	//  2. FALLBACK title match — a native GitHub issue whose external_key is
+	//     still EMPTY but whose title carries the bracketed key (e.g.
+	//     "lock files [LUCENE-1]"). This is a leading-wildcard LIKE the btree
+	//     can't serve, so it runs ONLY when the exact match misses (and is
+	//     index-assisted by idx_issues_title_trgm). It PREVENTS the missed-LINK
+	//     duplicate (#2): without it, projecting before the key backfill would
+	//     mint a synthetic that squats the key.
 	var existing int64
 	lerr := s.pool.QueryRow(ctx,
 		`SELECT issue_id FROM aveloxis_data.issues
-		 WHERE repo_id = $1
-		   AND ( (external_key = $2 AND external_key <> '')
-		         OR issue_title LIKE '%[' || $2 || ']%' )
-		 ORDER BY (external_key = $2) DESC
-		 LIMIT 1`,
+		 WHERE repo_id = $1 AND external_key = $2 AND external_key <> '' LIMIT 1`,
 		repoID, externalKey).Scan(&existing)
 	if lerr == nil && existing > 0 {
 		return existing, false, nil
 	}
 	if lerr != nil && !errors.Is(lerr, pgx.ErrNoRows) {
 		return 0, false, fmt.Errorf("link-or-create issue: lookup by external_key: %w", lerr)
+	}
+	// Fallback: native issue carrying the key only in its title.
+	ferr := s.pool.QueryRow(ctx,
+		`SELECT issue_id FROM aveloxis_data.issues
+		 WHERE repo_id = $1 AND COALESCE(external_key, '') = ''
+		   AND issue_title LIKE '%[' || $2 || ']%'
+		 ORDER BY issue_id LIMIT 1`,
+		repoID, externalKey).Scan(&existing)
+	if ferr == nil && existing > 0 {
+		return existing, false, nil
+	}
+	if ferr != nil && !errors.Is(ferr, pgx.ErrNoRows) {
+		return 0, false, fmt.Errorf("link-or-create issue: lookup by title: %w", ferr)
 	}
 
 	// CREATE: synthetic issue, idempotent on (repo_id, platform_issue_id).

--- a/internal/db/mailinglist_projection_store_test.go
+++ b/internal/db/mailinglist_projection_store_test.go
@@ -283,3 +283,20 @@ func TestBackfillExternalKeysSameStatementDup(t *testing.T) {
 		t.Errorf("exactly one issue must be keyed XDUP-1, got %d", keyed)
 	}
 }
+
+// TestProjectionBackfillIndexesDeclared pins the v0.25.20 indexes that keep the
+// projection backfill's per-row lookups off sequential scans.
+func TestProjectionBackfillIndexesDeclared(t *testing.T) {
+	schema := readSchema(t)
+	for _, n := range []string{"idx_messages_node_id", "idx_email_message_thread_root"} {
+		if !strings.Contains(schema, n) {
+			t.Errorf("schema.sql must declare %s", n)
+		}
+	}
+	mig := readSourceFile(t, "migrate.go")
+	for _, n := range []string{"idx_messages_node_id", "idx_email_message_thread_root"} {
+		if !strings.Contains(mig, n) {
+			t.Errorf("migrate.go must create %s CONCURRENTLY", n)
+		}
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -212,6 +212,18 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_rgls_group_email",
 		`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_rgls_group_email
 		 ON aveloxis_data.repo_groups_list_serve (repo_group_id, rgls_email)`)
+	// v0.25.20 — indexes for the mailing-list projection backfill's per-row
+	// lookups. Without these, backfill-mailing-list-projection (and the live
+	// projection path) sequential-scan messages / email_message per row — the
+	// cause of the ~500-rows-per-30-min crawl observed 2026-06-04. node_id is
+	// the body-row join key (UpsertMailingListMessageBody sets node_id =
+	// Message-ID); thread_root_id is FindIssueForThread's lookup key.
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_messages_node_id",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_node_id
+		 ON aveloxis_data.messages (node_id) WHERE node_id <> ''`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_email_message_thread_root",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_thread_root
+		 ON aveloxis_data.email_message (thread_root_id) WHERE thread_root_id <> ''`)
 
 	// v0.21.0 — ScancodeWorker state on aveloxis_data.repos.
 	//
@@ -334,6 +346,11 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 				ON aveloxis_data.repos
 				USING GIN ((repo_owner || '/' || repo_name) gin_trgm_ops)`)
 	}
+	// NOTE: the mailing-list projection's LINK-by-title fallback
+	// (`issue_title LIKE '%[KEY-N]%'`) does NOT need a trigram index — the query
+	// filters `repo_id` first (idx_issues_repo_id), so the LIKE only scans one
+	// repo's issues, not the whole table. The exact external_key match is tried
+	// first (idx_issues_external_key) and the fallback runs only on a miss.
 
 	// pull_request_repo: add unique constraint for ON CONFLICT support (v0.12.0).
 	execCreateIndexConcurrently(ctx, pg, logger, &errs,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2125,6 +2125,11 @@ CREATE INDEX IF NOT EXISTS idx_issues_updated_at ON aveloxis_data.issues (update
 CREATE INDEX IF NOT EXISTS idx_pull_requests_repo_id ON aveloxis_data.pull_requests (repo_id);
 CREATE INDEX IF NOT EXISTS idx_pull_requests_updated_at ON aveloxis_data.pull_requests (updated_at);
 CREATE INDEX IF NOT EXISTS idx_messages_repo_id ON aveloxis_data.messages (repo_id);
+-- v0.25.20: the mailing-list projection backfill looks up a body by node_id
+-- (= RFC-822 Message-ID); thread-inheritance looks up by thread_root_id.
+-- Without these the backfill sequential-scans messages / email_message per row.
+CREATE INDEX IF NOT EXISTS idx_messages_node_id ON aveloxis_data.messages (node_id) WHERE node_id <> '';
+CREATE INDEX IF NOT EXISTS idx_email_message_thread_root ON aveloxis_data.email_message (thread_root_id) WHERE thread_root_id <> '';
 CREATE INDEX IF NOT EXISTS idx_issue_events_repo_id ON aveloxis_data.issue_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_pr_events_repo_id ON aveloxis_data.pull_request_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_releases_repo_id ON aveloxis_data.releases (repo_id);

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -220,8 +220,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// forge-less kernel [PATCH] threads as PR-equivalents without polluting
 	// pull_requests).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.19"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.19\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.20"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.20\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.19"
+var ToolVersion = "0.25.20"


### PR DESCRIPTION
### 0.25.20 — 
Index the mailing-list projection backfill's per-row lookups (idx_messages_node_id, idx_email_message_thread_root) and try the indexed exact-key match before the title fallback. Fixes a pathological slowdown (~500 rows/30 min) where backfill-mailing-list-projection sequentially scanned messages/email_message per row.