### PR TITLE
Feat/ux ergo 1 - Deadlock fix

### DIFF
--- a/cmd/aveloxis/backfill_mailing_list_projection.go
+++ b/cmd/aveloxis/backfill_mailing_list_projection.go
@@ -42,6 +42,16 @@ func backfillMailingListProjectionCmd(cfgPath *string) *cobra.Command {
 				batch = 500
 			}
 
+			// Ensure the per-row-lookup indexes exist before draining (CONCURRENTLY,
+			// IF NOT EXISTS — instant if present, non-blocking if it must build).
+			// Without these the backfill sequential-scans messages/email_message
+			// per row and crawls for days; this makes the command self-sufficient
+			// rather than depending on a separate `aveloxis migrate` having run.
+			fmt.Println("ensuring projection indexes (idx_messages_node_id, idx_email_message_thread_root)...")
+			if err := store.EnsureMailingListProjectionIndexes(ctx, logger); err != nil {
+				return fmt.Errorf("ensuring projection indexes: %w", err)
+			}
+
 			// Step 1: keyed issue_event projection (runs to completion first so
 			// every thread with a keyed message has its issue before step 2).
 			keyed := 0

--- a/cmd/aveloxis/backfill_mailing_list_projection_test.go
+++ b/cmd/aveloxis/backfill_mailing_list_projection_test.go
@@ -35,3 +35,22 @@ func TestBackfillProjectionCmdRegisteredAndOrdered(t *testing.T) {
 		t.Error("backfill command must NOT migrate (v0.21.5 contract)")
 	}
 }
+
+// TestBackfillProjectionEnsuresIndexes pins that the command guarantees its
+// per-row-lookup indexes before draining (so it never silently crawls because
+// `aveloxis migrate` was skipped).
+func TestBackfillProjectionEnsuresIndexes(t *testing.T) {
+	src, err := os.ReadFile("backfill_mailing_list_projection.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "EnsureMailingListProjectionIndexes(") {
+		t.Error("the command must call EnsureMailingListProjectionIndexes before draining")
+	}
+	ensure := strings.Index(s, "EnsureMailingListProjectionIndexes(")
+	keyed := strings.Index(s, "BackfillKeyedIssueProjection(")
+	if ensure < 0 || keyed < 0 || ensure > keyed {
+		t.Error("indexes must be ensured BEFORE the first keyed-projection step")
+	}
+}

--- a/internal/db/contributor_batch_deadlock_test.go
+++ b/internal/db/contributor_batch_deadlock_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUpsertContributorBatchSortsForDeterministicLockOrder pins the 2026-06-09
+// deadlock fix: UpsertContributorBatch must acquire contributor locks in a
+// DETERMINISTIC (sorted-by-login) order across concurrent workers. Iterating
+// the dedup map directly is random per process, so two workers whose batches
+// both touch popular shared contributors (regro-cf-autotick-bot, etc.) lock
+// them in different orders and deadlock (40P01). A revert to `range merged`
+// for the insert loop reintroduces the deadlock storm on aveloxis_large.
+func TestUpsertContributorBatchSortsForDeterministicLockOrder(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertContributorBatch")
+
+	if !strings.Contains(body, "sort.Strings(logins)") {
+		t.Error("UpsertContributorBatch must sort logins before the insert loop so concurrent workers acquire contributor locks in the same order (deadlock avoidance)")
+	}
+	if !strings.Contains(body, "for _, login := range logins") {
+		t.Error("the contributor insert loop must iterate the SORTED logins slice")
+	}
+	// Negative pin: the random-order map-range insert loop must not return.
+	if strings.Contains(body, "for login, contrib := range merged") {
+		t.Error("UpsertContributorBatch must NOT iterate `range merged` for the insert loop — that's the random lock order that caused the 40P01 deadlock storm")
+	}
+}

--- a/internal/db/mailinglist_projection_backfill.go
+++ b/internal/db/mailinglist_projection_backfill.go
@@ -5,10 +5,44 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 )
+
+// EnsureMailingListProjectionIndexes guarantees the indexes the backfill's
+// per-row lookups depend on (idx_messages_node_id, idx_email_message_thread_root)
+// exist before draining. Built CONCURRENTLY + IF NOT EXISTS, so it's a no-op
+// (instant) when they're already present and non-blocking when it has to build
+// them — the command ensures its OWN performance precondition rather than
+// silently sequential-scanning for days because a separate `aveloxis migrate`
+// was skipped. On a large `messages` table the first build can take a while,
+// but it never blocks concurrent writes.
+func (s *PostgresStore) EnsureMailingListProjectionIndexes(ctx context.Context, logger *slog.Logger) error {
+	var errs []error
+	execCreateIndexConcurrently(ctx, s, logger, &errs, "aveloxis_data", "idx_messages_node_id",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_node_id
+		 ON aveloxis_data.messages (node_id) WHERE node_id <> ''`)
+	execCreateIndexConcurrently(ctx, s, logger, &errs, "aveloxis_data", "idx_email_message_thread_root",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_thread_root
+		 ON aveloxis_data.email_message (thread_root_id) WHERE thread_root_id <> ''`)
+	// Partial indexes for the two candidate-batch queries (keyed + threaded), so
+	// each batch is an index scan over only the still-unprojected rows in
+	// email_message_id order instead of a full seq scan + sort of email_message
+	// (~4.4s/batch on prod). They shrink as rows get projected. The predicates
+	// are all constants, so they're usable without the generic-plan caveat.
+	execCreateIndexConcurrently(ctx, s, logger, &errs, "aveloxis_data", "idx_em_proj_pending_keyed",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_em_proj_pending_keyed
+		 ON aveloxis_data.email_message (email_message_id)
+		 WHERE msg_class = 'issue_event' AND COALESCE(projected_kind, '') = '' AND linked_external_key <> ''`)
+	execCreateIndexConcurrently(ctx, s, logger, &errs, "aveloxis_data", "idx_em_proj_pending_threaded",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_em_proj_pending_threaded
+		 ON aveloxis_data.email_message (email_message_id)
+		 WHERE thread_root_id <> '' AND COALESCE(projected_kind, '') = ''`)
+	return errors.Join(errs...)
+}
 
 // mailinglist_projection_backfill.go is Phase 5 of the mailing-list subsystem
 // (summary/12 §8): migrate the projection (Phase A issue link-or-create +
@@ -56,8 +90,13 @@ type backfillRow struct {
 // (e.g. a metadata-only mirror) so the caller skips the bridge.
 func (s *PostgresStore) bodyMsgID(ctx context.Context, messageIDHeader string) (int64, bool) {
 	var id int64
+	// The `node_id <> ''` predicate is load-bearing, not redundant: idx_messages_node_id
+	// is a PARTIAL index (WHERE node_id <> ''), and under a parameterized/generic plan
+	// Postgres can't prove `$1 <> ''`, so without this literal predicate it falls back
+	// to a 66-SECOND parallel seq scan of ~20M rows per call (verified on prod). With it,
+	// the partial index is usable → ~0.2ms. (2026-06-09 diagnosis.)
 	err := s.pool.QueryRow(ctx,
-		`SELECT msg_id FROM aveloxis_data.messages WHERE node_id = $1 AND platform_id = 6 LIMIT 1`,
+		`SELECT msg_id FROM aveloxis_data.messages WHERE node_id = $1 AND node_id <> '' AND platform_id = 6 LIMIT 1`,
 		messageIDHeader).Scan(&id)
 	if err != nil {
 		return 0, false

--- a/internal/db/mailinglist_projection_backfill_test.go
+++ b/internal/db/mailinglist_projection_backfill_test.go
@@ -4,6 +4,8 @@
 package db
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 )
 
@@ -116,6 +118,28 @@ func TestMlBackfillTitle(t *testing.T) {
 	for _, c := range cases {
 		if got := mlBackfillTitle(c.subj, c.key); got != c.want {
 			t.Errorf("mlBackfillTitle(%q,%q)=%q want %q", c.subj, c.key, got, c.want)
+		}
+	}
+}
+
+// TestEnsureMailingListProjectionIndexes verifies the helper runs cleanly
+// (idempotent) and the two indexes exist afterward.
+func TestEnsureMailingListProjectionIndexes(t *testing.T) {
+	store, ctx := emConnect(t)
+	defer store.Close()
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := store.EnsureMailingListProjectionIndexes(ctx, lg); err != nil {
+		t.Fatalf("ensure indexes: %v", err)
+	}
+	// Idempotent second call.
+	if err := store.EnsureMailingListProjectionIndexes(ctx, lg); err != nil {
+		t.Fatalf("ensure indexes (re-run): %v", err)
+	}
+	for _, idx := range []string{"idx_messages_node_id", "idx_email_message_thread_root"} {
+		var n int
+		store.pool.QueryRow(ctx, `SELECT count(*) FROM pg_indexes WHERE schemaname='aveloxis_data' AND indexname=$1`, idx).Scan(&n)
+		if n != 1 {
+			t.Errorf("index %s must exist after EnsureMailingListProjectionIndexes; found %d", idx, n)
 		}
 	}
 }

--- a/internal/db/mailinglist_projection_store.go
+++ b/internal/db/mailinglist_projection_store.go
@@ -197,11 +197,16 @@ func (s *PostgresStore) FindIssueForThread(ctx context.Context, threadRoot strin
 		return 0, false, nil
 	}
 	var id int64
+	// `thread_root_id <> ''` in the first OR branch is load-bearing (not redundant):
+	// idx_email_message_thread_root is PARTIAL (WHERE thread_root_id <> ''), and under a
+	// parameterized/generic plan Postgres can't prove `$1 <> ''`, so without this literal
+	// the branch seq-scans email_message. threadRoot is always non-empty here (caller
+	// guards), so it changes no results. message_id_header uses its own UNIQUE index.
 	err := s.pool.QueryRow(ctx, `
 		SELECT linked_issue_id FROM aveloxis_data.email_message
 		WHERE linked_issue_id IS NOT NULL
 		  AND repo_id = $2
-		  AND (thread_root_id = $1 OR message_id_header = $1)
+		  AND ((thread_root_id = $1 AND thread_root_id <> '') OR message_id_header = $1)
 		LIMIT 1`, threadRoot, repoID).Scan(&id)
 	if err != nil {
 		return 0, false, nil //nolint:nilerr // no projected sibling yet is not an error

--- a/internal/db/mailinglist_projection_store_test.go
+++ b/internal/db/mailinglist_projection_store_test.go
@@ -287,16 +287,34 @@ func TestBackfillExternalKeysSameStatementDup(t *testing.T) {
 // TestProjectionBackfillIndexesDeclared pins the v0.25.20 indexes that keep the
 // projection backfill's per-row lookups off sequential scans.
 func TestProjectionBackfillIndexesDeclared(t *testing.T) {
+	idxs := []string{"idx_messages_node_id", "idx_email_message_thread_root", "idx_em_proj_pending_keyed", "idx_em_proj_pending_threaded"}
 	schema := readSchema(t)
-	for _, n := range []string{"idx_messages_node_id", "idx_email_message_thread_root"} {
+	for _, n := range idxs {
 		if !strings.Contains(schema, n) {
 			t.Errorf("schema.sql must declare %s", n)
 		}
 	}
 	mig := readSourceFile(t, "migrate.go")
-	for _, n := range []string{"idx_messages_node_id", "idx_email_message_thread_root"} {
+	for _, n := range idxs {
 		if !strings.Contains(mig, n) {
 			t.Errorf("migrate.go must create %s CONCURRENTLY", n)
 		}
+	}
+	// The backfill command's ensure-helper must cover all four too.
+	bf := readSourceFile(t, "mailinglist_projection_backfill.go")
+	for _, n := range idxs {
+		if !strings.Contains(bf, n) {
+			t.Errorf("EnsureMailingListProjectionIndexes must create %s", n)
+		}
+	}
+}
+
+// TestBodyMsgIDQueryHasPartialPredicate pins the load-bearing `node_id <> ”`
+// in bodyMsgID — without it the partial idx_messages_node_id is unusable under
+// a generic plan and the lookup seq-scans ~20M messages (66s on prod).
+func TestBodyMsgIDQueryHasPartialPredicate(t *testing.T) {
+	src := readSourceFile(t, "mailinglist_projection_backfill.go")
+	if !strings.Contains(src, "node_id = $1 AND node_id <> ''") {
+		t.Error("bodyMsgID must include `node_id <> ''` so the partial index is usable under a generic plan")
 	}
 }

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -224,6 +224,17 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_email_message_thread_root",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_thread_root
 		 ON aveloxis_data.email_message (thread_root_id) WHERE thread_root_id <> ''`)
+	// v0.25.22 — candidate-batch indexes for the projection backfill: each batch
+	// becomes an index scan over only the still-unprojected rows instead of a
+	// full seq scan + sort of email_message (~4.4s/batch on prod).
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_em_proj_pending_keyed",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_em_proj_pending_keyed
+		 ON aveloxis_data.email_message (email_message_id)
+		 WHERE msg_class = 'issue_event' AND COALESCE(projected_kind, '') = '' AND linked_external_key <> ''`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_em_proj_pending_threaded",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_em_proj_pending_threaded
+		 ON aveloxis_data.email_message (email_message_id)
+		 WHERE thread_root_id <> '' AND COALESCE(projected_kind, '') = ''`)
 
 	// v0.21.0 — ScancodeWorker state on aveloxis_data.repos.
 	//

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"sort"
 	"strings"
 	"time"
 
@@ -1295,7 +1296,22 @@ func (s *PostgresStore) UpsertContributorBatch(ctx context.Context, contribs []m
 		// in the savepoint name.
 		var spCounter int
 
-		for login, contrib := range merged {
+		// Acquire contributor locks in a DETERMINISTIC order (sorted by login)
+		// across every concurrent worker. Without this, the map iteration order
+		// is random, so two workers whose batches both touch popular shared
+		// contributors (e.g. regro-cf-autotick-bot, conda-forge-admin — bots
+		// that appear in thousands of repos) lock those rows in different orders
+		// and deadlock (SQLSTATE 40P01). Consistent ordering makes a lock cycle
+		// impossible. (2026-06-09: fixes the contributor-deadlock storm on
+		// aveloxis_large; same class as Augur's old contributor deadlocks.)
+		logins := make([]string, 0, len(merged))
+		for login := range merged {
+			logins = append(logins, login)
+		}
+		sort.Strings(logins)
+
+		for _, login := range logins {
+			contrib := merged[login]
 			var cntrb_id string
 			// v0.23.0: track whether this contributor's row was
 			// rename-recovered so the contributor_login_history rows

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2130,6 +2130,13 @@ CREATE INDEX IF NOT EXISTS idx_messages_repo_id ON aveloxis_data.messages (repo_
 -- Without these the backfill sequential-scans messages / email_message per row.
 CREATE INDEX IF NOT EXISTS idx_messages_node_id ON aveloxis_data.messages (node_id) WHERE node_id <> '';
 CREATE INDEX IF NOT EXISTS idx_email_message_thread_root ON aveloxis_data.email_message (thread_root_id) WHERE thread_root_id <> '';
+-- v0.25.22: partial indexes so each projection-backfill candidate batch is an
+-- index scan over only the still-unprojected rows (email_message_id order)
+-- instead of a full seq scan + sort. They shrink as rows are projected.
+CREATE INDEX IF NOT EXISTS idx_em_proj_pending_keyed ON aveloxis_data.email_message (email_message_id)
+    WHERE msg_class = 'issue_event' AND COALESCE(projected_kind, '') = '' AND linked_external_key <> '';
+CREATE INDEX IF NOT EXISTS idx_em_proj_pending_threaded ON aveloxis_data.email_message (email_message_id)
+    WHERE thread_root_id <> '' AND COALESCE(projected_kind, '') = '';
 CREATE INDEX IF NOT EXISTS idx_issue_events_repo_id ON aveloxis_data.issue_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_pr_events_repo_id ON aveloxis_data.pull_request_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_releases_repo_id ON aveloxis_data.releases (repo_id);

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -220,8 +220,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// forge-less kernel [PATCH] threads as PR-equivalents without polluting
 	// pull_requests).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.20"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.20\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.22"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.22\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -220,8 +220,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// forge-less kernel [PATCH] threads as PR-equivalents without polluting
 	// pull_requests).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.22"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.22\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.23"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.23\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.20"
+var ToolVersion = "0.25.22"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.22"
+var ToolVersion = "0.25.23"


### PR DESCRIPTION
 0.25.23 — fix a contributor-deadlock storm (40P01) under high collection concurrency: UpsertContributorBatch acquired per-row locks in random map order, so workers upserting the same popular bot contributors (e.g. regro-cf-autotick-bot) deadlocked. Locks are now taken in deterministic sorted-by-login order, making a cycle impossible.

0.25.22 — fix pathologically slow mailing-list projection backfill: the partial indexes it relies on were unusable under parameterized query plans (Postgres can't prove $1 <> ''), causing 66s-per-row sequential scans of the 20M-row messages table. 
- Queries now carry the literal <> '' predicate so the partial indexes are used, plus partial indexes for the candidate-batch scans. 
- ~66,000× faster per row.

0.25.21 — backfill-mailing-list-projection now ensures its own lookup indexes at startup (CONCURRENTLY, IF NOT EXISTS), so it can't silently sequential-scan for days when aveloxis migrate wasn't run on the target DB first.