### PR TITLE
Rf/collection audit

### DIFF
--- a/cmd/aveloxis/dedup_repos.go
+++ b/cmd/aveloxis/dedup_repos.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// `aveloxis dedup-repos` — v0.25.32 one-shot merge of case-variant
+// duplicate repositories. GitHub/GitLab treat owner/repo paths
+// case-insensitively, but repos.repo_git was byte-exact-unique, so
+// bulk-pasted case variants (github.com/azure/x vs github.com/Azure/x)
+// created full duplicate rows that each collected the same repository
+// twice.
+//
+// Per pair (winner = oldest repo_id): user_repos links repoint to the
+// winner, shared-copy rows (messages, email_message, commit_comment_ref,
+// contributor_repo) repoint, and the loser's duplicated child data plus
+// the loser row itself are deleted — the winner holds the same data.
+//
+// Operator workflow:
+//
+//	aveloxis dedup-repos --dry-run      # show the plan
+//	aveloxis dedup-repos --limit 50     # canary batch
+//	aveloxis dedup-repos                # full run (re-run until 0 pairs)
+//	aveloxis migrate --skip-views       # then: builds uq_repos_repo_git_ci
+//	aveloxis refresh-views              # analytics stop double-counting
+//
+// See CLAUDE.md v0.25.32 for the full rationale.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/spf13/cobra"
+)
+
+func dedupReposCmd(cfgPath *string) *cobra.Command {
+	var (
+		dryRun    bool
+		batchSize int
+		limit     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "dedup-repos",
+		Short: "Merge case-variant duplicate repositories (GitHub/GitLab case-insensitive URLs)",
+		Long: `Opt-in one-shot data consolidation (v0.25.32).
+
+For each group of repos whose repo_git differs only by case on a forge
+platform (GitHub/GitLab — their owner/repo paths are case-insensitive,
+so the variants ARE the same repository):
+
+  1. Repoint aveloxis_ops.user_repos to the winner (oldest repo_id) so
+     every user group that referenced either variant keeps the repo and
+     immediately sees the winner's collected data.
+  2. Repoint shared-copy rows (messages, email_message,
+     commit_comment_ref, contributor_repo, foundation_membership) —
+     these are globally unique, the pair shares one copy.
+  3. Delete the loser's duplicated child data (issues, PRs, commits,
+     ...) leaves-first, then the loser repos row. Nothing is lost: both
+     sides collected the same repository.
+  4. Enqueue the winner if it has never been collected.
+
+Pairs with either side mid-collection (status='collecting') are skipped
+and reported; re-run after those jobs finish. The command is idempotent
+— resolved pairs drop out of the candidate set.
+
+After the fleet reports 0 pairs, run 'aveloxis migrate --skip-views' to
+build the uq_repos_repo_git_ci unique index (the permanent DB-level
+backstop), then 'aveloxis refresh-views' so matviews stop
+double-counting.
+
+Use --dry-run first to see the plan.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDedupRepos(*cfgPath, dryRun, batchSize, limit)
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the merge plan without writing")
+	cmd.Flags().IntVar(&batchSize, "batch-size", 50, "pairs merged per batch (each pair is one heavy transaction)")
+	cmd.Flags().IntVar(&limit, "limit", 0, "cap total pairs merged this run (0 = no cap)")
+
+	return cmd
+}
+
+func runDedupRepos(cfgPath string, dryRun bool, batchSize, limit int) error {
+	bootLog := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	cfg := loadConfig(cfgPath, bootLog)
+	logger := newLogger(cfg)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	// v0.21.5: store.Migrate(ctx) intentionally NOT called here — only
+	// serve and migrate run schema migrations.
+	store, err := db.NewPostgresStore(ctx, cfg.Database.ConnectionString(), logger)
+	if err != nil {
+		return fmt.Errorf("connecting to database: %w", err)
+	}
+	defer store.Close()
+
+	count, err := db.CountCaseVariantRepoDups(ctx, store)
+	if err != nil {
+		return fmt.Errorf("count duplicate groups: %w", err)
+	}
+	logger.Info("v0.25.32 case-variant repo dedup plan",
+		"duplicate_groups", count,
+		"dry_run", dryRun,
+		"batch_size", batchSize,
+		"limit_cap", limit)
+
+	if count == 0 {
+		logger.Info("no case-variant duplicate repos — nothing to merge. " +
+			"Run `aveloxis migrate --skip-views` to build the uq_repos_repo_git_ci backstop if it doesn't exist yet.")
+		return nil
+	}
+
+	if dryRun {
+		sample, err := db.SampleCaseVariantRepoDups(ctx, store, 20)
+		if err != nil {
+			return fmt.Errorf("sample duplicate pairs: %w", err)
+		}
+		logger.Info("=== sample plan (first 20 pairs) ===")
+		for _, p := range sample {
+			logger.Info("  duplicate pair",
+				"winner_id", p.WinnerID, "winner_git", p.WinnerGit,
+				"loser_id", p.LoserID, "loser_git", p.LoserGit,
+				"group_size", p.GroupSize,
+				"winner_last_collected", fmtNullableTime(p.WinnerLastCollected),
+				"loser_last_collected", fmtNullableTime(p.LoserLastCollected),
+				"collecting_now", p.Collecting)
+		}
+		logger.Info("dry-run complete — no changes written. Re-run without --dry-run to apply.")
+		return nil
+	}
+
+	merged := 0
+	skipped := 0
+	startedAt := time.Now()
+	for {
+		if limit > 0 && merged >= limit {
+			logger.Info("hit --limit cap, stopping", "merged", merged, "limit", limit)
+			break
+		}
+		thisBatch := batchSize
+		if limit > 0 && merged+thisBatch > limit {
+			thisBatch = limit - merged
+		}
+
+		batchMerged, batchSkipped, err := db.DedupCaseVariantReposBatch(ctx, store, thisBatch)
+		merged += batchMerged
+		skipped = batchSkipped // per-round snapshot; skipped pairs recur each round
+		if err != nil {
+			logger.Error("batch dedup errored mid-way — completed pairs are preserved",
+				"batch_merged", batchMerged, "total_merged", merged, "error", err)
+			return err
+		}
+		logger.Info("batch complete",
+			"batch_merged", batchMerged,
+			"skipped_collecting", batchSkipped,
+			"total_merged", merged,
+			"elapsed", time.Since(startedAt).Round(time.Second))
+
+		if batchMerged == 0 {
+			break
+		}
+	}
+
+	logger.Info("v0.25.32 case-variant repo dedup complete",
+		"merged", merged,
+		"skipped_collecting", skipped,
+		"duration", time.Since(startedAt).Round(time.Second))
+	if skipped > 0 {
+		logger.Info("some pairs were mid-collection and skipped — re-run once those jobs finish",
+			"skipped_collecting", skipped)
+	}
+	if merged > 0 {
+		logger.Info("next steps: `aveloxis migrate --skip-views` builds the unique-index backstop; " +
+			"`aveloxis refresh-views` rebuilds matviews so analytics stop double-counting")
+	}
+	return nil
+}
+
+// fmtNullableTime renders a nullable timestamp for dry-run output.
+func fmtNullableTime(t *time.Time) string {
+	if t == nil {
+		return "never"
+	}
+	return t.Format("2006-01-02")
+}

--- a/cmd/aveloxis/dedup_repos_test.go
+++ b/cmd/aveloxis/dedup_repos_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the `aveloxis dedup-repos` command wiring
+// (v0.25.32). Mirrors the merge_cntrb_collisions_test.go style: pin the
+// registration, flag surface, and db-layer call sites so a refactor
+// can't silently disconnect the command from the store implementation.
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func readDedupReposSources(t *testing.T) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, f := range []string{"dedup_repos.go", "../../internal/db/repo_dedup.go"} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		sb.Write(b)
+	}
+	return sb.String()
+}
+
+func TestDedupReposCommandRegistered(t *testing.T) {
+	mainSrc, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	if !strings.Contains(string(mainSrc), "dedupReposCmd(&cfgPath)") {
+		t.Error("main.go must register dedupReposCmd in the root.AddCommand block — " +
+			"without registration the operator cannot invoke `aveloxis dedup-repos`.")
+	}
+}
+
+func TestDedupReposFlagSurface(t *testing.T) {
+	src, err := os.ReadFile("dedup_repos.go")
+	if err != nil {
+		t.Fatalf("read dedup_repos.go: %v", err)
+	}
+	code := string(src)
+
+	for _, needle := range []string{`"dry-run"`, `"batch-size"`, `"limit"`, `"dedup-repos"`} {
+		if !strings.Contains(code, needle) {
+			t.Errorf("dedup_repos.go must declare %s — the operator workflow is "+
+				"`--dry-run` first, then a `--limit N` canary, then the full run.", needle)
+		}
+	}
+}
+
+func TestDedupReposCallsStoreFunctions(t *testing.T) {
+	combined := readDedupReposSources(t)
+
+	for _, fn := range []string{
+		"CountCaseVariantRepoDups",
+		"SampleCaseVariantRepoDups",
+		"DedupCaseVariantReposBatch",
+	} {
+		if !strings.Contains(combined, fn) {
+			t.Errorf("dedup-repos must be wired to db.%s — count → dry-run sample → "+
+				"batched merge loop is the merge-cntrb-collisions command shape this "+
+				"mirrors.", fn)
+		}
+	}
+}
+
+// v0.21.5 contract: only serve + migrate run store.Migrate.
+func TestDedupReposDoesNotMigrate(t *testing.T) {
+	src, err := os.ReadFile("dedup_repos.go")
+	if err != nil {
+		t.Fatalf("read dedup_repos.go: %v", err)
+	}
+	// Strip // line comments so the explanatory "intentionally NOT
+	// called" comment at the call-site can't false-match the very
+	// pattern it documents (same approach as
+	// migrate_only_serve_and_migrate_test.go).
+	var code strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	if strings.Contains(code.String(), "store.Migrate(") {
+		t.Error("dedup-repos must NOT call store.Migrate — per the v0.21.5 contract " +
+			"only `serve` and `migrate` run schema migrations.")
+	}
+}

--- a/cmd/aveloxis/main.go
+++ b/cmd/aveloxis/main.go
@@ -74,6 +74,7 @@ func main() {
 		migrateCmd(&cfgPath),
 		migrateCntrbIDsCmd(&cfgPath),
 		mergeCntrbCollisionsCmd(&cfgPath),
+		dedupReposCmd(&cfgPath),
 		refreshViewsCmd(&cfgPath),
 		installToolsCmd(),
 		upgradeToolsCmd(),

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -332,8 +332,11 @@ Per pair, winner = the **oldest** `repo_id`, in one transaction:
    referenced either variant keeps the repo and immediately sees the
    winner's collected data.
 2. Repoints shared-copy rows (`messages`, `email_message`,
-   `commit_comment_ref`, `contributor_repo`, `foundation_membership`) —
-   these tables are globally unique, so the pair shares one copy.
+   `commit_comment_ref`, `foundation_membership`) — these tables are
+   globally unique, so the pair shares one copy. (`contributor_repo` is
+   deliberately untouched: it is the breadth worker's observational
+   record of contributors' GitHub-wide activity, keyed by the numeric
+   `gh_repo_id`, not a catalog reference.)
 3. Deletes the loser's duplicated child data (issues, PRs, commits,
    releases, dependency scans, ...) leaves-first, then the loser row
    itself. Nothing is lost: both sides collected the same repository.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -301,6 +301,62 @@ Safe to run repeatedly. All DDL uses `CREATE ... IF NOT EXISTS` and inserts use 
 
 ---
 
+## `aveloxis dedup-repos`
+
+Merges case-variant duplicate repositories (v0.25.32). GitHub and GitLab
+treat owner/repo URLs case-insensitively, so
+`github.com/azure/azure-sdk-tools` and `github.com/Azure/azure-sdk-tools`
+are the **same repository** — but fleets that predate v0.25.32 could
+accumulate both as separate rows, each collected in full (doubled API
+budget, storage, and double-counted analytics).
+
+```bash
+aveloxis dedup-repos --dry-run      # show the plan (first 20 pairs)
+aveloxis dedup-repos --limit 50     # canary batch
+aveloxis dedup-repos                # full run — re-run until "0 pairs"
+```
+
+### Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--dry-run` | false | Print the merge plan without writing. Shows winner/loser URLs + repo_ids, per-side last-collected dates, and whether either side is mid-collection. |
+| `--batch-size` | 50 | Pairs merged per batch. Each pair is one heavy transaction (repoints + child-data deletes). |
+| `--limit` | 0 | Cap total pairs merged this run (0 = no cap). |
+
+### What each merge does
+
+Per pair, winner = the **oldest** `repo_id`, in one transaction:
+
+1. Repoints `user_repos` to the winner — every user group that
+   referenced either variant keeps the repo and immediately sees the
+   winner's collected data.
+2. Repoints shared-copy rows (`messages`, `email_message`,
+   `commit_comment_ref`, `contributor_repo`, `foundation_membership`) —
+   these tables are globally unique, so the pair shares one copy.
+3. Deletes the loser's duplicated child data (issues, PRs, commits,
+   releases, dependency scans, ...) leaves-first, then the loser row
+   itself. Nothing is lost: both sides collected the same repository.
+4. Enqueues the winner if it has never been collected.
+
+Pairs with either side `status='collecting'` are **skipped and
+reported** — re-run once those jobs finish. The command is idempotent;
+merged pairs drop out of the candidate set.
+
+### After the run
+
+```bash
+aveloxis migrate --skip-views   # builds uq_repos_repo_git_ci — the permanent
+                                # DB-level backstop (skipped with a WARN while
+                                # duplicates remain)
+aveloxis refresh-views          # matviews stop double-counting immediately
+```
+
+Generic-git repos (platform 3) are never touched: unknown hosts may
+legitimately be case-sensitive, so their URLs stay byte-exact.
+
+---
+
 ## `aveloxis refresh-views`
 
 Manually refreshes all 19 materialized views.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1294,6 +1294,66 @@ If you still see them after upgrading, ensure both `aveloxis migrate` AND `avelo
 
 ---
 
+## Case-variant duplicate repositories
+
+**Symptom:** the same repository appears twice in the catalog and on
+dashboards under different casings — e.g. `repo_id 6000
+https://github.com/Azure/azure-rest-api-specs` AND `repo_id 94177
+https://github.com/azure/azure-rest-api-specs` — with both rows fully
+collected. Analytics double-count the repo, and every collection cycle
+burns twice the API budget on it.
+
+**Cause:** GitHub and GitLab treat owner/repo URL paths
+case-insensitively (both casings serve HTTP 200 with **no redirect**, so
+prelim's redirect-based dedup never fires), but before v0.25.32
+`repos.repo_git` matching was byte-exact everywhere — `UpsertRepo`,
+`FindRepoByURL`, and the web bulk-paste path all missed the existing row
+when a URL arrived with different casing and created a second full repo.
+
+**Diagnosis:**
+
+```sql
+SELECT LOWER(repo_git) AS repo, COUNT(*) AS variants
+FROM aveloxis_data.repos
+WHERE platform_id IN (1, 2)
+GROUP BY LOWER(repo_git)
+HAVING COUNT(*) > 1
+ORDER BY repo;
+```
+
+Zero rows means you're clean. `aveloxis migrate` also reports this
+state: while duplicates remain it logs
+
+```
+msg="case-variant duplicate repos present; skipping unique index uq_repos_repo_git_ci"
+  duplicate_groups=N hint="run `aveloxis dedup-repos` to merge them, then re-run `aveloxis migrate`"
+```
+
+**Fix sequence (v0.25.32+):**
+
+```bash
+aveloxis stop serve                 # optional — dedup-repos skips mid-flight
+                                    # pairs, but a quiet window drains all in one run
+aveloxis migrate --skip-views       # creates the LOWER(repo_git) lookup index;
+                                    # WARNs + skips the unique index while dups remain
+aveloxis dedup-repos --dry-run      # review the plan
+aveloxis dedup-repos --limit 50     # canary, then:
+aveloxis dedup-repos                # full run — repeat until "0 pairs"
+aveloxis migrate --skip-views       # now builds uq_repos_repo_git_ci (the backstop)
+aveloxis refresh-views              # matviews stop double-counting immediately
+aveloxis start all
+```
+
+Prevention is active from v0.25.32 regardless of cleanup state:
+`UpsertRepo`/`FindRepoByURL`/web paste resolve case variants to the
+existing row, and the Phase 0 self-heal corrects any stored casing that
+differs from the forge's canonical spelling. The unique index is the
+final DB-level guarantee once the fleet is clean. Generic-git repos
+(platform 3) deliberately stay byte-exact — unknown hosts may be
+case-sensitive.
+
+---
+
 ## Orphaned postgres backend after `aveloxis stop serve`
 
 **Symptom:** After stopping serve and starting it again (or running `aveloxis migrate`), the new process appears to hang. Specifically:

--- a/internal/collector/prelim.go
+++ b/internal/collector/prelim.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/aveloxis/aveloxis/internal/db"
 	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/aveloxis/aveloxis/internal/platform"
 )
 
 // PrelimResult describes what the prelim phase found.
@@ -118,13 +119,16 @@ func RunPrelim(ctx context.Context, store *db.PostgresStore, repo *model.Repo, l
 
 	// Update the repo struct so collection uses the new URL.
 	repo.GitURL = finalURL
-	// Re-parse owner/name from new URL if it changed.
-	newOwner, newName := parseOwnerName(finalURL)
-	if newOwner != "" {
-		repo.Owner = newOwner
-	}
-	if newName != "" {
-		repo.Name = newName
+	// Re-parse owner/name from the new URL (shared parser, v0.25.32).
+	// On parse failure the old owner/name are kept — same guard the
+	// deleted inline parseOwnerName provided via empty returns.
+	if ru, perr := platform.ParseAnyRepoURL(finalURL); perr == nil {
+		if ru.Owner != "" {
+			repo.Owner = ru.Owner
+		}
+		if ru.Repo != "" {
+			repo.Name = ru.Repo
+		}
 	}
 
 	return result, nil
@@ -195,18 +199,6 @@ func normalizeRepoURL(u string) string {
 	return strings.ToLower(u)
 }
 
-// parseOwnerName extracts owner and repo name from a URL like https://github.com/owner/repo.
-func parseOwnerName(u string) (owner, name string) {
-	u = strings.TrimPrefix(u, "https://")
-	u = strings.TrimPrefix(u, "http://")
-	u = strings.TrimSuffix(u, "/")
-	u = strings.TrimSuffix(u, ".git")
-	parts := strings.Split(u, "/")
-	if len(parts) < 3 {
-		return "", ""
-	}
-	// parts[0] = host, parts[1..n-1] = owner path, parts[n] = repo name
-	name = parts[len(parts)-1]
-	owner = strings.Join(parts[1:len(parts)-1], "/")
-	return owner, name
-}
+// The inline parseOwnerName helper that used to live here was
+// consolidated into platform.ParseAnyRepoURL (v0.25.32) — one shared
+// owner/name parser for prelim, the web store, and URL rewrites.

--- a/internal/collector/prelim_edge_test.go
+++ b/internal/collector/prelim_edge_test.go
@@ -44,58 +44,9 @@ func TestNormalizeRepoURL_HTTPOnly(t *testing.T) {
 	}
 }
 
-// ============================================================
-// parseOwnerName edge cases (beyond prelim_test.go coverage)
-// ============================================================
-
-func TestParseOwnerName_DeeplyNested(t *testing.T) {
-	owner, name := parseOwnerName("https://gitlab.com/a/b/c/d/project")
-	if owner != "a/b/c/d" {
-		t.Errorf("deeply nested owner = %q, want a/b/c/d", owner)
-	}
-	if name != "project" {
-		t.Errorf("name = %q", name)
-	}
-}
-
-func TestParseOwnerName_WithDotGit(t *testing.T) {
-	owner, name := parseOwnerName("https://github.com/org/repo.git")
-	if owner != "org" {
-		t.Errorf("owner = %q", owner)
-	}
-	if name != "repo" {
-		t.Errorf("name with .git = %q, want repo", name)
-	}
-}
-
-func TestParseOwnerName_TrailingSlash(t *testing.T) {
-	owner, name := parseOwnerName("https://github.com/org/repo/")
-	if owner != "org" || name != "repo" {
-		t.Errorf("trailing slash: owner=%q name=%q", owner, name)
-	}
-}
-
-func TestParseOwnerName_HostOnly(t *testing.T) {
-	owner, name := parseOwnerName("github.com")
-	if owner != "" || name != "" {
-		t.Errorf("host only: owner=%q name=%q", owner, name)
-	}
-}
-
-func TestParseOwnerName_HostAndOwnerOnly(t *testing.T) {
-	// Only 2 path segments — not enough for owner + name.
-	owner, name := parseOwnerName("https://github.com/org")
-	if owner != "" || name != "" {
-		t.Errorf("host+owner only: owner=%q name=%q", owner, name)
-	}
-}
-
-func TestParseOwnerName_Empty(t *testing.T) {
-	owner, name := parseOwnerName("")
-	if owner != "" || name != "" {
-		t.Errorf("empty: owner=%q name=%q", owner, name)
-	}
-}
+// The parseOwnerName edge-case tests that used to live here moved to
+// internal/platform/repourl_any_test.go when the inline parser was
+// consolidated into platform.ParseAnyRepoURL (v0.25.32).
 
 // ============================================================
 // PrelimResult field combinations

--- a/internal/collector/prelim_test.go
+++ b/internal/collector/prelim_test.go
@@ -25,31 +25,9 @@ func TestNormalizeRepoURL(t *testing.T) {
 	}
 }
 
-func TestParseOwnerName(t *testing.T) {
-	tests := []struct {
-		url       string
-		wantOwner string
-		wantName  string
-	}{
-		{"https://github.com/torvalds/linux", "torvalds", "linux"},
-		{"https://github.com/chaoss/augur.git", "chaoss", "augur"},
-		{"https://gitlab.com/group/subgroup/project", "group/subgroup", "project"},
-		{"https://gitlab.com/a/b/c/d", "a/b/c", "d"},
-		// Too few segments.
-		{"https://github.com/", "", ""},
-		{"https://github.com", "", ""},
-	}
-
-	for _, tt := range tests {
-		owner, name := parseOwnerName(tt.url)
-		if owner != tt.wantOwner {
-			t.Errorf("parseOwnerName(%q) owner = %q, want %q", tt.url, owner, tt.wantOwner)
-		}
-		if name != tt.wantName {
-			t.Errorf("parseOwnerName(%q) name = %q, want %q", tt.url, name, tt.wantName)
-		}
-	}
-}
+// TestParseOwnerName moved to internal/platform/repourl_any_test.go
+// (TestParseAnyRepoURL_ForgeURLs) when the inline parser was consolidated
+// into platform.ParseAnyRepoURL (v0.25.32).
 
 func TestNormalizeRepoURL_DetectsRedirect(t *testing.T) {
 	// Simulate a redirect: old URL and new URL should normalize differently

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -248,6 +248,23 @@ func (sc *StagedCollector) CollectRepo(ctx context.Context, repoID int64, owner,
 			sc.logger.Warn("failed to update repos.repo_description/primary_language/languages",
 				"owner", owner, "repo", repo, "error", updateErr)
 		}
+
+		// v0.25.32: case self-heal. The forge returns the CANONICAL
+		// owner/name spelling regardless of the casing we queried with;
+		// when the stored value differs only by case, correct repo_git/
+		// repo_owner/repo_name via the rename machinery. Real renames
+		// stay prelim's job (HealRepoCaseDrift enforces the case-only
+		// gate). Non-fatal: cosmetic case drift must never fail a
+		// collection job, so failures log and continue.
+		if info.FullName != "" {
+			if healed, healErr := sc.store.HealRepoCaseDrift(ctx, repoID, info.FullName); healErr != nil {
+				sc.logger.Warn("case-drift self-heal failed",
+					"owner", owner, "repo", repo, "error", healErr)
+			} else if healed {
+				sc.logger.Info("healed repo case drift",
+					"repo_id", repoID, "canonical", info.FullName)
+			}
+		}
 	}
 
 	for rel, relErr := range sc.client.ListReleases(ctx, owner, repo) {

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -1425,9 +1425,11 @@ func (p *Processor) processOne(ctx context.Context, repoID int64, platID int16, 
 		rc.Message.RepoID = repoID
 		rc.Comment.RepoID = repoID
 		rc.Message.ContributorID = p.resolveUser(ctx, platID, rc.Message.AuthorRef)
-		// Resolve platform review ID to DB pr_review_id.
+		// Resolve platform review ID to DB pr_review_id — repo-scoped
+		// (v0.25.33): the parent review must belong to this repo, or a
+		// case-variant duplicate pair gets cross-linked bridge rows.
 		if rc.Comment.PlatformReviewID != 0 {
-			dbID, err := p.store.FindReviewDBID(ctx, rc.Comment.PlatformReviewID)
+			dbID, err := p.store.FindReviewDBID(ctx, repoID, rc.Comment.PlatformReviewID)
 			if err == nil && dbID != 0 {
 				rc.Comment.ReviewID = dbID
 			}

--- a/internal/collector/staged_case_heal_test.go
+++ b/internal/collector/staged_case_heal_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the Phase 0 case self-heal hook (v0.25.32).
+
+package collector
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStagedPhase0CallsHealRepoCaseDrift(t *testing.T) {
+	src, err := os.ReadFile("staged.go")
+	if err != nil {
+		t.Fatalf("read staged.go: %v", err)
+	}
+	code := string(src)
+
+	healIdx := strings.Index(code, "HealRepoCaseDrift(")
+	if healIdx < 0 {
+		t.Fatal("staged.go Phase 0 must call store.HealRepoCaseDrift after a " +
+			"successful FetchRepoInfo — the forge-reported FullName is the canonical " +
+			"spelling that corrects case-drifted repo_git values (including dedup " +
+			"survivors whose older row happened to be the wrong-cased one).")
+	}
+
+	// The heal must be gated on the FullName being present and must run
+	// AFTER FetchRepoInfo in the file.
+	fetchIdx := strings.Index(code, "FetchRepoInfo(ctx, owner, repo)")
+	if fetchIdx < 0 {
+		t.Fatal("FetchRepoInfo call site not found — Phase 0 moved?")
+	}
+	if healIdx < fetchIdx {
+		t.Error("HealRepoCaseDrift must run after FetchRepoInfo (it consumes " +
+			"info.FullName).")
+	}
+	if !strings.Contains(code, "info.FullName") {
+		t.Error("the heal hook must consume info.FullName (guarded on non-empty).")
+	}
+
+	// Non-fatal contract: the heal failure path must log, not append to
+	// result.Errors — a failed case-heal must never fail a collection job.
+	window := code[healIdx:min(len(code), healIdx+600)]
+	if strings.Contains(window, "result.Errors") {
+		t.Error("HealRepoCaseDrift failures must be non-fatal (log-and-continue), " +
+			"never appended to result.Errors — cosmetic case drift must not fail " +
+			"collection jobs.")
+	}
+}

--- a/internal/db/find_review_dbid_scoped_test.go
+++ b/internal/db/find_review_dbid_scoped_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// v0.25.33: FindReviewDBID must be repo-scoped. The pre-v0.25.33
+// signature took only the platform review ID and looked it up globally
+// — on a case-variant duplicate pair the same platform_review_id exists
+// under BOTH repo_ids and the lookup returned an arbitrary copy,
+// creating cross-repo bridge rows (winner review_comments pointing at
+// loser reviews). Those cross-links are what broke the first production
+// dedup-repos run. Scoping the lookup by repo_id makes it impossible to
+// create new ones; `aveloxis dedup-repos` remaps the historical ones.
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindReviewDBIDIsRepoScoped(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "FindReviewDBID")
+
+	if !strings.Contains(body, "repoID") {
+		t.Fatal("FindReviewDBID must take a repoID parameter — the global lookup is " +
+			"ambiguous whenever the same repository exists under two repo_ids and " +
+			"silently creates cross-repo review bridge rows.")
+	}
+	if !strings.Contains(normWS(body), "repo_id = $") {
+		t.Error("FindReviewDBID's SQL must filter on repo_id — the comment's parent " +
+			"review MUST belong to the same repo as the comment.")
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -333,6 +333,29 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	// /issues, /pulls). One-time cleanup; idempotent.
 	cleanupRepoNameGitSuffix(ctx, pg, logger)
 
+	// repos.repo_git case-insensitive matching (v0.25.32). GitHub and
+	// GitLab treat owner/repo paths case-insensitively, so case-variant
+	// URLs are the SAME repository — byte-exact matching let the same
+	// repo in twice under different casing (1,220 duplicate pairs on the
+	// production fleet, each collected in full twice). Two indexes with
+	// different contracts:
+	//
+	// idx_repos_repo_git_lower (non-unique, FAIL-CLOSED) serves the
+	// LOWER(repo_git) lookups in FindRepoByURL / resolveCaseVariantURL —
+	// without it each lookup sequential-scans the repos table.
+	execCreateIndexConcurrently(ctx, pg, logger, &errs,
+		"aveloxis_data", "idx_repos_repo_git_lower",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_repo_git_lower
+		ON aveloxis_data.repos (LOWER(repo_git))`)
+
+	// uq_repos_repo_git_ci (UNIQUE partial, WARN-ONLY) is the hard
+	// backstop against future case-variant duplicates. It can only be
+	// created once the fleet has zero case-dup groups — operators run
+	// `aveloxis dedup-repos` first, then re-run migrate. Per the
+	// CLAUDE.md schema-DDL-ordering rule the index is NOT declared in
+	// schema.sql (CREATE UNIQUE INDEX fails on existing duplicates).
+	ensureRepoGitCaseInsensitiveUnique(ctx, pg, logger)
+
 	// pg_trgm extension + GIN index on repos for monitor search
 	// (v0.18.30). The dashboard's `?q=foo/bar` ILIKE search at v0.18.29
 	// was unindexable (leading wildcard). With pg_trgm + a GIN index on
@@ -1570,6 +1593,84 @@ func deduplicateCommits(ctx context.Context, pg *PostgresStore, logger *slog.Log
 	if err != nil {
 		logger.Warn("failed to create commits unique index", "error", err)
 	}
+}
+
+// ensureRepoGitCaseInsensitiveUnique creates the UNIQUE partial index
+// uq_repos_repo_git_ci ON aveloxis_data.repos (LOWER(repo_git)) WHERE
+// platform_id IN (1, 2) — the hard backstop that prevents case-variant
+// duplicate repositories (GitHub/GitLab treat owner/repo paths
+// case-insensitively; generic git hosts on platform 3 may legitimately
+// be case-sensitive, so they are excluded and stay byte-exact-unique via
+// the existing repos.repo_git UNIQUE constraint).
+//
+// Create-after-cleanup contract (mirrors deduplicateCommits, per the
+// CLAUDE.md schema-DDL-ordering rule): the index is NOT in schema.sql
+// and is only created once the fleet has ZERO case-dup groups. Unlike
+// deduplicateCommits this function does NOT delete the duplicates itself
+// — a duplicate repo pair carries full child-data trees whose merge is
+// the operator-invoked `aveloxis dedup-repos` command's job. While
+// duplicates remain, this function WARNs (naming the command) and skips.
+//
+// Deliberately warn-only (no *errs collector): a fleet with pending
+// duplicates must still be able to start serve. The application-level
+// resolution in FindRepoByURL/resolveCaseVariantURL keeps prevention
+// best-effort until the index lands; the next migrate run after
+// dedup-repos drains creates it.
+func ensureRepoGitCaseInsensitiveUnique(ctx context.Context, pg *PostgresStore, logger *slog.Logger) {
+	// Fast path: a VALID index already exists — nothing to do.
+	var existsValid bool
+	pg.pool.QueryRow(ctx, `
+		SELECT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'aveloxis_data' AND c.relname = 'uq_repos_repo_git_ci'`).Scan(&existsValid)
+	if existsValid {
+		return
+	}
+
+	// Gate on remaining case-variant duplicates: attempting the CREATE
+	// with duplicates present would fail and leave an INVALID index.
+	var dupGroups int
+	if err := pg.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT 1
+			FROM aveloxis_data.repos
+			WHERE platform_id IN (1, 2)
+			GROUP BY LOWER(repo_git)
+			HAVING COUNT(*) > 1
+		) dup`).Scan(&dupGroups); err != nil {
+		logger.Warn("could not count case-variant duplicate repos; skipping uq_repos_repo_git_ci", "error", err)
+		return
+	}
+	if dupGroups > 0 {
+		logger.Warn("case-variant duplicate repos present; skipping unique index uq_repos_repo_git_ci",
+			"duplicate_groups", dupGroups,
+			"hint", "run `aveloxis dedup-repos` to merge them, then re-run `aveloxis migrate`")
+		return
+	}
+
+	// Drop an INVALID leftover from a prior interrupted CONCURRENTLY
+	// build, then create. Same recovery shape as deduplicateCommits.
+	var existsInvalid bool
+	pg.pool.QueryRow(ctx, `
+		SELECT NOT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'aveloxis_data' AND c.relname = 'uq_repos_repo_git_ci'`).Scan(&existsInvalid)
+	if existsInvalid {
+		logger.Warn("dropping invalid uq_repos_repo_git_ci from prior interrupted CONCURRENT build")
+		pg.pool.Exec(ctx, `DROP INDEX IF EXISTS aveloxis_data.uq_repos_repo_git_ci`)
+	}
+	if _, err := pg.pool.Exec(ctx, `
+		CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_repos_repo_git_ci
+		ON aveloxis_data.repos (LOWER(repo_git))
+		WHERE platform_id IN (1, 2)`); err != nil {
+		logger.Warn("failed to create uq_repos_repo_git_ci", "error", err)
+		return
+	}
+	logger.Info("created case-insensitive unique index uq_repos_repo_git_ci — case-variant duplicate repos are now blocked at the database level")
 }
 
 // addColumnIfMissing runs ALTER TABLE ... ADD COLUMN IF NOT EXISTS for

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -998,6 +998,26 @@ func RunMigrations(ctx context.Context, pg *PostgresStore, logger *slog.Logger) 
 	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_ops", "idx_staging_repo_id",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_staging_repo_id ON aveloxis_ops.staging (repo_id)`)
 
+	// v0.25.34: FK-side indexes on email_message's projection links
+	// (linked_issue_id / linked_pull_request_id / linked_pr_review_id).
+	// The columns arrived in v0.25.7, after the v0.22.6/v0.22.7 FK-index
+	// audits, and shipped unindexed. Their FKs are NO-ACTION DEFERRABLE:
+	// bulk deletes of issues/PRs/reviews (`aveloxis dedup-repos`) queue
+	// one deferred check per deleted parent row and run them AT COMMIT —
+	// each check a sequential scan of email_message without these.
+	// Observed on the 2026-07-08 production dedup run: 18+ minutes inside
+	// a single `commit` statement. Partial (IS NOT NULL) — the RI check
+	// predicate implies IS NOT NULL, and most emails carry no link.
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_email_message_linked_issue",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_linked_issue
+		ON aveloxis_data.email_message (linked_issue_id) WHERE linked_issue_id IS NOT NULL`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_email_message_linked_pr",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_linked_pr
+		ON aveloxis_data.email_message (linked_pull_request_id) WHERE linked_pull_request_id IS NOT NULL`)
+	execCreateIndexConcurrently(ctx, pg, logger, &errs, "aveloxis_data", "idx_email_message_linked_review",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_message_linked_review
+		ON aveloxis_data.email_message (linked_pr_review_id) WHERE linked_pr_review_id IS NOT NULL`)
+
 	// v0.23.0: contributor_login_history table + backfill. Closes the
 	// rename-audit gap documented as a v0.22.13 limitation
 	// ("Intermediate login history is NOT stored"). The CREATE TABLE

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -247,6 +247,24 @@ func (s *PostgresStore) UpsertRepo(ctx context.Context, r *model.Repo) (int64, e
 	// reaches the DB. API URLs built from repo_name (/repos/{owner}/{name}/...)
 	// 404 when the slug has a ".git" suffix.
 	r.Name = model.NormalizeRepoName(r.Name)
+
+	// Store repo_git without trailing "/" or ".git" (v0.25.32 hardening) —
+	// suffix variants would otherwise slip past both ON CONFLICT (repo_git)
+	// and the case-insensitive unique index and create duplicate rows.
+	r.GitURL = strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(r.GitURL), "/"), ".git")
+
+	// Case-variant resolution (v0.25.32): GitHub and GitLab treat
+	// owner/repo paths case-insensitively, so a URL differing from a
+	// stored row only by case is the SAME repository. Substitute the
+	// stored spelling so the ON CONFLICT below updates that row instead
+	// of inserting a duplicate. Lookup errors are deliberately ignored —
+	// the INSERT below surfaces any real connectivity problem.
+	if r.Platform == model.PlatformGitHub || r.Platform == model.PlatformGitLab {
+		if stored, rerr := s.resolveCaseVariantURL(ctx, r.GitURL); rerr == nil && stored != "" {
+			r.GitURL = stored
+		}
+	}
+
 	var id int64
 	err := s.withRetry(ctx, func(ctx context.Context) error {
 		// Ensure a default repo group exists if no group is specified.
@@ -277,7 +295,8 @@ func (s *PostgresStore) UpsertRepo(ctx context.Context, r *model.Repo) (int64, e
 			updatedAt = r.UpdatedAt
 		}
 
-		return s.pool.QueryRow(ctx, `
+		insert := func() error {
+			return s.pool.QueryRow(ctx, `
 			INSERT INTO aveloxis_data.repos
 				(repo_group_id, platform_id, repo_git, repo_name, repo_owner,
 				 repo_description, primary_language, forked_from, repo_archived,
@@ -294,10 +313,28 @@ func (s *PostgresStore) UpsertRepo(ctx context.Context, r *model.Repo) (int64, e
 				tool_version = EXCLUDED.tool_version,
 				data_collection_date = NOW()
 			RETURNING repo_id`,
-			groupID, int16(r.Platform), r.GitURL, r.Name, r.Owner,
-			r.Description, r.PrimaryLanguage, r.ForkedFrom, r.Archived,
-			r.PlatformID, createdAt, updatedAt, r.Platform.String()+" API",
-		).Scan(&id)
+				groupID, int16(r.Platform), r.GitURL, r.Name, r.Owner,
+				r.Description, r.PrimaryLanguage, r.ForkedFrom, r.Archived,
+				r.PlatformID, createdAt, updatedAt, r.Platform.String()+" API",
+			).Scan(&id)
+		}
+
+		err := insert()
+		// Unique-index race (v0.25.32): the pre-insert case resolution and
+		// the INSERT are not atomic. When uq_repos_repo_git_ci exists and a
+		// concurrent writer lands the other case variant between our resolve
+		// and our INSERT, the partial unique index rejects us with 23505 —
+		// re-resolve to the now-stored spelling and retry once, which routes
+		// the statement through ON CONFLICT (repo_git) DO UPDATE instead.
+		var pgErr *pgconn.PgError
+		if err != nil && errors.As(err, &pgErr) &&
+			pgErr.Code == "23505" && pgErr.ConstraintName == "uq_repos_repo_git_ci" {
+			if stored, rerr := s.resolveCaseVariantURL(ctx, r.GitURL); rerr == nil && stored != "" {
+				r.GitURL = stored
+				err = insert()
+			}
+		}
+		return err
 	})
 	return id, err
 }
@@ -441,10 +478,22 @@ func (s *PostgresStore) FindPRDBID(ctx context.Context, repoID, prNumber int64) 
 }
 
 // FindRepoByURL returns the repo_id for a given git URL, or 0 if not found.
+//
+// v0.25.32: matching is case-insensitive for GitHub/GitLab (platform 1/2)
+// because those forges treat owner/repo paths case-insensitively — a URL
+// differing from a stored row only by case IS the same repository. A
+// byte-exact match is preferred when both exist (a pre-dedup DB can hold
+// both case variants; the exact row is the caller's literal intent).
+// Generic git (platform 3) stays byte-exact on purpose: unknown hosts may
+// legitimately be case-sensitive.
 func (s *PostgresStore) FindRepoByURL(ctx context.Context, gitURL string) (int64, error) {
 	var id int64
-	err := s.pool.QueryRow(ctx,
-		`SELECT repo_id FROM aveloxis_data.repos WHERE repo_git = $1`, gitURL,
+	err := s.pool.QueryRow(ctx, `
+		SELECT repo_id FROM aveloxis_data.repos
+		WHERE repo_git = $1
+		   OR (LOWER(repo_git) = LOWER($1) AND platform_id IN (1, 2))
+		ORDER BY (repo_git = $1) DESC, repo_id
+		LIMIT 1`, gitURL,
 	).Scan(&id)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -453,6 +502,29 @@ func (s *PostgresStore) FindRepoByURL(ctx context.Context, gitURL string) (int64
 		return 0, err
 	}
 	return id, nil
+}
+
+// resolveCaseVariantURL returns the stored repo_git spelling of an
+// existing GitHub/GitLab row whose URL matches gitURL case-insensitively,
+// or "" when no such row exists. UpsertRepo substitutes the stored
+// spelling before its INSERT so ON CONFLICT (repo_git) targets the
+// existing row instead of creating a case-variant duplicate. The
+// platform_id IN (1, 2) gate keeps generic-git hosts byte-exact.
+func (s *PostgresStore) resolveCaseVariantURL(ctx context.Context, gitURL string) (string, error) {
+	var stored string
+	err := s.pool.QueryRow(ctx, `
+		SELECT repo_git FROM aveloxis_data.repos
+		WHERE LOWER(repo_git) = LOWER($1) AND platform_id IN (1, 2)
+		ORDER BY (repo_git = $1) DESC, repo_id
+		LIMIT 1`, gitURL,
+	).Scan(&stored)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return stored, nil
 }
 
 // ArchiveRepo marks a repo as archived/dead. Data is kept, but the repo
@@ -529,17 +601,18 @@ func extractRepoPath(u string) string {
 // UpdateRepoURL changes the git URL, owner, and name of a repo (e.g., after a redirect).
 // Extracts the new owner/name from the URL so the dashboard and API show correct values.
 func (s *PostgresStore) UpdateRepoURL(ctx context.Context, repoID int64, newURL string) error {
-	// Parse owner/name from the new URL.
+	// Parse owner/name from the new URL via the shared parser (v0.25.32
+	// consolidation; unparseable URLs keep empty owner/name — the URL
+	// column still updates, matching the historical permissiveness).
 	newURL = strings.TrimSuffix(strings.TrimSuffix(newURL, "/"), ".git")
-	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(newURL, "https://"), "http://"), "/")
 	owner := ""
 	name := ""
-	if len(parts) >= 3 {
-		name = parts[len(parts)-1]
-		owner = strings.Join(parts[1:len(parts)-1], "/")
+	if ru, perr := platform.ParseAnyRepoURL(newURL); perr == nil {
+		owner = ru.Owner
+		name = ru.Repo
 	}
-	// Defense in depth: even after TrimSuffix above, normalize the extracted
-	// slug so every write path produces the same canonical form.
+	// Defense in depth: even after the parser's trimming, normalize the
+	// extracted slug so every write path produces the same canonical form.
 	name = model.NormalizeRepoName(name)
 
 	_, err := s.pool.Exec(ctx,

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -441,12 +441,22 @@ func (s *PostgresStore) GetReposForRenameCheck(ctx context.Context, limit int) (
 	return repos, rows.Err()
 }
 
-// FindReviewDBID looks up the aveloxis DB pr_review_id from a platform review ID.
-func (s *PostgresStore) FindReviewDBID(ctx context.Context, platformReviewID int64) (int64, error) {
+// FindReviewDBID looks up the aveloxis DB pr_review_id for a platform
+// review ID within one repo.
+//
+// v0.25.33: repo-scoped. The pre-v0.25.33 global lookup returned an
+// ARBITRARY copy whenever the same repository existed under two
+// repo_ids (case-variant duplicates, pre-dedup), silently creating
+// cross-repo bridge rows — winner-owned review_comments pointing at
+// loser-owned reviews — which then broke `aveloxis dedup-repos` with
+// SQLSTATE 23503. A review comment's parent review MUST belong to the
+// same repo as the comment.
+func (s *PostgresStore) FindReviewDBID(ctx context.Context, repoID, platformReviewID int64) (int64, error) {
 	var id int64
 	err := s.pool.QueryRow(ctx,
-		`SELECT pr_review_id FROM aveloxis_data.pull_request_reviews WHERE platform_review_id = $1`,
-		platformReviewID).Scan(&id)
+		`SELECT pr_review_id FROM aveloxis_data.pull_request_reviews
+		 WHERE platform_review_id = $1 AND repo_id = $2`,
+		platformReviewID, repoID).Scan(&id)
 	if err != nil {
 		return 0, nil
 	}

--- a/internal/db/repo_case_heal.go
+++ b/internal/db/repo_case_heal.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// repo_case_heal.go — Phase 0 case self-heal (v0.25.32).
+//
+// GitHub and GitLab accept case-variant owner/repo lookups but always
+// RETURN the canonical spelling (nameWithOwner / full_name /
+// path_with_namespace). When a repo entered the catalog with
+// non-canonical casing (bulk paste, or a dedup-repos merge whose older
+// winner happened to be the wrong-cased row), the staged collector's
+// Phase 0 passes the forge-reported FullName here and the stored
+// repo_git/repo_owner/repo_name get corrected in place.
+//
+// Deliberate carve-out from the "prelim owns rename detection" design
+// decision: the forge treats case variants as the SAME resource, so a
+// case-only correction does not change repo identity — unlike a real
+// rename, where mutating identity mid-job risks split-identity data.
+// Anything that differs by more than case is therefore logged and left
+// for prelim's redirect handling.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// HealRepoCaseDrift corrects repos.repo_git / repo_owner / repo_name
+// when the forge-reported fullName ("owner/name", canonical casing)
+// differs from the stored values ONLY by case. Returns healed=true when
+// a correction was written. Safe no-op in every other situation.
+func (s *PostgresStore) HealRepoCaseDrift(ctx context.Context, repoID int64, fullName string) (healed bool, err error) {
+	if fullName == "" {
+		return false, nil
+	}
+
+	var gitURL, owner, name string
+	err = s.pool.QueryRow(ctx,
+		`SELECT repo_git, repo_owner, repo_name FROM aveloxis_data.repos WHERE repo_id = $1`,
+		repoID).Scan(&gitURL, &owner, &name)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("load repo %d: %w", repoID, err)
+	}
+
+	storedPath := owner + "/" + name
+	if storedPath == fullName {
+		return false, nil // already canonical
+	}
+	if !strings.EqualFold(storedPath, fullName) {
+		// More than case changed — a real rename/transfer. That is
+		// prelim's job (redirect detection at job start); mutating repo
+		// identity mid-collection risks split-identity data.
+		s.logger.Info("repo name differs from forge-canonical by more than case — leaving to prelim rename detection",
+			"repo_id", repoID, "stored", storedPath, "canonical", fullName)
+		return false, nil
+	}
+
+	// Rebuild the URL with the canonical path, preserving scheme + host.
+	scheme, host := schemeAndHost(gitURL)
+	if host == "" {
+		return false, fmt.Errorf("cannot derive host from stored repo_git %q", gitURL)
+	}
+	newURL := scheme + "://" + host + "/" + fullName
+	if newURL == gitURL {
+		return false, nil
+	}
+
+	// Occupancy guard: if ANOTHER row already holds the canonical URL,
+	// this is an unmerged case-variant duplicate pair — correcting this
+	// row would collide with it. Exact-match check excluding ourselves
+	// (NOT the case-insensitive FindRepoByURL, which would match the
+	// very row being healed).
+	var occupant int64
+	err = s.pool.QueryRow(ctx,
+		`SELECT repo_id FROM aveloxis_data.repos WHERE repo_git = $1 AND repo_id <> $2`,
+		newURL, repoID).Scan(&occupant)
+	if err == nil {
+		s.logger.Warn("canonical URL already tracked by another repo — case-variant duplicate pair",
+			"repo_id", repoID, "stored", gitURL,
+			"canonical_url", newURL, "occupant_repo_id", occupant,
+			"hint", "run `aveloxis dedup-repos` to merge the pair")
+		return false, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return false, fmt.Errorf("occupancy check for %q: %w", newURL, err)
+	}
+
+	// Reuse the rename machinery: updates repo_git/repo_owner/repo_name
+	// AND rewrites the owner/name path inside stored issue/PR/review/
+	// release URLs.
+	if err := s.UpdateRepoURLs(ctx, repoID, gitURL, newURL); err != nil {
+		return false, fmt.Errorf("update repo URLs %q -> %q: %w", gitURL, newURL, err)
+	}
+	s.logger.Info("healed repo case drift to forge-canonical spelling",
+		"repo_id", repoID, "old", gitURL, "new", newURL)
+	return true, nil
+}
+
+// schemeAndHost extracts the scheme (defaulting to https) and host from
+// a stored repo URL.
+func schemeAndHost(gitURL string) (scheme, host string) {
+	scheme = "https"
+	rest := gitURL
+	if s, r, found := strings.Cut(gitURL, "://"); found {
+		if s == "http" {
+			scheme = "http"
+		}
+		rest = r
+	}
+	host, _, _ = strings.Cut(rest, "/")
+	return scheme, host
+}

--- a/internal/db/repo_case_heal_test.go
+++ b/internal/db/repo_case_heal_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for HealRepoCaseDrift (v0.25.32) — the Phase 0
+// self-heal that corrects a repo's stored URL casing when the forge
+// reports a canonical spelling that differs ONLY by case. Real renames
+// (more than case) stay prelim's job: the forge treats case variants as
+// the same resource, so a case-only change does not change identity —
+// unlike a rename, where mutating repo identity mid-job risks
+// split-identity data (the documented prelim-owns-renames decision).
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHealRepoCaseDriftContract(t *testing.T) {
+	body := extractFunctionBody(t, "repo_case_heal.go", "HealRepoCaseDrift")
+
+	if !strings.Contains(body, "EqualFold") {
+		t.Error("HealRepoCaseDrift must gate on strings.EqualFold — anything that " +
+			"differs by MORE than case is a real rename and stays prelim's job.")
+	}
+	if !strings.Contains(body, "UpdateRepoURLs(") {
+		t.Error("HealRepoCaseDrift must reuse UpdateRepoURLs — the existing rename " +
+			"machinery that also rewrites stored issue/PR html_urls; do not invent a " +
+			"parallel URL-rewrite path.")
+	}
+	if !strings.Contains(body, "repo_id <>") && !strings.Contains(body, "repo_id !=") {
+		t.Error("HealRepoCaseDrift must run an exact-match occupancy check excluding " +
+			"the repo itself (repo_git = $newURL AND repo_id <> $repoID) — NOT the " +
+			"case-insensitive FindRepoByURL, which would match the very row being " +
+			"healed.")
+	}
+	if !strings.Contains(body, "dedup-repos") {
+		t.Error("when the canonical URL is already occupied by ANOTHER row (an " +
+			"unmerged duplicate pair), HealRepoCaseDrift must WARN with the " +
+			"`aveloxis dedup-repos` hint and skip — never collide two rows itself.")
+	}
+}

--- a/internal/db/repo_case_integration_test.go
+++ b/internal/db/repo_case_integration_test.go
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// Integration tests for the v0.25.32 case-variant duplicate-repo
+// prevention layer. Gated on AVELOXIS_TEST_DB (scratch DB only — see
+// docs/guide/ci-cd.md for the local recipe). Covers:
+//
+//   - UpsertRepo resolving a case-variant URL to the existing row
+//     (same repo_id, one row per LOWER(repo_git) key).
+//   - FindRepoByURL preferring a byte-exact match on a pre-dedup DB
+//     that holds both variants, and falling back deterministically.
+//   - Generic git (platform 3) staying byte-exact on purpose.
+//   - HealRepoCaseDrift correcting case drift and refusing to collide
+//     with an existing occupant.
+//   - The cross-user sharing contract: a second group adding a case
+//     variant of an already-tracked repo links the SHARED repo_id.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+func caseConnect(t *testing.T) (context.Context, *PostgresStore) {
+	t.Helper()
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store, err := NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(store.Close)
+	store.SetMatviewSkip(true)
+	if err := RunMigrations(ctx, store, logger); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	return ctx, store
+}
+
+// cleanupCaseRepos removes every test repo whose URL carries the given
+// slug, including queue/user_repos leftovers from prior runs.
+func cleanupCaseRepos(ctx context.Context, t *testing.T, store *PostgresStore, slug string) {
+	t.Helper()
+	like := "%" + slug + "%"
+	for _, sql := range []string{
+		`DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_ops.user_repos WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.repos WHERE repo_git ILIKE $1`,
+	} {
+		if _, err := store.pool.Exec(ctx, sql, like); err != nil {
+			t.Logf("cleanup (non-fatal): %v", err)
+		}
+	}
+}
+
+func TestUpsertRepoCaseVariantResolvesToSameRow(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avcase_upsert"
+	cleanupCaseRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupCaseRepos(ctx, t, store, slug) })
+
+	id1, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGitHub,
+		GitURL:   "https://github.com/" + slug + "_Org/Repo",
+		Owner:    slug + "_Org", Name: "Repo",
+	})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	id2, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGitHub,
+		GitURL:   "https://github.com/" + strings.ToLower(slug+"_Org/Repo"),
+		Owner:    strings.ToLower(slug + "_Org"), Name: "repo",
+	})
+	if err != nil {
+		t.Fatalf("case-variant upsert: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("case-variant upsert created a second row: %d vs %d — the "+
+			"resolveCaseVariantURL substitution is not firing", id1, id2)
+	}
+
+	var count int
+	if err := store.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.repos WHERE LOWER(repo_git) = LOWER($1)`,
+		"https://github.com/"+slug+"_Org/Repo").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 repos row for the LOWER key, got %d", count)
+	}
+}
+
+func TestFindRepoByURLCaseFallbackAndExactPreference(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avcase_find"
+	cleanupCaseRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupCaseRepos(ctx, t, store, slug) })
+
+	gid := defaultRepoGroup(ctx, t, store)
+	dropCaseUniqueIndex(ctx, t, store)
+
+	// Seed BOTH variants directly (bypassing UpsertRepo's resolution) —
+	// exactly the pre-dedup production state.
+	var upperID, lowerID int64
+	upperURL := "https://github.com/" + slug + "_Org/Repo"
+	lowerURL := strings.ToLower(upperURL)
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'Repo', $3) RETURNING repo_id`, gid, upperURL, slug+"_Org").Scan(&upperID); err != nil {
+		t.Fatalf("seed upper: %v", err)
+	}
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'repo', $3) RETURNING repo_id`, gid, lowerURL, strings.ToLower(slug+"_Org")).Scan(&lowerID); err != nil {
+		t.Fatalf("seed lower: %v", err)
+	}
+
+	// Byte-exact match wins when both variants exist.
+	if got, err := store.FindRepoByURL(ctx, lowerURL); err != nil || got != lowerID {
+		t.Fatalf("exact lower lookup = (%d, %v), want %d", got, err, lowerID)
+	}
+	if got, err := store.FindRepoByURL(ctx, upperURL); err != nil || got != upperID {
+		t.Fatalf("exact upper lookup = (%d, %v), want %d", got, err, upperID)
+	}
+
+	// A THIRD casing matches case-insensitively with the deterministic
+	// repo_id tiebreak (oldest row).
+	mixed := "https://github.com/" + strings.ToUpper(slug) + "_ORG/REPO"
+	if got, err := store.FindRepoByURL(ctx, mixed); err != nil || got != upperID {
+		t.Fatalf("mixed-case lookup = (%d, %v), want oldest row %d", got, err, upperID)
+	}
+}
+
+func TestGenericGitStaysByteExact(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avcase_generic"
+	cleanupCaseRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupCaseRepos(ctx, t, store, slug) })
+
+	url := "https://selfhosted.example.org/" + slug + "_Team/Repo"
+	id1, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGenericGit, GitURL: url,
+		Owner: slug + "_Team", Name: "Repo",
+	})
+	if err != nil {
+		t.Fatalf("generic upsert: %v", err)
+	}
+	id2, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGenericGit, GitURL: strings.ToLower(url),
+		Owner: strings.ToLower(slug + "_Team"), Name: "repo",
+	})
+	if err != nil {
+		t.Fatalf("generic case-variant upsert: %v", err)
+	}
+	if id1 == id2 {
+		t.Fatal("generic-git case variants must stay DISTINCT rows — unknown hosts " +
+			"may legitimately be case-sensitive (platform gate broke)")
+	}
+	if got, _ := store.FindRepoByURL(ctx, strings.ToUpper(url)); got != 0 {
+		t.Fatalf("generic-git lookup must be byte-exact; case-variant lookup returned %d", got)
+	}
+}
+
+func TestHealRepoCaseDriftEndToEnd(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avcase_heal"
+	cleanupCaseRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupCaseRepos(ctx, t, store, slug) })
+
+	// Happy path: stored casing differs from canonical only by case.
+	id, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGitHub,
+		GitURL:   "https://github.com/" + slug + "_wrong/CaSe",
+		Owner:    slug + "_wrong", Name: "CaSe",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := slug + "_Wrong/Case"
+	healed, err := store.HealRepoCaseDrift(ctx, id, canonical)
+	if err != nil {
+		t.Fatalf("heal: %v", err)
+	}
+	if !healed {
+		t.Fatal("expected healed=true for a case-only drift")
+	}
+	var gitURL, owner, name string
+	if err := store.pool.QueryRow(ctx,
+		`SELECT repo_git, repo_owner, repo_name FROM aveloxis_data.repos WHERE repo_id = $1`,
+		id).Scan(&gitURL, &owner, &name); err != nil {
+		t.Fatal(err)
+	}
+	if gitURL != "https://github.com/"+canonical || owner != slug+"_Wrong" || name != "Case" {
+		t.Fatalf("heal wrote (%q, %q, %q), want canonical spelling", gitURL, owner, name)
+	}
+
+	// Real rename (more than case) is refused.
+	if healed, err := store.HealRepoCaseDrift(ctx, id, slug+"_Wrong/renamed-project"); err != nil || healed {
+		t.Fatalf("real rename must be left to prelim: healed=%v err=%v", healed, err)
+	}
+
+	// Occupancy guard: another row already holds the canonical URL.
+	// (Seeding a real duplicate pair requires the pre-dedup state.)
+	dropCaseUniqueIndex(ctx, t, store)
+	gid := defaultRepoGroup(ctx, t, store)
+	var occupantID, driftedID int64
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'Repo', $3) RETURNING repo_id`,
+		gid, "https://github.com/"+slug+"_Occ/Repo", slug+"_Occ").Scan(&occupantID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'repo', $3) RETURNING repo_id`,
+		gid, "https://github.com/"+strings.ToLower(slug+"_Occ/Repo"), strings.ToLower(slug+"_Occ")).Scan(&driftedID); err != nil {
+		t.Fatal(err)
+	}
+	if healed, err := store.HealRepoCaseDrift(ctx, driftedID, slug+"_Occ/Repo"); err != nil || healed {
+		t.Fatalf("heal into an occupied canonical URL must refuse (dedup-repos "+
+			"territory): healed=%v err=%v", healed, err)
+	}
+}
+
+// The cross-user sharing contract: when a second group adds a case
+// variant of an already-tracked repo, the SHARED repo_id is linked into
+// that group — no new repos row, no second queue row.
+func TestAddRepoToGroupSharesRepoAcrossGroups(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avcase_share"
+	cleanupCaseRepos(ctx, t, store, slug)
+	cleanupSQL := func() {
+		cleanupCaseRepos(ctx, t, store, slug)
+		store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_groups WHERE name ILIKE $1`, "%"+slug+"%")
+		store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.users WHERE login_name = $1`, slug+"_user")
+	}
+	cleanupSQL()
+	t.Cleanup(cleanupSQL)
+
+	var userID int
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ($1, TRUE)
+		RETURNING user_id`, slug+"_user").Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	var groupA, groupB int64
+	for name, dst := range map[string]*int64{slug + "_A": &groupA, slug + "_B": &groupB} {
+		if err := store.pool.QueryRow(ctx, `
+			INSERT INTO aveloxis_ops.user_groups (user_id, name, status) VALUES ($1, $2, 'approved')
+			RETURNING group_id`, userID, name).Scan(dst); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	canonicalURL := "https://github.com/" + slug + "_Org/Repo"
+	if err := store.AddRepoToGroup(ctx, userID, groupA, canonicalURL); err != nil {
+		t.Fatalf("group A add: %v", err)
+	}
+	// Second group adds the CASE VARIANT of the same repo.
+	if err := store.AddRepoToGroup(ctx, userID, groupB, strings.ToLower(canonicalURL)); err != nil {
+		t.Fatalf("group B case-variant add: %v", err)
+	}
+
+	var repoCount int
+	if err := store.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.repos WHERE LOWER(repo_git) = LOWER($1)`,
+		canonicalURL).Scan(&repoCount); err != nil {
+		t.Fatal(err)
+	}
+	if repoCount != 1 {
+		t.Fatalf("expected ONE shared repos row, got %d — the case variant created a duplicate", repoCount)
+	}
+
+	var linkedA, linkedB int64
+	if err := store.pool.QueryRow(ctx,
+		`SELECT repo_id FROM aveloxis_ops.user_repos WHERE group_id = $1`, groupA).Scan(&linkedA); err != nil {
+		t.Fatalf("group A link: %v", err)
+	}
+	if err := store.pool.QueryRow(ctx,
+		`SELECT repo_id FROM aveloxis_ops.user_repos WHERE group_id = $1`, groupB).Scan(&linkedB); err != nil {
+		t.Fatalf("group B link: %v", err)
+	}
+	if linkedA != linkedB {
+		t.Fatalf("groups link different repo_ids (%d vs %d) — data sharing broken", linkedA, linkedB)
+	}
+
+	var queueCount int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_ops.collection_queue q
+		JOIN aveloxis_data.repos r ON r.repo_id = q.repo_id
+		WHERE LOWER(r.repo_git) = LOWER($1)`, canonicalURL).Scan(&queueCount); err != nil {
+		t.Fatal(err)
+	}
+	if queueCount != 1 {
+		t.Fatalf("expected exactly 1 queue row for the shared repo, got %d", queueCount)
+	}
+}
+
+// dropCaseUniqueIndex simulates the pre-dedup fleet state: on a fleet
+// that still HAS case-variant duplicates, uq_repos_repo_git_ci cannot
+// exist yet (the migration skips it with a WARN until `aveloxis
+// dedup-repos` drains). Tests that deliberately seed duplicate pairs
+// must drop it first — on a clean scratch DB the previous RunMigrations
+// created it, which is itself proof the backstop works. The next
+// RunMigrations recreates it once the test's cleanup removes the pairs.
+func dropCaseUniqueIndex(ctx context.Context, t *testing.T, store *PostgresStore) {
+	t.Helper()
+	if _, err := store.pool.Exec(ctx, `DROP INDEX IF EXISTS aveloxis_data.uq_repos_repo_git_ci`); err != nil {
+		t.Fatalf("drop uq_repos_repo_git_ci: %v", err)
+	}
+}
+
+// defaultRepoGroup returns (creating if needed) the Default repo group
+// used for direct-seed inserts.
+func defaultRepoGroup(ctx context.Context, t *testing.T, store *PostgresStore) int64 {
+	t.Helper()
+	var gid int64
+	err := store.pool.QueryRow(ctx,
+		`SELECT repo_group_id FROM aveloxis_data.repo_groups WHERE rg_name = 'Default'`).Scan(&gid)
+	if err != nil {
+		if err := store.pool.QueryRow(ctx, `
+			INSERT INTO aveloxis_data.repo_groups (rg_name, rg_description)
+			VALUES ('Default', 'Auto-created') RETURNING repo_group_id`).Scan(&gid); err != nil {
+			t.Fatalf("create Default repo group: %v", err)
+		}
+	}
+	return gid
+}

--- a/internal/db/repo_case_test.go
+++ b/internal/db/repo_case_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the case-variant duplicate-repo prevention
+// layer (v0.25.32). GitHub and GitLab treat owner/repo case-insensitively
+// and serve case variants with 200 (no redirect), so byte-exact matching
+// on repos.repo_git let the same repository in twice under different
+// casing — 1,220 duplicate pairs on the production fleet, each collected
+// in full twice. These tests pin the store-layer fix: case-insensitive
+// resolution for forge platforms (1=GitHub, 2=GitLab), byte-exact
+// matching preserved for generic git (3) whose hosts may legitimately be
+// case-sensitive.
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// normWS collapses all whitespace runs to single spaces so SQL pins
+// survive gofmt / query reformatting.
+func normWS(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// FindRepoByURL must resolve case variants for forge platforms while
+// preferring a byte-exact match when both exist (pre-dedup DBs can hold
+// both variants; the exact row is the caller's intent).
+func TestFindRepoByURLIsCaseInsensitiveForForgePlatforms(t *testing.T) {
+	body := normWS(extractFunctionBody(t, "postgres.go", "FindRepoByURL"))
+
+	for _, needle := range []string{
+		"LOWER(repo_git) = LOWER($1)",
+		"platform_id IN (1, 2)",
+		"ORDER BY (repo_git = $1) DESC",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("FindRepoByURL must contain %q — case-insensitive fallback for "+
+				"GitHub/GitLab with exact-match preference. Without it, case-variant "+
+				"URLs miss the existing row and callers create duplicate repos.", needle)
+		}
+	}
+}
+
+// UpsertRepo must resolve a case-variant URL to the stored row's exact
+// repo_git BEFORE the INSERT so ON CONFLICT (repo_git) targets the
+// existing row instead of inserting a new one.
+func TestUpsertRepoResolvesCaseVariantBeforeInsert(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertRepo")
+
+	resolveIdx := strings.Index(body, "resolveCaseVariantURL(")
+	insertIdx := strings.Index(body, "INSERT INTO aveloxis_data.repos")
+	if resolveIdx < 0 {
+		t.Fatal("UpsertRepo must call resolveCaseVariantURL — the single choke point " +
+			"that makes all 10 UpsertRepo callers (CLI, scheduler org refreshes, web " +
+			"scanOrgRepos) case-variant-safe.")
+	}
+	if insertIdx < 0 {
+		t.Fatal("UpsertRepo INSERT not found — extraction target moved?")
+	}
+	if resolveIdx > insertIdx {
+		t.Error("resolveCaseVariantURL must run BEFORE the INSERT so ON CONFLICT " +
+			"(repo_git) targets the existing row.")
+	}
+}
+
+// The pre-resolve + insert pair is not atomic. Once uq_repos_repo_git_ci
+// exists, a concurrent insert of the other case variant surfaces as
+// SQLSTATE 23505 on that constraint — UpsertRepo must re-resolve and
+// retry once instead of failing (withRetry only covers 40P01 deadlocks).
+func TestUpsertRepoRetriesOnCaseUniqueIndexRace(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertRepo")
+
+	for _, needle := range []string{"23505", "uq_repos_repo_git_ci"} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("UpsertRepo must handle the unique-index race: expected %q in the "+
+				"function body (re-resolve + one retry on 23505 against uq_repos_repo_git_ci).",
+				needle)
+		}
+	}
+}
+
+// Hardening: repo_git must be stored without trailing "/" or ".git" so
+// suffix variants can't bypass the LOWER(repo_git) unique index. (The
+// production duplicate cohort is pure case variants, but the same entry
+// paths accept suffixed URLs.)
+func TestUpsertRepoTrimsGitURLSuffixes(t *testing.T) {
+	body := extractFunctionBody(t, "postgres.go", "UpsertRepo")
+
+	if !strings.Contains(body, `TrimSuffix`) || !strings.Contains(body, `".git"`) {
+		t.Error("UpsertRepo must trim trailing \"/\" and \".git\" from r.GitURL before " +
+			"the insert (suffix variants would bypass the case-insensitive unique index).")
+	}
+}
+
+// The resolve helper itself: LOWER match gated to forge platforms, exact
+// match preferred, deterministic tiebreak.
+func TestResolveCaseVariantURLHelperContract(t *testing.T) {
+	body := normWS(extractFunctionBody(t, "postgres.go", "resolveCaseVariantURL"))
+
+	for _, needle := range []string{
+		"LOWER(repo_git) = LOWER($1)",
+		"platform_id IN (1, 2)",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("resolveCaseVariantURL must contain %q — the platform gate keeps "+
+				"generic-git (platform 3) hosts byte-exact on purpose.", needle)
+		}
+	}
+}

--- a/internal/db/repo_dedup.go
+++ b/internal/db/repo_dedup.go
@@ -414,6 +414,36 @@ func dedupOnePair(ctx context.Context, store *PostgresStore, pair RepoDupPair) e
 		{"clear unmapped email_message review links", `
 			UPDATE aveloxis_data.email_message SET linked_pr_review_id = NULL
 			WHERE linked_pr_review_id IN (SELECT pr_review_id FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1)`, []any{pair.LoserID}},
+
+		// --- Step 2c: cross-repo review links (v0.25.33). Review
+		// comments used to resolve their parent review via a
+		// globally-scoped FindReviewDBID (repo-scoped since v0.25.33),
+		// so WINNER-owned bridge rows can point at LOSER-owned
+		// pull_request_reviews rows — the 2026-07-08 production failure
+		// (SQLSTATE 23503 on review_comments_pr_review_id_fkey). Remap
+		// every bridge row (ANY repo_id) from a loser review to the
+		// winner's copy of the same review; delete the leftovers with no
+		// winner equivalent. No bridge may still reference a loser
+		// review when Step 4 deletes them. Neither table has a unique
+		// key involving pr_review_id, so the remaps cannot conflict.
+		{"remap cross-repo review_comments", `
+			UPDATE aveloxis_data.review_comments rc SET pr_review_id = wr.pr_review_id
+			FROM aveloxis_data.pull_request_reviews lr
+			JOIN aveloxis_data.pull_request_reviews wr
+			  ON wr.repo_id = $2 AND wr.platform_review_id = lr.platform_review_id
+			WHERE rc.pr_review_id = lr.pr_review_id AND lr.repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"delete unmappable review_comments cross-links", `
+			DELETE FROM aveloxis_data.review_comments WHERE pr_review_id IN
+			(SELECT pr_review_id FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1)`, []any{pair.LoserID}},
+		{"remap cross-repo pull_request_review_message_ref", `
+			UPDATE aveloxis_data.pull_request_review_message_ref mr SET pr_review_id = wr.pr_review_id
+			FROM aveloxis_data.pull_request_reviews lr
+			JOIN aveloxis_data.pull_request_reviews wr
+			  ON wr.repo_id = $2 AND wr.platform_review_id = lr.platform_review_id
+			WHERE mr.pr_review_id = lr.pr_review_id AND lr.repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"delete unmappable pull_request_review_message_ref cross-links", `
+			DELETE FROM aveloxis_data.pull_request_review_message_ref WHERE pr_review_id IN
+			(SELECT pr_review_id FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1)`, []any{pair.LoserID}},
 	}
 	for _, st := range steps {
 		if err := exec(st.label, st.sql, st.args...); err != nil {

--- a/internal/db/repo_dedup.go
+++ b/internal/db/repo_dedup.go
@@ -368,8 +368,13 @@ func dedupOnePair(ctx context.Context, store *PostgresStore, pair RepoDupPair) e
 		{"repoint email_message.repo_id", `UPDATE aveloxis_data.email_message SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
 		{"repoint email_message.signaled_repo_id", `UPDATE aveloxis_data.email_message SET signaled_repo_id = $2 WHERE signaled_repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
 		{"repoint commit_comment_ref", `UPDATE aveloxis_data.commit_comment_ref SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
-		{"repoint contributor_repo", `UPDATE aveloxis_data.contributor_repo SET repo_git = $2, repo_name = $3 WHERE repo_git = $1`,
-			[]any{pair.LoserGit, pair.WinnerGit, pair.WinnerName}},
+		// contributor_repo is DELIBERATELY not touched (v0.25.34). It is
+		// the breadth worker's observational record of each contributor's
+		// GitHub-WIDE event stream: its repo_git values overwhelmingly
+		// reference repos Aveloxis does not track, it has no FK to repos,
+		// and its stable repo key is the numeric gh_repo_id (case-immune).
+		// The v0.25.32 repoint rewrote observational history AND
+		// sequential-scanned the 51M-row table once per pair.
 		{"migrate foundation_membership", `
 			INSERT INTO aveloxis_ops.foundation_membership (foundation, status, project_name, homepage_url, repo_url)
 			SELECT foundation, status, project_name, homepage_url, $2

--- a/internal/db/repo_dedup.go
+++ b/internal/db/repo_dedup.go
@@ -1,0 +1,457 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// repo_dedup.go — store layer for `aveloxis dedup-repos` (v0.25.32).
+//
+// GitHub and GitLab treat owner/repo paths case-insensitively, but
+// repos.repo_git was byte-exact-unique, so bulk-pasted case variants of
+// already-tracked repos created full duplicate rows that each collected
+// the same repository twice (1,220 pairs on the production fleet). This
+// file merges each duplicate group down to one winner:
+//
+//   - winner = MIN(repo_id) — the oldest row, referenced the longest.
+//     A wrong-cased winner is harmless: the Phase 0 case self-heal
+//     (HealRepoCaseDrift) corrects its spelling on the next collection.
+//   - group/user links (aveloxis_ops.user_repos) are repointed to the
+//     winner so every group that referenced either variant keeps seeing
+//     the repo.
+//   - SHARED-COPY rows are repointed, never deleted. Tables whose unique
+//     key is global rather than per-repo (messages: UNIQUE
+//     (platform_msg_id, platform_id); commit_comment_ref; email_message;
+//     contributor_repo by repo_git text) hold ONE row for the pair —
+//     whichever variant collected first owns it. Deleting "the loser's"
+//     rows there would destroy the only copy or trip the winner's
+//     RESTRICT refs.
+//   - per-repo duplicated child data (issues, PRs, commits, ... — all
+//     keyed UNIQUE (repo_id, platform_*)) is byte-duplicate of the
+//     winner's and is hard-deleted leaves-first, then the loser repos
+//     row itself is deleted. Nothing is lost: the winner holds the same
+//     data.
+//
+// One transaction per pair; idempotent across runs (resolved pairs drop
+// out of the candidate set). Pairs with either side mid-collection
+// (status='collecting') are skipped and reported — never deleted out
+// from under a worker.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// RepoDupPair is one case-variant duplicate pair: the winner that
+// survives and the loser that merges into it.
+type RepoDupPair struct {
+	LowerGit   string
+	WinnerID   int64
+	WinnerGit  string
+	WinnerName string
+	LoserID    int64
+	LoserGit   string
+	// GroupSize is the number of case variants sharing LowerGit. All
+	// production groups are pairs (2); larger groups drain one loser per
+	// pass.
+	GroupSize int
+	// Last-collected timestamps for dry-run visibility (nil = never).
+	WinnerLastCollected *time.Time
+	LoserLastCollected  *time.Time
+	// Collecting is true when either side's queue row is mid-collection;
+	// such pairs are skipped this pass and reported.
+	Collecting bool
+}
+
+// repoDupCandidatesSQL is the shared candidate query. Winner =
+// MIN(repo_id); the LATERAL picks the lowest-id loser so >2-variant
+// groups drain deterministically. Scoped to forge platforms — generic
+// git hosts (platform 3) may legitimately be case-sensitive, so their
+// case variants are NOT duplicates.
+const repoDupCandidatesSQL = `
+	WITH dup_groups AS (
+		SELECT LOWER(repo_git) AS lower_git,
+		       MIN(repo_id)    AS winner_id,
+		       COUNT(*)        AS group_size
+		FROM aveloxis_data.repos
+		WHERE platform_id IN (1, 2)
+		GROUP BY LOWER(repo_git)
+		HAVING COUNT(*) > 1
+	)
+	SELECT g.lower_git,
+	       g.winner_id,
+	       w.repo_git,
+	       w.repo_name,
+	       l.repo_id,
+	       l.repo_git,
+	       g.group_size,
+	       qw.last_collected,
+	       ql.last_collected,
+	       (COALESCE(qw.status, '') = 'collecting'
+	        OR COALESCE(ql.status, '') = 'collecting') AS collecting
+	FROM dup_groups g
+	JOIN aveloxis_data.repos w ON w.repo_id = g.winner_id
+	JOIN LATERAL (
+		SELECT r.repo_id, r.repo_git
+		FROM aveloxis_data.repos r
+		WHERE LOWER(r.repo_git) = g.lower_git
+		  AND r.platform_id IN (1, 2)
+		  AND r.repo_id <> g.winner_id
+		ORDER BY r.repo_id
+		LIMIT 1
+	) l ON TRUE
+	LEFT JOIN aveloxis_ops.collection_queue qw ON qw.repo_id = g.winner_id
+	LEFT JOIN aveloxis_ops.collection_queue ql ON ql.repo_id = l.repo_id
+	ORDER BY g.lower_git
+	LIMIT $1`
+
+// CountCaseVariantRepoDups returns the number of unresolved case-variant
+// duplicate groups among forge-platform repos.
+func CountCaseVariantRepoDups(ctx context.Context, store *PostgresStore) (int, error) {
+	var n int
+	err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT 1
+			FROM aveloxis_data.repos
+			WHERE platform_id IN (1, 2)
+			GROUP BY LOWER(repo_git)
+			HAVING COUNT(*) > 1
+		) dup`).Scan(&n)
+	return n, err
+}
+
+// SampleCaseVariantRepoDups returns up to limit candidate pairs for
+// dry-run display and for the batch loop.
+func SampleCaseVariantRepoDups(ctx context.Context, store *PostgresStore, limit int) ([]RepoDupPair, error) {
+	rows, err := store.pool.Query(ctx, repoDupCandidatesSQL, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var pairs []RepoDupPair
+	for rows.Next() {
+		var p RepoDupPair
+		if err := rows.Scan(&p.LowerGit, &p.WinnerID, &p.WinnerGit, &p.WinnerName,
+			&p.LoserID, &p.LoserGit, &p.GroupSize,
+			&p.WinnerLastCollected, &p.LoserLastCollected, &p.Collecting); err != nil {
+			return pairs, err
+		}
+		pairs = append(pairs, p)
+	}
+	return pairs, rows.Err()
+}
+
+// errPairCollecting signals that the loser transitioned to 'collecting'
+// between the candidate query and the pair transaction — skip, don't
+// delete a repo out from under its worker.
+var errPairCollecting = errors.New("pair is mid-collection")
+
+// DedupCaseVariantReposBatch merges up to batchSize pairs, one
+// transaction each. Returns how many merged and how many were skipped
+// because a side was mid-collection. Callers loop until merged == 0;
+// resolved pairs drop out of the candidate set, so re-runs are no-ops.
+func DedupCaseVariantReposBatch(ctx context.Context, store *PostgresStore, batchSize int) (merged, skippedCollecting int, err error) {
+	if batchSize <= 0 {
+		return 0, 0, fmt.Errorf("batchSize must be positive, got %d", batchSize)
+	}
+	pairs, err := SampleCaseVariantRepoDups(ctx, store, batchSize)
+	if err != nil {
+		return 0, 0, fmt.Errorf("load dedup candidates: %w", err)
+	}
+	for _, pair := range pairs {
+		if pair.Collecting {
+			skippedCollecting++
+			continue
+		}
+		if perr := dedupOnePair(ctx, store, pair); perr != nil {
+			if errors.Is(perr, errPairCollecting) {
+				skippedCollecting++
+				continue
+			}
+			return merged, skippedCollecting, fmt.Errorf(
+				"dedup %s (loser repo_id=%d -> winner repo_id=%d): %w",
+				pair.LowerGit, pair.LoserID, pair.WinnerID, perr)
+		}
+		merged++
+
+		// Post-merge: a winner that has never been collected gets
+		// enqueued immediately. This is what makes the simple
+		// MIN(repo_id) winner rule safe when the data-less side wins —
+		// it just collects fresh.
+		var collected bool
+		qerr := store.pool.QueryRow(ctx,
+			`SELECT last_collected IS NOT NULL FROM aveloxis_ops.collection_queue WHERE repo_id = $1`,
+			pair.WinnerID).Scan(&collected)
+		if errors.Is(qerr, pgx.ErrNoRows) || (qerr == nil && !collected) {
+			if eerr := store.EnqueueRepo(ctx, pair.WinnerID, 100); eerr != nil {
+				return merged, skippedCollecting, fmt.Errorf(
+					"enqueue never-collected winner repo_id=%d: %w", pair.WinnerID, eerr)
+			}
+		}
+	}
+	return merged, skippedCollecting, nil
+}
+
+// loserJoinDeletes removes grandchild rows that carry NO repo_id column
+// and must go before their parents. Each SQL takes $1 = loser repo_id.
+var loserJoinDeletes = []struct {
+	label string
+	sql   string
+}{
+	{"pull_request_teams", `DELETE FROM aveloxis_data.pull_request_teams
+		WHERE pull_request_id IN (SELECT pull_request_id FROM aveloxis_data.pull_requests WHERE repo_id = $1)`},
+	{"pull_request_analysis", `DELETE FROM aveloxis_data.pull_request_analysis
+		WHERE pull_request_id IN (SELECT pull_request_id FROM aveloxis_data.pull_requests WHERE repo_id = $1)`},
+	{"pull_request_repo", `DELETE FROM aveloxis_data.pull_request_repo
+		WHERE pr_repo_meta_id IN (SELECT pr_meta_id FROM aveloxis_data.pull_request_meta WHERE repo_id = $1)`},
+	{"commit_parents", `DELETE FROM aveloxis_data.commit_parents
+		WHERE cmt_id IN (SELECT cmt_id FROM aveloxis_data.commits WHERE repo_id = $1)`},
+	{"library_dependencies", `DELETE FROM aveloxis_data.library_dependencies
+		WHERE library_id IN (SELECT library_id FROM aveloxis_data.libraries WHERE repo_id = $1)`},
+	{"library_version", `DELETE FROM aveloxis_data.library_version
+		WHERE library_id IN (SELECT library_id FROM aveloxis_data.libraries WHERE repo_id = $1)`},
+}
+
+// loserRepoIDDeletes are the loser's per-repo duplicated child tables,
+// hard-deleted as `DELETE FROM <table> WHERE repo_id = $1` in FK-safe
+// leaves-first order: issue children -> review children -> reviews ->
+// PR children -> issues/pull_requests -> commits -> repo-level tables.
+// Every row here is byte-duplicate of the winner's collection of the
+// same repository.
+var loserRepoIDDeletes = []string{
+	// message-bridge rows (reference the shared messages rows, which are
+	// repointed — the loser's bridges duplicate the winner's)
+	"aveloxis_data.issue_message_ref",
+	"aveloxis_data.pull_request_review_message_ref",
+	"aveloxis_data.pull_request_message_ref",
+	"aveloxis_data.review_comments",
+	// issue children
+	"aveloxis_data.issue_labels",
+	"aveloxis_data.issue_assignees",
+	"aveloxis_data.issue_events",
+	// PR children (reviews after their own children above)
+	"aveloxis_data.pull_request_reviews",
+	"aveloxis_data.pull_request_labels",
+	"aveloxis_data.pull_request_assignees",
+	"aveloxis_data.pull_request_reviewers",
+	"aveloxis_data.pull_request_commits",
+	"aveloxis_data.pull_request_files",
+	"aveloxis_data.pull_request_events",
+	"aveloxis_data.pull_request_meta",
+	// parents
+	"aveloxis_data.issues",
+	"aveloxis_data.pull_requests",
+	// git-side
+	"aveloxis_data.commit_messages",
+	"aveloxis_data.commits",
+	// repo-level (no inter-dependencies; records before insights for
+	// safety, everything else order-free)
+	"aveloxis_data.releases",
+	"aveloxis_data.repo_info",
+	"aveloxis_data.repo_clones",
+	"aveloxis_data.repo_badging",
+	"aveloxis_data.dei_badging",
+	"aveloxis_data.repo_insights_records",
+	"aveloxis_data.repo_insights",
+	"aveloxis_data.repo_dependencies",
+	"aveloxis_data.repo_deps_libyear",
+	"aveloxis_data.repo_deps_scorecard",
+	"aveloxis_data.repo_deps_vulnerabilities",
+	"aveloxis_data.repo_sbom_scans",
+	"aveloxis_data.libraries",
+	"aveloxis_data.lstm_anomaly_results",
+	"aveloxis_data.topic_model_meta",
+	"aveloxis_data.repo_cluster_messages",
+	"aveloxis_data.repo_topic",
+	"aveloxis_data.repo_labor",
+	"aveloxis_data.repo_meta",
+	"aveloxis_data.repo_stats",
+	"aveloxis_data.message_analysis_summary",
+	"aveloxis_data.message_sentiment_summary",
+	"aveloxis_data.repo_distribution",
+	"aveloxis_data.repo_distribution_manifest",
+}
+
+// loserHygieneDeletes covers tables that carry a repo_id column with NO
+// foreign key: derived aggregates (rebuilt by RefreshAllRepoAggregates),
+// history snapshots, scancode results, and network exports. Deleting the
+// loser's rows keeps analytics from double-counting; nothing references
+// them.
+var loserHygieneDeletes = []string{
+	"aveloxis_data.dm_repo_annual",
+	"aveloxis_data.dm_repo_monthly",
+	"aveloxis_data.dm_repo_weekly",
+	"aveloxis_data.repo_info_history",
+	"aveloxis_data.repo_deps_libyear_history",
+	"aveloxis_data.repo_deps_scorecard_history",
+	"aveloxis_data.repo_distribution_history",
+	"aveloxis_data.repo_distribution_manifest_history",
+	"aveloxis_scan.scancode_scans",
+	"aveloxis_scan.scancode_file_results",
+	"aveloxis_scan.scancode_scans_history",
+	"aveloxis_scan.scancode_file_results_history",
+	"aveloxis_data.historical_repo_urls",
+	"aveloxis_data.topic_model_event",
+	"aveloxis_ops.network_weighted_commits",
+	"aveloxis_ops.network_weighted_issues",
+	"aveloxis_ops.network_weighted_pr_reviews",
+	"aveloxis_ops.network_weighted_prs",
+}
+
+// Deliberately untouched: aveloxis_ops.worker_history (audit log of what
+// each worker did — historical fact, not repo state) and the
+// Augur-legacy no-write-path tables (repos_fetch_log, working_commits,
+// repo_test_coverage, network_beyond_augur*).
+
+// dedupOnePair merges one loser into its winner inside a single
+// transaction. Statement order matters — most child FKs are ON DELETE
+// RESTRICT, which checks immediately even though the constraints are
+// DEFERRABLE (RESTRICT cannot be deferred; verified empirically in
+// v0.22.7).
+func dedupOnePair(ctx context.Context, store *PostgresStore, pair RepoDupPair) error {
+	tx, err := store.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Re-check the loser's queue status under lock: a worker can claim
+	// the repo between the candidate query and this transaction.
+	// Deleting a 'collecting' repo's rows would corrupt the in-flight
+	// job (its CompleteJob would also resurrect a queue row for a repo
+	// we just deleted).
+	var loserStatus string
+	err = tx.QueryRow(ctx,
+		`SELECT COALESCE(status, '') FROM aveloxis_ops.collection_queue
+		 WHERE repo_id = $1 FOR UPDATE`, pair.LoserID).Scan(&loserStatus)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("lock loser queue row: %w", err)
+	}
+	if loserStatus == "collecting" {
+		return errPairCollecting
+	}
+
+	exec := func(label, sql string, args ...any) error {
+		if _, e := tx.Exec(ctx, sql, args...); e != nil {
+			return fmt.Errorf("%s: %w", label, e)
+		}
+		return nil
+	}
+
+	// --- Step 1: ops linkage. user_repos is repointed (PK (group_id,
+	// repo_id), no FK on repo_id) so every group that referenced either
+	// variant keeps the repo; queue/status/staging rows are loser-scoped
+	// bookkeeping and go away.
+	steps := []struct {
+		label string
+		sql   string
+		args  []any
+	}{
+		{"repoint user_repos", `
+			INSERT INTO aveloxis_ops.user_repos (group_id, repo_id)
+			SELECT group_id, $2 FROM aveloxis_ops.user_repos WHERE repo_id = $1
+			ON CONFLICT DO NOTHING`, []any{pair.LoserID, pair.WinnerID}},
+		{"delete loser user_repos", `DELETE FROM aveloxis_ops.user_repos WHERE repo_id = $1`, []any{pair.LoserID}},
+		{"delete loser collection_queue", `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id = $1`, []any{pair.LoserID}},
+		{"delete loser collection_status", `DELETE FROM aveloxis_ops.collection_status WHERE repo_id = $1`, []any{pair.LoserID}},
+		{"delete loser staging", `DELETE FROM aveloxis_ops.staging WHERE repo_id = $1`, []any{pair.LoserID}},
+		{"repoint mailing_list_staging", `UPDATE aveloxis_ops.mailing_list_staging SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+
+		// --- Step 2: shared-copy repoints (UPDATE, never DELETE). These
+		// tables are globally unique — the pair shares ONE row, owned by
+		// whichever variant collected first. Unique keys exclude repo_id,
+		// so the repoint can't conflict.
+		{"repoint messages", `UPDATE aveloxis_data.messages SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"repoint email_message.repo_id", `UPDATE aveloxis_data.email_message SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"repoint email_message.signaled_repo_id", `UPDATE aveloxis_data.email_message SET signaled_repo_id = $2 WHERE signaled_repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"repoint commit_comment_ref", `UPDATE aveloxis_data.commit_comment_ref SET repo_id = $2 WHERE repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"repoint contributor_repo", `UPDATE aveloxis_data.contributor_repo SET repo_git = $2, repo_name = $3 WHERE repo_git = $1`,
+			[]any{pair.LoserGit, pair.WinnerGit, pair.WinnerName}},
+		{"migrate foundation_membership", `
+			INSERT INTO aveloxis_ops.foundation_membership (foundation, status, project_name, homepage_url, repo_url)
+			SELECT foundation, status, project_name, homepage_url, $2
+			FROM aveloxis_ops.foundation_membership WHERE repo_url = $1
+			ON CONFLICT DO NOTHING`, []any{pair.LoserGit, pair.WinnerGit}},
+		{"delete loser foundation_membership", `DELETE FROM aveloxis_ops.foundation_membership WHERE repo_url = $1`, []any{pair.LoserGit}},
+
+		// --- Step 2b: email_message links into the loser's issue/PR/
+		// review trees (mailing-list projection, v0.25.7). Remap each
+		// link to the winner's equivalent row by platform ID so the
+		// bridge survives the merge; clear any leftover links whose
+		// winner equivalent doesn't exist (their NO-ACTION-deferred FKs
+		// would otherwise fail the transaction at COMMIT once the loser
+		// rows are deleted).
+		{"remap email_message issue links", `
+			UPDATE aveloxis_data.email_message em
+			SET linked_issue_id = wi.issue_id
+			FROM aveloxis_data.issues li
+			JOIN aveloxis_data.issues wi
+			  ON wi.repo_id = $2 AND wi.platform_issue_id = li.platform_issue_id
+			WHERE em.linked_issue_id = li.issue_id AND li.repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"clear unmapped email_message issue links", `
+			UPDATE aveloxis_data.email_message SET linked_issue_id = NULL
+			WHERE linked_issue_id IN (SELECT issue_id FROM aveloxis_data.issues WHERE repo_id = $1)`, []any{pair.LoserID}},
+		{"remap email_message PR links", `
+			UPDATE aveloxis_data.email_message em
+			SET linked_pull_request_id = wp.pull_request_id
+			FROM aveloxis_data.pull_requests lp
+			JOIN aveloxis_data.pull_requests wp
+			  ON wp.repo_id = $2 AND wp.platform_pr_id = lp.platform_pr_id
+			WHERE em.linked_pull_request_id = lp.pull_request_id AND lp.repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"clear unmapped email_message PR links", `
+			UPDATE aveloxis_data.email_message SET linked_pull_request_id = NULL
+			WHERE linked_pull_request_id IN (SELECT pull_request_id FROM aveloxis_data.pull_requests WHERE repo_id = $1)`, []any{pair.LoserID}},
+		{"remap email_message review links", `
+			UPDATE aveloxis_data.email_message em
+			SET linked_pr_review_id = wr.pr_review_id
+			FROM aveloxis_data.pull_request_reviews lr
+			JOIN aveloxis_data.pull_request_reviews wr
+			  ON wr.repo_id = $2 AND wr.platform_review_id = lr.platform_review_id
+			WHERE em.linked_pr_review_id = lr.pr_review_id AND lr.repo_id = $1`, []any{pair.LoserID, pair.WinnerID}},
+		{"clear unmapped email_message review links", `
+			UPDATE aveloxis_data.email_message SET linked_pr_review_id = NULL
+			WHERE linked_pr_review_id IN (SELECT pr_review_id FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1)`, []any{pair.LoserID}},
+	}
+	for _, st := range steps {
+		if err := exec(st.label, st.sql, st.args...); err != nil {
+			return err
+		}
+	}
+
+	// --- Step 3: grandchildren without a repo_id column, join-deleted
+	// before their parents.
+	for _, jd := range loserJoinDeletes {
+		if err := exec("join-delete "+jd.label, jd.sql, pair.LoserID); err != nil {
+			return err
+		}
+	}
+
+	// --- Step 4: the loser's per-repo duplicated child data,
+	// leaves-first.
+	for _, table := range loserRepoIDDeletes {
+		if err := exec("delete "+table,
+			fmt.Sprintf(`DELETE FROM %s WHERE repo_id = $1`, table), pair.LoserID); err != nil {
+			return err
+		}
+	}
+
+	// --- Step 5: no-FK hygiene deletes (aggregates, history snapshots,
+	// scancode results, network exports).
+	for _, table := range loserHygieneDeletes {
+		if err := exec("delete "+table,
+			fmt.Sprintf(`DELETE FROM %s WHERE repo_id = $1`, table), pair.LoserID); err != nil {
+			return err
+		}
+	}
+
+	// --- Step 6: the loser row itself.
+	if err := exec("delete loser repos row",
+		`DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, pair.LoserID); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/db/repo_dedup_integration_test.go
+++ b/internal/db/repo_dedup_integration_test.go
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// Integration tests for the v0.25.32 dedup-repos merge. Gated on
+// AVELOXIS_TEST_DB (scratch DB only). The merge itself is exercised via
+// dedupOnePair with a hand-built pair so the test can never touch other
+// rows in a shared scratch database; the candidate query is exercised
+// read-only via SampleCaseVariantRepoDups.
+//
+// Seeded shape (both sides "collected", like 1,216 of the 1,220
+// production pairs):
+//
+//	winner (lower repo_id)  — issue (same platform_issue_id), queue row
+//	loser                   — issue + PR + commits + a MESSAGE OWNED BY
+//	                          THE LOSER bridged via issue_message_ref,
+//	                          user_repos link, queue row, staging row
+//
+// The loser-owned message is the load-bearing case: messages are
+// globally unique (the pair shares one row), so the merge must REPOINT
+// it to the winner — deleting it would destroy the only copy.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDedupOnePairEndToEnd(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avdedup_pair"
+	cleanupDedupRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupDedupRepos(ctx, t, store, slug) })
+
+	winnerURL := "https://github.com/" + slug + "_Org/Repo"
+	loserURL := strings.ToLower(winnerURL)
+	winnerID, loserID := seedDedupPair(ctx, t, store, slug, winnerURL, loserURL)
+
+	// The candidate query must surface exactly this pair.
+	pair := findPairByLowerGit(ctx, t, store, strings.ToLower(winnerURL))
+	if pair == nil {
+		t.Fatal("candidate query did not surface the seeded pair")
+	}
+	if pair.WinnerID != winnerID || pair.LoserID != loserID {
+		t.Fatalf("candidate pair = (winner %d, loser %d), want (%d, %d) — MIN(repo_id) rule",
+			pair.WinnerID, pair.LoserID, winnerID, loserID)
+	}
+	if pair.Collecting {
+		t.Fatal("pair should not be flagged collecting")
+	}
+
+	if err := dedupOnePair(ctx, store, *pair); err != nil {
+		t.Fatalf("dedupOnePair: %v", err)
+	}
+
+	// Loser gone, winner intact.
+	var n int
+	store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_data.repos WHERE repo_id = $1`, loserID).Scan(&n)
+	if n != 0 {
+		t.Error("loser repos row must be deleted")
+	}
+	store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_data.repos WHERE repo_id = $1`, winnerID).Scan(&n)
+	if n != 1 {
+		t.Error("winner repos row must survive")
+	}
+
+	// The shared message was repointed to the winner (not deleted).
+	var msgRepo int64
+	if err := store.pool.QueryRow(ctx, `
+		SELECT repo_id FROM aveloxis_data.messages WHERE platform_msg_id = 909090901 AND platform_id = 1`,
+	).Scan(&msgRepo); err != nil {
+		t.Fatalf("shared message must survive the merge: %v", err)
+	}
+	if msgRepo != winnerID {
+		t.Errorf("shared message repo_id = %d, want winner %d (repointed)", msgRepo, winnerID)
+	}
+
+	// The loser's issue/PR/commit trees are gone; the winner's issue
+	// survives.
+	for _, q := range []string{
+		`SELECT COUNT(*) FROM aveloxis_data.issues WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_data.pull_requests WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_data.commits WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_data.issue_message_ref WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_ops.collection_queue WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_ops.staging WHERE repo_id = $1`,
+		`SELECT COUNT(*) FROM aveloxis_ops.user_repos WHERE repo_id = $1`,
+	} {
+		store.pool.QueryRow(ctx, q, loserID).Scan(&n)
+		if n != 0 {
+			t.Errorf("loser rows must be gone: %q left %d rows", q, n)
+		}
+	}
+	store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_data.issues WHERE repo_id = $1`, winnerID).Scan(&n)
+	if n != 1 {
+		t.Errorf("winner's issue must survive, got %d", n)
+	}
+
+	// user_repos repointed: the group that referenced the loser now
+	// references the winner.
+	store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_ops.user_repos WHERE repo_id = $1`, winnerID).Scan(&n)
+	if n != 1 {
+		t.Errorf("winner must carry the repointed user_repos link, got %d", n)
+	}
+
+	// Idempotent: the pair no longer appears in the candidate set.
+	if p := findPairByLowerGit(ctx, t, store, strings.ToLower(winnerURL)); p != nil {
+		t.Error("merged pair must drop out of the candidate set")
+	}
+}
+
+func TestDedupOnePairSkipsCollectingLoser(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avdedup_coll"
+	cleanupDedupRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupDedupRepos(ctx, t, store, slug) })
+
+	winnerURL := "https://github.com/" + slug + "_Org/Repo"
+	loserURL := strings.ToLower(winnerURL)
+	winnerID, loserID := seedDedupPair(ctx, t, store, slug, winnerURL, loserURL)
+
+	// The candidate query flags the pair.
+	if _, err := store.pool.Exec(ctx,
+		`UPDATE aveloxis_ops.collection_queue SET status = 'collecting' WHERE repo_id = $1`,
+		loserID); err != nil {
+		t.Fatal(err)
+	}
+	pair := findPairByLowerGit(ctx, t, store, strings.ToLower(winnerURL))
+	if pair == nil {
+		t.Fatal("candidate query did not surface the pair")
+	}
+	if !pair.Collecting {
+		t.Error("candidate query must flag the pair as collecting")
+	}
+
+	// And the in-transaction recheck refuses even when the caller
+	// ignores the flag (the claim can land between query and tx).
+	pair.Collecting = false
+	err := dedupOnePair(ctx, store, *pair)
+	if !errors.Is(err, errPairCollecting) {
+		t.Fatalf("dedupOnePair on a collecting loser = %v, want errPairCollecting", err)
+	}
+
+	// Nothing was touched.
+	var n int
+	store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_data.repos WHERE repo_id IN ($1, $2)`,
+		winnerID, loserID).Scan(&n)
+	if n != 2 {
+		t.Fatalf("collecting pair must be left fully intact, found %d of 2 rows", n)
+	}
+}
+
+// seedDedupPair inserts the winner/loser pair with the full child shape
+// described in the file header and returns their ids.
+func seedDedupPair(ctx context.Context, t *testing.T, store *PostgresStore, slug, winnerURL, loserURL string) (winnerID, loserID int64) {
+	t.Helper()
+	gid := defaultRepoGroup(ctx, t, store)
+
+	// Seeding a duplicate pair requires the pre-dedup fleet state — the
+	// unique backstop cannot coexist with the duplicates it prevents.
+	dropCaseUniqueIndex(ctx, t, store)
+
+	mustScan := func(dst *int64, sql string, args ...any) {
+		t.Helper()
+		if err := store.pool.QueryRow(ctx, sql, args...).Scan(dst); err != nil {
+			t.Fatalf("seed %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := store.pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	// Winner first — MIN(repo_id) makes it the winner.
+	mustScan(&winnerID, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'Repo', $3) RETURNING repo_id`, gid, winnerURL, slug+"_Org")
+	mustScan(&loserID, `
+		INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
+		VALUES ($1, 1, $2, 'repo', $3) RETURNING repo_id`, gid, loserURL, strings.ToLower(slug+"_Org"))
+
+	// Both sides collected the same issue (per-repo duplicated data).
+	mustExec(`INSERT INTO aveloxis_data.issues (repo_id, platform_issue_id, issue_number)
+		VALUES ($1, 424242421, 42)`, winnerID)
+	var loserIssueID int64
+	mustScan(&loserIssueID, `INSERT INTO aveloxis_data.issues (repo_id, platform_issue_id, issue_number)
+		VALUES ($1, 424242421, 42) RETURNING issue_id`, loserID)
+
+	// The SHARED comment: one messages row, owned by the loser (it
+	// collected first), bridged from the loser's issue.
+	var msgID int64
+	mustScan(&msgID, `INSERT INTO aveloxis_data.messages (repo_id, platform_msg_id, platform_id)
+		VALUES ($1, 909090901, 1) RETURNING msg_id`, loserID)
+	mustExec(`INSERT INTO aveloxis_data.issue_message_ref (issue_id, repo_id, msg_id)
+		VALUES ($1, $2, $3)`, loserIssueID, loserID, msgID)
+
+	// Loser-side PR + commits + staging.
+	mustExec(`INSERT INTO aveloxis_data.pull_requests (repo_id, platform_pr_id, pr_number)
+		VALUES ($1, 565656561, 56)`, loserID)
+	mustExec(`INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename)
+		VALUES ($1, 'deadbeef'||$2, 'main.go')`, loserID, slug)
+	mustExec(`INSERT INTO aveloxis_ops.staging (repo_id, platform_id, entity_type, payload)
+		VALUES ($1, 1, 'issue', '{}'::jsonb)`, loserID)
+
+	// Queue rows: both collected (the dominant production shape).
+	for _, id := range []int64{winnerID, loserID} {
+		mustExec(`INSERT INTO aveloxis_ops.collection_queue (repo_id, status, due_at, last_collected)
+			VALUES ($1, 'queued', NOW(), $2) ON CONFLICT (repo_id) DO NOTHING`, id, time.Now())
+	}
+
+	// A user group referencing the loser (must be repointed).
+	var userID int64
+	mustScan(&userID, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ($1, TRUE)
+		ON CONFLICT (login_name) DO UPDATE SET admin = TRUE
+		RETURNING user_id`, slug+"_user")
+	var groupID int64
+	mustScan(&groupID, `
+		INSERT INTO aveloxis_ops.user_groups (user_id, name, status) VALUES ($1, $2, 'approved')
+		RETURNING group_id`, userID, slug+"_grp")
+	mustExec(`INSERT INTO aveloxis_ops.user_repos (group_id, repo_id) VALUES ($1, $2)`, groupID, loserID)
+
+	return winnerID, loserID
+}
+
+// findPairByLowerGit scans the candidate query output for the test's
+// pair — scoped so shared scratch DBs with unrelated duplicates don't
+// perturb assertions.
+func findPairByLowerGit(ctx context.Context, t *testing.T, store *PostgresStore, lowerGit string) *RepoDupPair {
+	t.Helper()
+	pairs, err := SampleCaseVariantRepoDups(ctx, store, 10000)
+	if err != nil {
+		t.Fatalf("SampleCaseVariantRepoDups: %v", err)
+	}
+	for i := range pairs {
+		if pairs[i].LowerGit == lowerGit {
+			return &pairs[i]
+		}
+	}
+	return nil
+}
+
+// cleanupDedupRepos removes everything a prior run of these tests may
+// have left, child tables first.
+func cleanupDedupRepos(ctx context.Context, t *testing.T, store *PostgresStore, slug string) {
+	t.Helper()
+	like := "%" + slug + "%"
+	for _, sql := range []string{
+		`DELETE FROM aveloxis_data.issue_message_ref WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.messages WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.issues WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.pull_requests WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.commits WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_ops.staging WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_ops.user_repos WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.repos WHERE repo_git ILIKE $1`,
+		`DELETE FROM aveloxis_ops.user_groups WHERE name ILIKE $1`,
+		`DELETE FROM aveloxis_ops.users WHERE login_name ILIKE $1`,
+	} {
+		if _, err := store.pool.Exec(ctx, sql, like); err != nil {
+			t.Logf("cleanup (non-fatal): %v", err)
+		}
+	}
+
+	// Belt-and-suspenders: the shared test message is keyed globally
+	// (platform_msg_id), so also remove it by that key in case a prior
+	// run left it repointed at a repo outside the slug scope. Runs after
+	// the loop so its bridge rows are already gone (RESTRICT).
+	if _, err := store.pool.Exec(ctx,
+		`DELETE FROM aveloxis_data.messages WHERE platform_msg_id = 909090901 AND platform_id = 1`); err != nil {
+		t.Logf("cleanup shared message (non-fatal): %v", err)
+	}
+}

--- a/internal/db/repo_dedup_integration_test.go
+++ b/internal/db/repo_dedup_integration_test.go
@@ -153,6 +153,110 @@ func TestDedupOnePairSkipsCollectingLoser(t *testing.T) {
 	}
 }
 
+// TestDedupOnePairRemapsCrossRepoReviewLinks reproduces the 2026-07-08
+// production failure (18f/identity-idp): the pre-v0.25.33 global
+// FindReviewDBID let WINNER-owned review_comments rows point at
+// LOSER-owned pull_request_reviews rows, and the pair transaction died
+// with SQLSTATE 23503 on review_comments_pr_review_id_fkey when it
+// deleted the loser's reviews. The merge must remap the cross-link to
+// the winner's copy of the same review (by platform_review_id) and
+// delete cross-links with no winner equivalent.
+func TestDedupOnePairRemapsCrossRepoReviewLinks(t *testing.T) {
+	ctx, store := caseConnect(t)
+	const slug = "_avdedup_xrev"
+	cleanupDedupRepos(ctx, t, store, slug)
+	t.Cleanup(func() { cleanupDedupRepos(ctx, t, store, slug) })
+
+	winnerURL := "https://github.com/" + slug + "_Org/Repo"
+	loserURL := strings.ToLower(winnerURL)
+	winnerID, loserID := seedDedupPair(ctx, t, store, slug, winnerURL, loserURL)
+
+	mustScan := func(dst *int64, sql string, args ...any) {
+		t.Helper()
+		if err := store.pool.QueryRow(ctx, sql, args...).Scan(dst); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := store.pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// Both sides collected the same PR and the same review
+	// (platform_review_id 777000111). seedDedupPair already made the
+	// loser's PR 565656561; give the winner its copy plus reviews.
+	var winnerPRID, loserPRID int64
+	mustScan(&winnerPRID, `INSERT INTO aveloxis_data.pull_requests (repo_id, platform_pr_id, pr_number)
+		VALUES ($1, 565656561, 56) RETURNING pull_request_id`, winnerID)
+	mustScan(&loserPRID, `SELECT pull_request_id FROM aveloxis_data.pull_requests
+		WHERE repo_id = $1 AND platform_pr_id = 565656561`, loserID)
+
+	var winnerReview, loserReview, loserOnlyReview int64
+	mustScan(&winnerReview, `INSERT INTO aveloxis_data.pull_request_reviews
+		(pull_request_id, repo_id, platform_id, platform_review_id)
+		VALUES ($1, $2, 1, 777000111) RETURNING pr_review_id`, winnerPRID, winnerID)
+	mustScan(&loserReview, `INSERT INTO aveloxis_data.pull_request_reviews
+		(pull_request_id, repo_id, platform_id, platform_review_id)
+		VALUES ($1, $2, 1, 777000111) RETURNING pr_review_id`, loserPRID, loserID)
+	// A loser review with NO winner equivalent (timing skew).
+	mustScan(&loserOnlyReview, `INSERT INTO aveloxis_data.pull_request_reviews
+		(pull_request_id, repo_id, platform_id, platform_review_id)
+		VALUES ($1, $2, 1, 777000222) RETURNING pr_review_id`, loserPRID, loserID)
+
+	// WINNER-owned review comments whose pr_review_id points at LOSER
+	// reviews — the production cross-link shape.
+	var msgA, msgB int64
+	mustScan(&msgA, `INSERT INTO aveloxis_data.messages (repo_id, platform_msg_id, platform_id)
+		VALUES ($1, 909090902, 1) RETURNING msg_id`, winnerID)
+	mustScan(&msgB, `INSERT INTO aveloxis_data.messages (repo_id, platform_msg_id, platform_id)
+		VALUES ($1, 909090903, 1) RETURNING msg_id`, winnerID)
+	mustExec(`INSERT INTO aveloxis_data.review_comments (repo_id, msg_id, pr_review_id, platform_src_id)
+		VALUES ($1, $2, $3, 111222001)`, winnerID, msgA, loserReview)
+	mustExec(`INSERT INTO aveloxis_data.review_comments (repo_id, msg_id, pr_review_id, platform_src_id)
+		VALUES ($1, $2, $3, 111222002)`, winnerID, msgB, loserOnlyReview)
+
+	pair := findPairByLowerGit(ctx, t, store, strings.ToLower(winnerURL))
+	if pair == nil {
+		t.Fatal("candidate query did not surface the seeded pair")
+	}
+	if err := dedupOnePair(ctx, store, *pair); err != nil {
+		t.Fatalf("dedupOnePair must survive cross-repo review links, got: %v", err)
+	}
+
+	// Cross-link with a winner equivalent: remapped, not deleted.
+	var remapped int64
+	if err := store.pool.QueryRow(ctx,
+		`SELECT pr_review_id FROM aveloxis_data.review_comments WHERE platform_src_id = 111222001`,
+	).Scan(&remapped); err != nil {
+		t.Fatalf("remappable cross-link must survive: %v", err)
+	}
+	if remapped != winnerReview {
+		t.Errorf("cross-link pr_review_id = %d, want winner review %d", remapped, winnerReview)
+	}
+
+	// Cross-link with NO winner equivalent: deleted.
+	var n int
+	store.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.review_comments WHERE platform_src_id = 111222002`).Scan(&n)
+	if n != 0 {
+		t.Errorf("unmappable cross-link must be deleted, found %d rows", n)
+	}
+
+	// Loser reviews gone; winner review intact.
+	store.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1`, loserID).Scan(&n)
+	if n != 0 {
+		t.Errorf("loser reviews must be deleted, found %d", n)
+	}
+	store.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.pull_request_reviews WHERE pr_review_id = $1`, winnerReview).Scan(&n)
+	if n != 1 {
+		t.Error("winner review must survive")
+	}
+}
+
 // seedDedupPair inserts the winner/loser pair with the full child shape
 // described in the file header and returns their ids.
 func seedDedupPair(ctx context.Context, t *testing.T, store *PostgresStore, slug, winnerURL, loserURL string) (winnerID, loserID int64) {
@@ -253,6 +357,10 @@ func cleanupDedupRepos(ctx context.Context, t *testing.T, store *PostgresStore, 
 	for _, sql := range []string{
 		`DELETE FROM aveloxis_data.issue_message_ref WHERE repo_id IN
 		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.review_comments WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
+		`DELETE FROM aveloxis_data.pull_request_reviews WHERE repo_id IN
+		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
 		`DELETE FROM aveloxis_data.messages WHERE repo_id IN
 		   (SELECT repo_id FROM aveloxis_data.repos WHERE repo_git ILIKE $1)`,
 		`DELETE FROM aveloxis_data.issues WHERE repo_id IN
@@ -281,7 +389,8 @@ func cleanupDedupRepos(ctx context.Context, t *testing.T, store *PostgresStore, 
 	// run left it repointed at a repo outside the slug scope. Runs after
 	// the loop so its bridge rows are already gone (RESTRICT).
 	if _, err := store.pool.Exec(ctx,
-		`DELETE FROM aveloxis_data.messages WHERE platform_msg_id = 909090901 AND platform_id = 1`); err != nil {
+		`DELETE FROM aveloxis_data.messages
+		 WHERE platform_msg_id IN (909090901, 909090902, 909090903) AND platform_id = 1`); err != nil {
 		t.Logf("cleanup shared message (non-fatal): %v", err)
 	}
 }

--- a/internal/db/repo_dedup_test.go
+++ b/internal/db/repo_dedup_test.go
@@ -81,7 +81,6 @@ func TestRepoDedupRepointsSharedCopyTables(t *testing.T) {
 		"UPDATE aveloxis_data.email_message SET repo_id",
 		"UPDATE aveloxis_data.email_message SET signaled_repo_id",
 		"UPDATE aveloxis_data.commit_comment_ref SET repo_id",
-		"UPDATE aveloxis_data.contributor_repo SET repo_git",
 		"UPDATE aveloxis_ops.mailing_list_staging SET repo_id",
 	}
 	for _, needle := range repoints {
@@ -100,6 +99,29 @@ func TestRepoDedupRepointsSharedCopyTables(t *testing.T) {
 			t.Errorf("repo_dedup.go must NOT contain %q — messages/email_message rows "+
 				"are shared between the pair (global unique keys) and must be "+
 				"repointed, not deleted.", forbidden)
+		}
+	}
+}
+
+// contributor_repo is DELIBERATELY untouched (v0.25.34). It is the
+// breadth worker's observational record of each contributor's
+// GitHub-wide event stream — its repo_git values overwhelmingly
+// reference repos Aveloxis does not track, it has NO foreign key to
+// repos, and its stable repo key is the numeric gh_repo_id (case-
+// immune). v0.25.32's repoint both rewrote observational history and
+// sequential-scanned the 51M-row table once per pair (observed on the
+// 2026-07-08 production run).
+func TestRepoDedupLeavesContributorRepoAlone(t *testing.T) {
+	dedup := readRepoDedupSource(t)
+	for _, forbidden := range []string{
+		"UPDATE aveloxis_data.contributor_repo",
+		"DELETE FROM aveloxis_data.contributor_repo",
+	} {
+		if strings.Contains(dedup, forbidden) {
+			t.Errorf("repo_dedup.go must NOT touch contributor_repo (%q found) — it is "+
+				"an observational GitHub-wide event stream keyed by gh_repo_id, not a "+
+				"catalog reference; mutating it rewrites history and costs a 51M-row "+
+				"seqscan per pair.", forbidden)
 		}
 	}
 }

--- a/internal/db/repo_dedup_test.go
+++ b/internal/db/repo_dedup_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the v0.25.32 `aveloxis dedup-repos` cleanup
+// (internal/db/repo_dedup.go). The command merges case-variant duplicate
+// repo pairs (GitHub/GitLab treat owner/repo case-insensitively; the
+// production fleet accumulated 1,220 pairs, 1,216 fully collected on
+// BOTH sides). Per pair: user_repos repointed to the winner, shared-copy
+// rows repointed (never deleted), the loser's per-repo duplicated child
+// data hard-deleted leaves-first, then the loser repos row deleted.
+
+package db
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readRepoDedupSource(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("repo_dedup.go")
+	if err != nil {
+		t.Fatalf("read repo_dedup.go: %v", err)
+	}
+	return string(src)
+}
+
+// The drift guard: every table with an FK to repos(repo_id) in schema.sql
+// must be handled (deleted, join-deleted, or repointed) by repo_dedup.go.
+// A future schema addition that forgets dedup handling fails CI here
+// instead of silently breaking the per-pair delete with an FK violation.
+func TestRepoDedupCoversEveryReposFK(t *testing.T) {
+	schema, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatalf("read schema.sql: %v", err)
+	}
+	dedup := readRepoDedupSource(t)
+
+	// Walk schema.sql tracking the current CREATE TABLE; collect every
+	// table owning a column that REFERENCES aveloxis_data.repos(repo_id).
+	createRe := regexp.MustCompile(`CREATE TABLE (?:IF NOT EXISTS )?([a-z_]+\.[a-z_]+)`)
+	fkRe := regexp.MustCompile(`REFERENCES aveloxis_data\.repos\s*\(repo_id\)`)
+
+	current := ""
+	owners := map[string]bool{}
+	for _, line := range strings.Split(string(schema), "\n") {
+		if m := createRe.FindStringSubmatch(line); m != nil {
+			current = m[1]
+		}
+		if fkRe.MatchString(line) && current != "" {
+			owners[current] = true
+		}
+	}
+	if len(owners) < 40 {
+		t.Fatalf("schema scan found only %d tables with repos(repo_id) FKs — scanner broke?", len(owners))
+	}
+
+	for table := range owners {
+		// The dedup file must reference every FK-owning table by its
+		// qualified name (in a DELETE, UPDATE, or join-delete).
+		if !strings.Contains(dedup, table) {
+			t.Errorf("repo_dedup.go does not handle %s — every table with an FK to "+
+				"repos(repo_id) needs a delete/join-delete/repoint action in the "+
+				"per-pair transaction, or the loser repos-row DELETE fails with an "+
+				"FK violation (most FKs are ON DELETE RESTRICT).", table)
+		}
+	}
+}
+
+// Shared-copy tables have GLOBAL unique keys (not per-repo), so the
+// duplicate pair shares ONE row — these must be REPOINTED to the winner,
+// never deleted. Deleting would either RESTRICT-fail against the
+// winner's ref rows (messages) or destroy the only copy.
+func TestRepoDedupRepointsSharedCopyTables(t *testing.T) {
+	dedup := normWS(readRepoDedupSource(t))
+
+	repoints := []string{
+		"UPDATE aveloxis_data.messages SET repo_id",
+		"UPDATE aveloxis_data.email_message SET repo_id",
+		"UPDATE aveloxis_data.email_message SET signaled_repo_id",
+		"UPDATE aveloxis_data.commit_comment_ref SET repo_id",
+		"UPDATE aveloxis_data.contributor_repo SET repo_git",
+		"UPDATE aveloxis_ops.mailing_list_staging SET repo_id",
+	}
+	for _, needle := range repoints {
+		if !strings.Contains(dedup, needle) {
+			t.Errorf("repo_dedup.go must REPOINT the shared-copy row via %q — these "+
+				"tables are globally unique (the pair shares one row); a DELETE would "+
+				"lose the only copy or trip the winner's RESTRICT refs.", needle)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"DELETE FROM aveloxis_data.messages",
+		"DELETE FROM aveloxis_data.email_message",
+	} {
+		if strings.Contains(dedup, forbidden) {
+			t.Errorf("repo_dedup.go must NOT contain %q — messages/email_message rows "+
+				"are shared between the pair (global unique keys) and must be "+
+				"repointed, not deleted.", forbidden)
+		}
+	}
+}
+
+// foundation_membership's PK includes repo_url, so a plain UPDATE can
+// PK-collide when both variants were imported — insert-then-delete.
+func TestRepoDedupHandlesFoundationMembership(t *testing.T) {
+	dedup := normWS(readRepoDedupSource(t))
+	if !strings.Contains(dedup, "INSERT INTO aveloxis_ops.foundation_membership") ||
+		!strings.Contains(dedup, "DELETE FROM aveloxis_ops.foundation_membership") {
+		t.Error("repo_dedup.go must migrate foundation_membership rows via " +
+			"insert-winner-then-delete-loser (PK includes repo_url; a plain UPDATE " +
+			"can PK-collide when both case variants were imported).")
+	}
+}
+
+// Pairs with either side mid-collection are skipped and reported —
+// deleting a 'collecting' repo's rows out from under a worker corrupts
+// the in-flight job.
+func TestRepoDedupSkipsCollectingPairs(t *testing.T) {
+	dedup := readRepoDedupSource(t)
+	if !strings.Contains(dedup, "'collecting'") {
+		t.Error("repo_dedup.go's candidate query must detect status='collecting' on " +
+			"either side of a pair so mid-flight repos are skipped + reported, not " +
+			"deleted out from under their worker.")
+	}
+	if !strings.Contains(dedup, "FOR UPDATE") {
+		t.Error("dedupOnePair must re-check the loser's queue row FOR UPDATE inside " +
+			"the transaction — a repo can transition to 'collecting' between the " +
+			"candidate query and the pair transaction.")
+	}
+}
+
+// Winner selection: MIN(repo_id) — the oldest row, referenced the
+// longest. Deterministic and stable across runs; a wrong-cased winner is
+// harmless (the Phase 0 self-heal corrects casing on its next cycle).
+func TestRepoDedupWinnerIsMinRepoID(t *testing.T) {
+	dedup := normWS(readRepoDedupSource(t))
+	if !strings.Contains(dedup, "MIN(repo_id)") {
+		t.Error("repo_dedup.go's candidate query must select the winner as MIN(repo_id).")
+	}
+	if !strings.Contains(dedup, "GROUP BY LOWER(repo_git)") ||
+		!strings.Contains(dedup, "HAVING COUNT(*) > 1") {
+		t.Error("candidate query must group case variants by LOWER(repo_git) with " +
+			"HAVING COUNT(*) > 1.")
+	}
+	if !strings.Contains(dedup, "platform_id IN (1, 2)") {
+		t.Error("candidate query must scope to forge platforms (1, 2) — generic git " +
+			"hosts may legitimately be case-sensitive.")
+	}
+}
+
+// After a merge, a winner that has never been collected must be enqueued
+// — this is what makes the simple MIN(repo_id) rule safe for the pairs
+// where the data-less side wins (it just collects fresh).
+func TestRepoDedupEnqueuesUncollectedWinner(t *testing.T) {
+	dedup := readRepoDedupSource(t)
+	if !strings.Contains(dedup, "EnqueueRepo(") {
+		t.Error("repo_dedup.go must enqueue the winner post-merge when it has no " +
+			"queue row or last_collected IS NULL — covers the never-collected and " +
+			"one-collected pairs under the MIN(repo_id) winner rule.")
+	}
+}

--- a/internal/db/repo_dedup_test.go
+++ b/internal/db/repo_dedup_test.go
@@ -152,6 +152,47 @@ func TestRepoDedupWinnerIsMinRepoID(t *testing.T) {
 	}
 }
 
+// Cross-repo review links (v0.25.33 hotfix). Review comments resolve
+// their parent review via FindReviewDBID, which was NOT repo-scoped —
+// on a duplicate pair the same platform_review_id exists twice and the
+// lookup picked an arbitrary copy, so WINNER-owned bridge rows can
+// point at LOSER-owned pull_request_reviews rows. The first production
+// run failed exactly there (18f/identity-idp, SQLSTATE 23503 on
+// review_comments_pr_review_id_fkey): deleting bridges by
+// repo_id = loser leaves the winner's cross-links behind, and they
+// RESTRICT the loser's reviews delete. The merge must REMAP cross-links
+// to the winner's equivalent review (by platform_review_id) and delete
+// any leftovers with no equivalent, BEFORE deleting the loser's reviews.
+func TestRepoDedupRemapsCrossRepoReviewLinks(t *testing.T) {
+	dedup := normWS(readRepoDedupSource(t))
+
+	for _, needle := range []string{
+		"UPDATE aveloxis_data.review_comments rc SET pr_review_id",
+		"UPDATE aveloxis_data.pull_request_review_message_ref mr SET pr_review_id",
+		// The remap join key: the winner's copy of the SAME review.
+		"wr.platform_review_id = lr.platform_review_id",
+	} {
+		if !strings.Contains(dedup, needle) {
+			t.Errorf("repo_dedup.go must remap cross-repo review links before deleting "+
+				"the loser's pull_request_reviews: expected %q. Without the remap, "+
+				"winner-owned bridge rows RESTRICT the delete (the 2026-07-08 "+
+				"production failure).", needle)
+		}
+	}
+
+	// Leftovers with no winner-equivalent review must be deleted (any
+	// repo_id) — their FK would still block the reviews delete.
+	for _, needle := range []string{
+		"DELETE FROM aveloxis_data.review_comments WHERE pr_review_id IN",
+		"DELETE FROM aveloxis_data.pull_request_review_message_ref WHERE pr_review_id IN",
+	} {
+		if !strings.Contains(dedup, needle) {
+			t.Errorf("repo_dedup.go must delete leftover bridge rows still pointing at "+
+				"loser reviews after the remap: expected %q.", needle)
+		}
+	}
+}
+
 // After a merge, a winner that has never been collected must be enqueued
 // — this is what makes the simple MIN(repo_id) rule safe for the pairs
 // where the data-less side wins (it just collects fresh).

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2154,6 +2154,22 @@ CREATE INDEX IF NOT EXISTS idx_em_proj_pending_keyed ON aveloxis_data.email_mess
     WHERE msg_class = 'issue_event' AND COALESCE(projected_kind, '') = '' AND linked_external_key <> '';
 CREATE INDEX IF NOT EXISTS idx_em_proj_pending_threaded ON aveloxis_data.email_message (email_message_id)
     WHERE thread_root_id <> '' AND COALESCE(projected_kind, '') = '';
+-- v0.25.34: FK-side indexes for email_message's projection links. These
+-- columns arrived in v0.25.7 (after the v0.22.6/v0.22.7 FK-index audits)
+-- and shipped unindexed. Their FKs are NO-ACTION DEFERRABLE, so bulk
+-- deletes of issues/PRs/reviews (e.g. `aveloxis dedup-repos`) queue one
+-- deferred check per deleted parent row and run them AT COMMIT — each an
+-- unindexed sequential scan of email_message. Observed 2026-07-08: an
+-- Azure-sized pair spent 18+ minutes inside the `commit` statement.
+-- Partial (IS NOT NULL) because most emails carry no projection link;
+-- the RI check predicate (col = $1) implies IS NOT NULL, so the partial
+-- index serves it.
+CREATE INDEX IF NOT EXISTS idx_email_message_linked_issue
+    ON aveloxis_data.email_message (linked_issue_id) WHERE linked_issue_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_email_message_linked_pr
+    ON aveloxis_data.email_message (linked_pull_request_id) WHERE linked_pull_request_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_email_message_linked_review
+    ON aveloxis_data.email_message (linked_pr_review_id) WHERE linked_pr_review_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_issue_events_repo_id ON aveloxis_data.issue_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_pr_events_repo_id ON aveloxis_data.pull_request_events (repo_id);
 CREATE INDEX IF NOT EXISTS idx_releases_repo_id ON aveloxis_data.releases (repo_id);

--- a/internal/db/v025_32_repo_git_ci_test.go
+++ b/internal/db/v025_32_repo_git_ci_test.go
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the v0.25.32 case-insensitive repo_git
+// indexes. Two indexes with different contracts:
+//
+//   - idx_repos_repo_git_lower — non-unique expression index, created
+//     unconditionally and FAIL-CLOSED (execCreateIndexConcurrently with
+//     the errs collector). It serves the new LOWER(repo_git) lookups in
+//     FindRepoByURL / resolveCaseVariantURL.
+//   - uq_repos_repo_git_ci — UNIQUE partial index (platform 1/2 only),
+//     the hard backstop against future case-variant duplicates. Created
+//     WARN-ONLY by ensureRepoGitCaseInsensitiveUnique, and ONLY once the
+//     fleet has zero case-dup groups (operators run `aveloxis
+//     dedup-repos` first). Per the CLAUDE.md schema-DDL-ordering rule,
+//     dedup unique indexes must NOT be declared in schema.sql — CREATE
+//     would fail on existing duplicate data.
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// extractTopLevelFunc returns the source of a plain (non-method) function
+// from a file in this package.
+func extractTopLevelFunc(t *testing.T, filename, funcName string) string {
+	t.Helper()
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	code := string(src)
+	marker := "func " + funcName + "("
+	startIdx := strings.Index(code, marker)
+	if startIdx < 0 {
+		t.Fatalf("function %s not found in %s", funcName, filename)
+	}
+	tail := code[startIdx+1:]
+	endRel := strings.Index(tail, "\nfunc ")
+	if endRel < 0 {
+		endRel = len(tail)
+	}
+	return code[startIdx : startIdx+1+endRel]
+}
+
+func TestMigrationCreatesRepoGitLowerLookupIndex(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	code := string(src)
+
+	idx := strings.Index(code, "idx_repos_repo_git_lower")
+	if idx < 0 {
+		t.Fatal("migrate.go must create idx_repos_repo_git_lower — without it every " +
+			"LOWER(repo_git) lookup sequential-scans the repos table on each upsert/find.")
+	}
+	// The creation must go through execCreateIndexConcurrently (fail-closed
+	// + INVALID-index recovery), not a bare Exec.
+	window := code[max(0, idx-600):min(len(code), idx+600)]
+	if !strings.Contains(window, "execCreateIndexConcurrently") {
+		t.Error("idx_repos_repo_git_lower must be created via execCreateIndexConcurrently " +
+			"(fail-closed, INVALID-leftover recovery), not a bare Exec.")
+	}
+	if !strings.Contains(normWS(window), "LOWER(repo_git)") {
+		t.Error("idx_repos_repo_git_lower must be an expression index on LOWER(repo_git).")
+	}
+}
+
+func TestEnsureRepoGitCaseInsensitiveUniqueContract(t *testing.T) {
+	body := extractTopLevelFunc(t, "migrate.go", "ensureRepoGitCaseInsensitiveUnique")
+	flat := normWS(body)
+
+	needles := []string{
+		"uq_repos_repo_git_ci",
+		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS",
+		// Partial predicate: only forge platforms are case-insensitive-unique;
+		// generic git hosts (platform 3) may legitimately be case-sensitive.
+		"WHERE platform_id IN (1, 2)",
+		// The dup-count gate: never attempt the unique create while
+		// case-variant duplicates exist (CREATE would fail / leave INVALID).
+		"HAVING COUNT(*) > 1",
+		// Operator hint in the WARN path.
+		"dedup-repos",
+		// INVALID-leftover recovery (interrupted CONCURRENTLY builds).
+		"indisvalid",
+	}
+	for _, n := range needles {
+		if !strings.Contains(flat, n) {
+			t.Errorf("ensureRepoGitCaseInsensitiveUnique must contain %q — see the "+
+				"create-after-cleanup contract in the file header of this test.", n)
+		}
+	}
+}
+
+// The unique-index step is deliberately WARN-ONLY (mirrors
+// deduplicateCommits): a fleet with existing duplicates must still be
+// able to start serve — the WARN names the dedup-repos command instead
+// of blocking startup.
+func TestEnsureRepoGitCaseInsensitiveUniqueIsWarnOnly(t *testing.T) {
+	body := extractTopLevelFunc(t, "migrate.go", "ensureRepoGitCaseInsensitiveUnique")
+
+	sigEnd := strings.Index(body, "{")
+	if sigEnd < 0 {
+		t.Fatal("malformed function extraction")
+	}
+	sig := body[:sigEnd]
+	if strings.Contains(sig, "errs") {
+		t.Error("ensureRepoGitCaseInsensitiveUnique must NOT take the *[]error collector — " +
+			"it is warn-only by design so fleets with pending duplicates can still start " +
+			"serve. The fail-closed contract belongs to idx_repos_repo_git_lower only.")
+	}
+
+	if !strings.Contains(body, "logger.Warn") {
+		t.Error("ensureRepoGitCaseInsensitiveUnique must WARN (with the dedup-repos hint) " +
+			"when duplicates block the unique index.")
+	}
+}
+
+func TestRunMigrationsInvokesRepoGitCaseInsensitiveUnique(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	if !strings.Contains(string(src), "ensureRepoGitCaseInsensitiveUnique(ctx, pg, logger)") {
+		t.Error("RunMigrations must invoke ensureRepoGitCaseInsensitiveUnique — without " +
+			"the call site the unique backstop never gets created on any fleet.")
+	}
+}
+
+// Per CLAUDE.md ("Schema DDL ordering"): dedup unique indexes must NOT be
+// in schema.sql — they are created by the migration function after dedup
+// cleanup. A fresh install gets it on its first migrate (zero rows = zero
+// duplicates); an existing fleet gets it after dedup-repos drains.
+func TestRepoGitCiUniqueIndexNotInSchemaSQL(t *testing.T) {
+	src, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatalf("read schema.sql: %v", err)
+	}
+	if strings.Contains(string(src), "uq_repos_repo_git_ci") {
+		t.Error("uq_repos_repo_git_ci must NOT be declared in schema.sql — CREATE UNIQUE " +
+			"INDEX fails on existing duplicate data; the migration function owns its " +
+			"creation after cleanup (CLAUDE.md schema-DDL-ordering rule).")
+	}
+}

--- a/internal/db/v025_34_email_message_link_indexes_test.go
+++ b/internal/db/v025_34_email_message_link_indexes_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// v0.25.34: indexes on email_message's linked_issue_id /
+// linked_pull_request_id / linked_pr_review_id. These FK columns were
+// added in v0.25.7, AFTER the v0.22.6/v0.22.7 FK-index audits, and
+// shipped unindexed. The cost surfaced on the first production
+// dedup-repos run (2026-07-08): every deleted issue/PR/review queues a
+// deferred NO-ACTION FK check against email_message at COMMIT, each an
+// unindexed sequential scan — an Azure-sized pair spent 18+ minutes
+// inside the literal `commit` statement running ~50K seqscans over a
+// ~197K-row table. Same lesson as v0.22.6: an FK without an index on
+// the referencing column is invisible until something deletes the
+// referenced rows in bulk.
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+var emailMessageLinkIndexes = []string{
+	"idx_email_message_linked_issue",
+	"idx_email_message_linked_pr",
+	"idx_email_message_linked_review",
+}
+
+func TestSchemaDeclaresEmailMessageLinkIndexes(t *testing.T) {
+	src, err := os.ReadFile("schema.sql")
+	if err != nil {
+		t.Fatalf("read schema.sql: %v", err)
+	}
+	code := normWS(string(src))
+	for _, idx := range emailMessageLinkIndexes {
+		if !strings.Contains(code, idx) {
+			t.Errorf("schema.sql must declare %s — fresh installs need the FK-side "+
+				"indexes so bulk deletes of issues/PRs/reviews don't seqscan "+
+				"email_message per deferred constraint check.", idx)
+		}
+	}
+	// Partial WHERE ... IS NOT NULL — most email_message rows carry no
+	// link; the RI check predicate (col = $1) implies IS NOT NULL, so
+	// partial indexes serve it.
+	for _, pred := range []string{
+		"(linked_issue_id) WHERE linked_issue_id IS NOT NULL",
+		"(linked_pull_request_id) WHERE linked_pull_request_id IS NOT NULL",
+		"(linked_pr_review_id) WHERE linked_pr_review_id IS NOT NULL",
+	} {
+		if !strings.Contains(code, pred) {
+			t.Errorf("schema.sql email_message link index must be partial: expected %q", pred)
+		}
+	}
+}
+
+func TestMigrationCreatesEmailMessageLinkIndexesConcurrently(t *testing.T) {
+	src, err := os.ReadFile("migrate.go")
+	if err != nil {
+		t.Fatalf("read migrate.go: %v", err)
+	}
+	code := string(src)
+	for _, idx := range emailMessageLinkIndexes {
+		i := strings.Index(code, idx)
+		if i < 0 {
+			t.Errorf("migrate.go must build %s (existing fleets already have the "+
+				"email_message table; schema.sql alone only covers fresh installs).", idx)
+			continue
+		}
+		window := code[max(0, i-700):min(len(code), i+700)]
+		if !strings.Contains(window, "execCreateIndexConcurrently") {
+			t.Errorf("%s must be created via execCreateIndexConcurrently (fail-closed, "+
+				"non-blocking, INVALID-leftover recovery).", idx)
+		}
+	}
+}

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -267,10 +267,15 @@ func TestVersionStampedV0256(t *testing.T) {
 	// 1,220 duplicate pairs on aveloxis_large. Prevention via
 	// resolveCaseVariantURL in UpsertRepo/FindRepoByURL, cleanup via
 	// `aveloxis dedup-repos`, uq_repos_repo_git_ci backstop after drain,
-	// Phase 0 case self-heal via HealRepoCaseDrift).
+	// Phase 0 case self-heal via HealRepoCaseDrift) → 0.25.33 (first
+	// production dedup-repos run failed on 18f/identity-idp: the
+	// globally-scoped FindReviewDBID had cross-linked winner-owned
+	// review_comments to loser-owned reviews; dedupOnePair now remaps
+	// cross-repo review links to winner equivalents and FindReviewDBID is
+	// repo-scoped).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.32"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.32\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.33"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.33\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -261,10 +261,16 @@ func TestVersionStampedV0256(t *testing.T) {
 	// and GetKey waits for a quarantined key to recover instead of returning
 	// ErrAllKeysInvalidated. Fixes the 2026-06-17 aveloxis_large crash-loop
 	// where transient GitHub-auth-backend 401s bled 18 good keys out one at a
-	// time over 15 hours and the scheduler then crashed on ClassAuth).
+	// time over 15 hours and the scheduler then crashed on ClassAuth) →
+	// 0.25.32 (case-variant duplicate repos: GitHub/GitLab URLs are
+	// case-insensitive at the forge, but repo_git matching was byte-exact —
+	// 1,220 duplicate pairs on aveloxis_large. Prevention via
+	// resolveCaseVariantURL in UpsertRepo/FindRepoByURL, cleanup via
+	// `aveloxis dedup-repos`, uq_repos_repo_git_ci backstop after drain,
+	// Phase 0 case self-heal via HealRepoCaseDrift).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.31"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.31\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.32"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.32\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -272,10 +272,16 @@ func TestVersionStampedV0256(t *testing.T) {
 	// globally-scoped FindReviewDBID had cross-linked winner-owned
 	// review_comments to loser-owned reviews; dedupOnePair now remaps
 	// cross-repo review links to winner equivalents and FindReviewDBID is
-	// repo-scoped).
+	// repo-scoped) → 0.25.34 (dedup pairs spent 18+ min inside COMMIT:
+	// email_message's linked_issue/PR/review FK columns shipped unindexed
+	// in v0.25.7, so deferred NO-ACTION checks seqscanned per deleted
+	// parent row — three partial indexes added; and the contributor_repo
+	// repoint was removed from dedupOnePair: it's the breadth worker's
+	// GitHub-wide observational stream with no repos FK, and the repoint
+	// both rewrote history and seqscanned 51M rows per pair).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.25.33"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.33\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.25.34"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.25.34\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.31"
+var ToolVersion = "0.25.32"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.32"
+var ToolVersion = "0.25.33"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.25.33"
+var ToolVersion = "0.25.34"

--- a/internal/db/web_store.go
+++ b/internal/db/web_store.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/aveloxis/aveloxis/internal/platform"
 )
 
 // GetUserEmail returns the email column for the given user_id.
@@ -420,42 +423,31 @@ func (s *PostgresStore) AddRepoToGroup(ctx context.Context, userID int, groupID 
 		return fmt.Errorf("group has been rejected by an administrator")
 	}
 
-	// Ensure repo exists in repos table.
-	var repoID int64
-	err := s.pool.QueryRow(ctx,
-		`SELECT repo_id FROM aveloxis_data.repos WHERE repo_git = $1`, repoURL).Scan(&repoID)
+	// Resolve the URL to an existing repo first — case-insensitively for
+	// GitHub/GitLab (v0.25.32). When ANY user already tracks this
+	// repository (under any casing), the SHARED repo_id is linked into
+	// this group below and the existing collected data is immediately
+	// visible: no new repos row, no re-collection.
+	repoID, err := s.FindRepoByURL(ctx, repoURL)
 	if err != nil {
-		// Not found — need to insert. Determine platform from URL.
-		platform := int16(1) // GitHub default
-		if strings.Contains(repoURL, "gitlab") {
-			platform = 2
-		} else if !strings.Contains(repoURL, "github.com") {
-			platform = 3 // Generic git — facade/analysis only
+		return fmt.Errorf("resolve repo URL: %w", err)
+	}
+	if repoID == 0 {
+		// New repo. Parse owner/name/platform via the shared parser.
+		// Unparseable URLs stay permissive (generic git, empty owner/name)
+		// to match the historical web-path behavior — ValidateRepoURL has
+		// already screened the input upstream.
+		newRepo := &model.Repo{GitURL: repoURL, Platform: model.PlatformGenericGit}
+		if ru, perr := platform.ParseAnyRepoURL(repoURL); perr == nil {
+			newRepo.Platform = ru.Platform
+			newRepo.Owner = ru.Owner
+			newRepo.Name = ru.Repo
 		}
-		// Extract owner/name from URL.
-		parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(strings.TrimPrefix(repoURL, "https://"), "http://"), "/"), "/")
-		owner := ""
-		name := ""
-		if len(parts) >= 3 {
-			name = parts[len(parts)-1]
-			owner = strings.Join(parts[1:len(parts)-1], "/")
-		}
-
-		// Get or create default group.
-		var groupIDDB int64
-		_ = s.pool.QueryRow(ctx,
-			`SELECT repo_group_id FROM aveloxis_data.repo_groups WHERE rg_name = 'Default'`).Scan(&groupIDDB)
-		if groupIDDB == 0 {
-			s.pool.QueryRow(ctx,
-				`INSERT INTO aveloxis_data.repo_groups (rg_name, rg_description) VALUES ('Default', 'Auto-created') RETURNING repo_group_id`).Scan(&groupIDDB)
-		}
-
-		err = s.pool.QueryRow(ctx, `
-			INSERT INTO aveloxis_data.repos (repo_group_id, platform_id, repo_git, repo_name, repo_owner)
-			VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (repo_git) DO UPDATE SET repo_name = EXCLUDED.repo_name
-			RETURNING repo_id`,
-			groupIDDB, platform, repoURL, name, owner).Scan(&repoID)
+		// Existing repos are deliberately NOT routed through UpsertRepo:
+		// its ON CONFLICT DO UPDATE would clobber collected metadata
+		// (description, language, ...) with this minimal struct's empty
+		// fields. UpsertRepo runs only on this not-found branch.
+		repoID, err = s.UpsertRepo(ctx, newRepo)
 		if err != nil {
 			return err
 		}
@@ -465,10 +457,9 @@ func (s *PostgresStore) AddRepoToGroup(ctx context.Context, userID int, groupID 
 		// gives the admin a chance to review submissions before they
 		// burn API quota.
 		if status == "approved" {
-			s.pool.Exec(ctx, `
-				INSERT INTO aveloxis_ops.collection_queue (repo_id, priority, status, due_at)
-				VALUES ($1, 100, 'queued', NOW())
-				ON CONFLICT (repo_id) DO NOTHING`, repoID)
+			if err := s.EnqueueRepo(ctx, repoID, 100); err != nil {
+				return fmt.Errorf("enqueue repo: %w", err)
+			}
 		}
 	}
 
@@ -487,16 +478,20 @@ func (s *PostgresStore) AddOrgToGroup(ctx context.Context, userID int, groupID i
 		return err
 	}
 
-	// Determine platform and org name.
+	// Determine platform and org name via the shared parser (v0.25.32
+	// consolidation). Platform detection keeps the historical
+	// host-contains-"gitlab" heuristic; unparseable URLs keep an empty
+	// org name, matching the old inline split's permissiveness.
 	orgURL = strings.TrimSuffix(strings.TrimSpace(orgURL), "/")
-	platform := "github"
-	if strings.Contains(orgURL, "gitlab") {
-		platform = "gitlab"
-	}
-	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(orgURL, "https://"), "http://"), "/")
+	platformName := "github"
 	orgName := ""
-	if len(parts) >= 2 {
-		orgName = parts[1]
+	if host, org, perr := platform.ParseOrgURL(orgURL); perr == nil {
+		orgName = org
+		if strings.Contains(host, "gitlab") {
+			platformName = "gitlab"
+		}
+	} else if strings.Contains(orgURL, "gitlab") {
+		platformName = "gitlab"
 	}
 
 	// Insert org request.
@@ -505,7 +500,7 @@ func (s *PostgresStore) AddOrgToGroup(ctx context.Context, userID int, groupID i
 			(user_id, group_id, org_url, org_name, platform)
 		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (group_id, org_url) DO NOTHING`,
-		userID, groupID, orgURL, orgName, platform)
+		userID, groupID, orgURL, orgName, platformName)
 	return err
 }
 

--- a/internal/db/web_store_addrepo_test.go
+++ b/internal/db/web_store_addrepo_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Source-contract tests for the v0.25.32 AddRepoToGroup refactor. The
+// pre-v0.25.32 implementation hand-rolled its own exact-match SELECT,
+// inline platform detection, inline owner/name parsing, and a raw INSERT
+// INTO aveloxis_data.repos — a parallel repo-creation path that (a)
+// missed case variants of already-tracked repos (the source of the
+// production duplicate cohort: bulk-pasted lowercase URLs) and (b) left
+// data_source empty. The refactor routes through the shared store
+// helpers so there is exactly ONE way a repo row comes into existence.
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAddRepoToGroupUsesSharedResolvers(t *testing.T) {
+	body := extractFunctionBody(t, "web_store.go", "AddRepoToGroup")
+
+	for _, needle := range []string{"s.FindRepoByURL(", "s.UpsertRepo(", "s.EnqueueRepo("} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("AddRepoToGroup must call %s — the shared resolver/creator path is "+
+				"what makes web bulk-paste case-variant-safe and cross-user repo sharing "+
+				"work (a case variant of an already-collected repo links the SHARED "+
+				"repo_id into the new user's group).", needle)
+		}
+	}
+
+	if strings.Contains(body, "INSERT INTO aveloxis_data.repos") {
+		t.Error("AddRepoToGroup must NOT hand-roll its own INSERT INTO aveloxis_data.repos — " +
+			"that parallel creation path bypassed case-variant resolution and left " +
+			"data_source empty. Route through UpsertRepo.")
+	}
+}
+
+// The v0.19.0 group-approval gate must survive the refactor: pending
+// groups defer enqueue to ApproveGroup; rejected groups refuse the add.
+func TestAddRepoToGroupKeepsApprovalGate(t *testing.T) {
+	body := extractFunctionBody(t, "web_store.go", "AddRepoToGroup")
+
+	for _, needle := range []string{`"rejected"`, `"approved"`, "user_repos"} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("AddRepoToGroup must keep the v0.19.0 approval gate and the "+
+				"user_repos link; expected %q in the function body.", needle)
+		}
+	}
+}
+
+// Existing repos must NOT be routed through UpsertRepo — its ON CONFLICT
+// DO UPDATE would clobber populated columns (repo_description,
+// primary_language, ...) with the web path's empty struct. UpsertRepo is
+// only for the not-found branch.
+func TestAddRepoToGroupOnlyUpsertsWhenNotFound(t *testing.T) {
+	body := extractFunctionBody(t, "web_store.go", "AddRepoToGroup")
+
+	findIdx := strings.Index(body, "s.FindRepoByURL(")
+	upsertIdx := strings.Index(body, "s.UpsertRepo(")
+	if findIdx < 0 || upsertIdx < 0 {
+		t.Skip("resolver calls missing — covered by TestAddRepoToGroupUsesSharedResolvers")
+	}
+	if findIdx > upsertIdx {
+		t.Error("AddRepoToGroup must look up via FindRepoByURL FIRST and only call " +
+			"UpsertRepo when the repo is not found — routing existing repos through " +
+			"UpsertRepo's DO UPDATE clobbers collected metadata with empty values.")
+	}
+}

--- a/internal/model/repoinfo.go
+++ b/internal/model/repoinfo.go
@@ -9,8 +9,16 @@ import "time"
 // Populated via GitHub GraphQL API to get accurate PR/issue/commit counts
 // and community profile files — the REST API doesn't expose these.
 type RepoInfo struct {
-	ID             int64
-	RepoID         int64
+	ID     int64
+	RepoID int64
+	// FullName is the forge's CANONICAL "owner/name" spelling exactly as
+	// reported (GitHub nameWithOwner / REST full_name, GitLab
+	// path_with_namespace — the latter carries nested groups in full).
+	// Both forges accept case-variant lookups but always return the
+	// canonical casing; the Phase 0 self-heal (HealRepoCaseDrift) uses
+	// this to correct case-drifted repo_git values. Empty when the
+	// transport didn't provide it.
+	FullName       string
 	LastUpdated    time.Time
 	IssuesEnabled  bool
 	PRsEnabled     bool

--- a/internal/platform/github/client.go
+++ b/internal/platform/github/client.go
@@ -894,6 +894,7 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 	}
 
 	return &model.RepoInfo{
+		FullName:          r.NameWithOwner,
 		LastUpdated:       r.UpdatedAt,
 		IssuesEnabled:     r.HasIssuesEnabled,
 		WikiEnabled:       r.HasWikiEnabled,
@@ -950,6 +951,7 @@ func (c *Client) fetchRepoInfoREST(ctx context.Context, owner, repo string) (*mo
 		languages[raw.Language] = 1 // sentinel — real bytes via GraphQL
 	}
 	return &model.RepoInfo{
+		FullName:        raw.FullName,
 		LastUpdated:     raw.UpdatedAt,
 		IssuesEnabled:   raw.HasIssues,
 		WikiEnabled:     raw.HasWiki,
@@ -978,6 +980,7 @@ func (c *Client) fetchRepoInfoREST(ctx context.Context, owner, repo string) (*mo
 func repoInfoGraphQL(owner, repo string) string {
 	return fmt.Sprintf(`{
   repository(owner: "%s", name: "%s") {
+    nameWithOwner
     updatedAt
     description
     hasIssuesEnabled
@@ -1052,6 +1055,7 @@ type graphQLRepoInfoResponse struct {
 }
 
 type graphQLRepo struct {
+	NameWithOwner    string    `json:"nameWithOwner"` // v0.25.32 — canonical owner/name for the case self-heal
 	UpdatedAt        time.Time `json:"updatedAt"`
 	HasIssuesEnabled bool      `json:"hasIssuesEnabled"`
 	HasWikiEnabled   bool      `json:"hasWikiEnabled"`

--- a/internal/platform/github/repoinfo_fullname_test.go
+++ b/internal/platform/github/repoinfo_fullname_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// v0.25.32: RepoInfo carries the forge's canonical "owner/name" spelling
+// (FullName) so the Phase 0 case self-heal can correct case-drifted
+// repo_git values. GitHub GraphQL calls it nameWithOwner; REST full_name.
+
+package github
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGraphQLRepoInfoQuerySelectsNameWithOwner(t *testing.T) {
+	q := repoInfoGraphQL("chaoss", "augur")
+	if !strings.Contains(q, "nameWithOwner") {
+		t.Error("repoInfoGraphQL must select nameWithOwner — it is the canonical-case " +
+			"source for the Phase 0 case self-heal (HealRepoCaseDrift). The API is " +
+			"case-insensitive on lookup but always RETURNS the canonical spelling.")
+	}
+}
+
+func TestGhRepoInfoDecodesFullName(t *testing.T) {
+	var raw ghRepoInfo
+	if err := json.Unmarshal([]byte(`{"full_name": "Azure/azure-sdk-tools"}`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if raw.FullName != "Azure/azure-sdk-tools" {
+		t.Errorf("ghRepoInfo.FullName = %q, want the decoded full_name — the REST "+
+			"fallback path must carry the canonical spelling too.", raw.FullName)
+	}
+}
+
+func TestFetchRepoInfoMapsFullName(t *testing.T) {
+	src, err := os.ReadFile("client.go")
+	if err != nil {
+		t.Fatalf("read client.go: %v", err)
+	}
+	// Both the GraphQL path and the REST fallback must populate
+	// model.RepoInfo.FullName.
+	if strings.Count(string(src), "FullName:") < 2 {
+		t.Error("client.go must map FullName into model.RepoInfo on BOTH the GraphQL " +
+			"path (r.NameWithOwner) and the REST fallback (raw.FullName) — a canonical " +
+			"name that only arrives on one path makes the self-heal availability " +
+			"depend on which transport happened to serve Phase 0.")
+	}
+}

--- a/internal/platform/github/types.go
+++ b/internal/platform/github/types.go
@@ -213,6 +213,7 @@ type ghFile struct {
 }
 
 type ghRepoInfo struct {
+	FullName        string `json:"full_name"` // v0.25.32 — canonical owner/name for the case self-heal
 	ForksCount      int    `json:"forks_count"`
 	StargazersCount int    `json:"stargazers_count"`
 	WatchersCount   int    `json:"watchers_count"`

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -1001,6 +1001,7 @@ func (c *Client) FetchRepoInfo(ctx context.Context, owner, repo string) (*model.
 	}
 
 	return &model.RepoInfo{
+		FullName:          raw.PathWithNamespace,
 		LastUpdated:       raw.LastActivityAt,
 		IssuesEnabled:     raw.IssuesEnabled,
 		PRsEnabled:        raw.MergeRequestsEnabled,

--- a/internal/platform/gitlab/repoinfo_fullname_test.go
+++ b/internal/platform/gitlab/repoinfo_fullname_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// v0.25.32: GitLab's canonical repo spelling is path_with_namespace —
+// carried as RepoInfo.FullName for the Phase 0 case self-heal. GitLab
+// nested groups are covered because path_with_namespace holds the full
+// group/subgroup/project path.
+
+package gitlab
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGlProjectDecodesPathWithNamespace(t *testing.T) {
+	var raw glProject
+	if err := json.Unmarshal([]byte(`{"id": 1, "path_with_namespace": "GitLab-Org/sub/Project"}`), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if raw.PathWithNamespace != "GitLab-Org/sub/Project" {
+		t.Errorf("glProject.PathWithNamespace = %q, want the decoded path_with_namespace.",
+			raw.PathWithNamespace)
+	}
+}
+
+func TestGitLabFetchRepoInfoMapsFullName(t *testing.T) {
+	src, err := os.ReadFile("client.go")
+	if err != nil {
+		t.Fatalf("read client.go: %v", err)
+	}
+	if !strings.Contains(string(src), "FullName:") {
+		t.Error("gitlab client.go's FetchRepoInfo must map path_with_namespace into " +
+			"model.RepoInfo.FullName — GitLab/GitHub parity for the case self-heal.")
+	}
+}

--- a/internal/platform/gitlab/types.go
+++ b/internal/platform/gitlab/types.go
@@ -140,6 +140,7 @@ type glMRApproval struct {
 
 type glProject struct {
 	ID                   int64     `json:"id"`
+	PathWithNamespace    string    `json:"path_with_namespace"` // v0.25.32 — canonical group/subgroup/project for the case self-heal
 	Description          string    `json:"description"`
 	DefaultBranch        string    `json:"default_branch"`
 	WebURL               string    `json:"web_url"`

--- a/internal/platform/repourl.go
+++ b/internal/platform/repourl.go
@@ -120,6 +120,75 @@ func ParseRepoURLWithHints(rawURL string, gitlabHosts map[string]bool) (RepoURL,
 	return result, nil
 }
 
+// ParseAnyRepoURL is ParseRepoURL with a generic-git fallback: URLs on
+// hosts that are neither GitHub nor GitLab return Platform =
+// model.PlatformGenericGit (last path segment as Repo, the rest as Owner)
+// instead of ErrUnknownPlatform. Use this where the catalog accepts any
+// git host (web bulk paste, redirect handling, URL rewrites); use
+// ParseRepoURL where only forge URLs are valid.
+//
+// Note the host-based detection is stricter than the historical
+// strings.Contains(url, "github.com") checks it replaces: a URL like
+// https://mirror.example/github.com/x now classifies as generic git.
+func ParseAnyRepoURL(rawURL string) (RepoURL, error) {
+	parsed, err := ParseRepoURLWithHints(rawURL, nil)
+	if err == nil {
+		return parsed, nil
+	}
+	if !errors.Is(err, ErrUnknownPlatform) {
+		return RepoURL{}, err
+	}
+
+	// Unknown host — generic git. Re-derive host/path with the same
+	// trimming rules as ParseRepoURLWithHints.
+	trimmed := strings.TrimSpace(rawURL)
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+	u, perr := url.Parse(trimmed)
+	if perr != nil {
+		return RepoURL{}, fmt.Errorf("%w: %v", ErrInvalidRepoURL, perr)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return RepoURL{}, fmt.Errorf("%w: need at least owner/repo in path", ErrInvalidRepoURL)
+	}
+	return RepoURL{
+		Platform: model.PlatformGenericGit,
+		Host:     strings.ToLower(u.Host),
+		Owner:    strings.Join(parts[:len(parts)-1], "/"),
+		Repo:     parts[len(parts)-1],
+		Raw:      trimmed,
+	}, nil
+}
+
+// ParseOrgURL extracts the host and org/group name from an org URL like
+// https://github.com/torvalds or https://gitlab.com/gitlab-org. The org
+// name is the FIRST path segment only (top-level org/group) — matching the
+// historical inline parsers in AddOrgToGroup and scanOrgRepos this
+// consolidates. Schemeless input ("github.com/chaoss") is tolerated
+// because the web org-add path historically accepted it.
+func ParseOrgURL(rawURL string) (host, orgName string, err error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", "", fmt.Errorf("%w: empty URL", ErrInvalidRepoURL)
+	}
+	if !strings.Contains(rawURL, "://") {
+		rawURL = "https://" + rawURL
+	}
+	u, perr := url.Parse(rawURL)
+	if perr != nil {
+		return "", "", fmt.Errorf("%w: %v", ErrInvalidRepoURL, perr)
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("%w: missing host", ErrInvalidRepoURL)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return "", "", fmt.Errorf("%w: missing org name in path", ErrInvalidRepoURL)
+	}
+	return strings.ToLower(u.Host), parts[0], nil
+}
+
 // detectPlatform identifies the platform from the hostname.
 func detectPlatform(host string, gitlabHosts map[string]bool) model.Platform {
 	if host == "github.com" || strings.HasSuffix(host, ".github.com") {

--- a/internal/platform/repourl_any_test.go
+++ b/internal/platform/repourl_any_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// ParseAnyRepoURL is the consolidation target for the inline owner/name
+// parsers that used to live in collector/prelim.go (parseOwnerName),
+// db/web_store.go (AddRepoToGroup), db/postgres.go (UpdateRepoURL), and
+// web/server.go (scanOrgRepos). The forge cases below are ported verbatim
+// from prelim_test.go TestParseOwnerName and prelim_edge_test.go so the
+// behavior contract survives the consolidation.
+func TestParseAnyRepoURL_ForgeURLs(t *testing.T) {
+	tests := []struct {
+		url          string
+		wantPlatform model.Platform
+		wantOwner    string
+		wantRepo     string
+	}{
+		{"https://github.com/torvalds/linux", model.PlatformGitHub, "torvalds", "linux"},
+		{"https://github.com/chaoss/augur.git", model.PlatformGitHub, "chaoss", "augur"},
+		{"https://github.com/org/repo/", model.PlatformGitHub, "org", "repo"},
+		// GitLab nested groups: everything but the last segment is the owner.
+		{"https://gitlab.com/group/subgroup/project", model.PlatformGitLab, "group/subgroup", "project"},
+		{"https://gitlab.com/a/b/c/d", model.PlatformGitLab, "a/b/c", "d"},
+		{"https://gitlab.com/a/b/c/d/project", model.PlatformGitLab, "a/b/c/d", "project"},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseAnyRepoURL(tt.url)
+		if err != nil {
+			t.Errorf("ParseAnyRepoURL(%q) unexpected error: %v", tt.url, err)
+			continue
+		}
+		if got.Platform != tt.wantPlatform {
+			t.Errorf("ParseAnyRepoURL(%q) platform = %v, want %v", tt.url, got.Platform, tt.wantPlatform)
+		}
+		if got.Owner != tt.wantOwner {
+			t.Errorf("ParseAnyRepoURL(%q) owner = %q, want %q", tt.url, got.Owner, tt.wantOwner)
+		}
+		if got.Repo != tt.wantRepo {
+			t.Errorf("ParseAnyRepoURL(%q) repo = %q, want %q", tt.url, got.Repo, tt.wantRepo)
+		}
+	}
+}
+
+// Unknown hosts must NOT error the way ParseRepoURL does — they fall back
+// to PlatformGenericGit so facade-only collection can proceed. This is the
+// behavioral difference that justifies the "Any" name.
+func TestParseAnyRepoURL_GenericGitFallback(t *testing.T) {
+	tests := []struct {
+		url       string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"https://git.example.org/owner/repo", "owner", "repo"},
+		{"https://code.company.io/team/sub/project.git", "team/sub", "project"},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseAnyRepoURL(tt.url)
+		if err != nil {
+			t.Errorf("ParseAnyRepoURL(%q) unexpected error: %v", tt.url, err)
+			continue
+		}
+		if got.Platform != model.PlatformGenericGit {
+			t.Errorf("ParseAnyRepoURL(%q) platform = %v, want PlatformGenericGit", tt.url, got.Platform)
+		}
+		if got.Owner != tt.wantOwner || got.Repo != tt.wantRepo {
+			t.Errorf("ParseAnyRepoURL(%q) = (%q, %q), want (%q, %q)",
+				tt.url, got.Owner, got.Repo, tt.wantOwner, tt.wantRepo)
+		}
+	}
+}
+
+func TestParseAnyRepoURL_Errors(t *testing.T) {
+	bad := []string{
+		"",                              // empty
+		"https://github.com",            // no path
+		"https://github.com/",           // empty path
+		"https://github.com/org",        // single segment: no repo
+		"github.com/org/repo",           // schemeless — callers validate/prepend scheme first
+		"ssh://git@github.com/org/repo", // unsupported scheme
+	}
+	for _, u := range bad {
+		if _, err := ParseAnyRepoURL(u); err == nil {
+			t.Errorf("ParseAnyRepoURL(%q) expected error, got nil", u)
+		}
+	}
+}
+
+func TestParseOrgURL(t *testing.T) {
+	tests := []struct {
+		url      string
+		wantHost string
+		wantOrg  string
+	}{
+		{"https://github.com/torvalds", "github.com", "torvalds"},
+		{"https://github.com/Azure/", "github.com", "Azure"},
+		{"https://gitlab.com/gitlab-org", "gitlab.com", "gitlab-org"},
+		// Schemeless tolerated: the web org-add path historically accepted it.
+		{"github.com/chaoss", "github.com", "chaoss"},
+	}
+
+	for _, tt := range tests {
+		host, org, err := ParseOrgURL(tt.url)
+		if err != nil {
+			t.Errorf("ParseOrgURL(%q) unexpected error: %v", tt.url, err)
+			continue
+		}
+		if host != tt.wantHost || org != tt.wantOrg {
+			t.Errorf("ParseOrgURL(%q) = (%q, %q), want (%q, %q)",
+				tt.url, host, org, tt.wantHost, tt.wantOrg)
+		}
+	}
+}
+
+func TestParseOrgURL_Errors(t *testing.T) {
+	for _, u := range []string{"", "https://github.com", "https://github.com/"} {
+		if _, _, err := ParseOrgURL(u); err == nil {
+			t.Errorf("ParseOrgURL(%q) expected error, got nil", u)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1007,12 +1007,11 @@ func (s *Server) handleAddOrg(w http.ResponseWriter, r *http.Request) {
 // Handles both orgs (/orgs/{name}/repos) and users (/users/{name}/repos).
 func (s *Server) scanOrgRepos(ctx context.Context, groupID int64, orgURL string) {
 	orgURL = strings.TrimSuffix(strings.TrimSpace(orgURL), "/")
-	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(orgURL, "https://"), "http://"), "/")
-	if len(parts) < 2 {
+	host, name, err := platform.ParseOrgURL(orgURL)
+	if err != nil {
 		return
 	}
-	name := parts[1]
-	isGitHub := strings.Contains(orgURL, "github.com")
+	isGitHub := host == "github.com"
 
 	if !isGitHub || s.ghKeys == nil {
 		return


### PR DESCRIPTION
Fixing an issue I encountered with batch loading. This is similar to an issue that once existed in Augur. The biggest difference here is low impact and comprehensive cleanup. 

Part 1 — Self-heal of case drift at collection time

Files: internal/model/repoinfo.go, internal/platform/github/client.go + types.go, internal/platform/gitlab/types.go + client.go, new internal/db/repo_case_heal.go, internal/collector/staged.go

- Add RepoInfo.FullName — GitHub GraphQL repoInfoGraphQL selects nameWithOwner; REST fallback maps full_name (new field on ghRepoInfo — note types.go:107 FullName belongs to a different struct); GitLab maps path_with_namespace (add to glProject).
- New HealRepoCaseDrift(ctx, repoID, fullName) (healed bool, err error): no-op if stored owner/name == fullName; if NOT strings.EqualFold → Info-log only (real renames stay prelim's job — documented carve-out: forge treats case variants as the same resource, so case-only change ≠ identity change); else build newURL (scheme+host from stored URL + fullName), exact-match occupancy check (repo_git = $newURL AND repo_id <> $1 — NOT the now-case-insensitive FindRepoByURL, which would match itself); if occupied → WARN with dedup-repos hint; else UpdateRepoURLs (also rewrites stored issue/PR html_urls). GitLab nested groups work: both sides carry full group/subgroup path.
- Staged collector Phase 0 (staged.go ~:251, after UpdateRepoMetadata): guarded non-fatal call, Info log on heal.

Part 2 — Parser consolidation (adjacent complexity reduction)

File: internal/platform/repourl.go — two new exported helpers:
- ParseAnyRepoURL(rawURL) (RepoURL, error) — ParseRepoURLWithHints + generic-git fallback (unknown host → model.PlatformGenericGit instead of error).
- ParseOrgURL(rawURL) (host, orgName string, err error).

Replace inline duplicates: prelim.go:198 parseOwnerName (delete; call site :122 uses ParseAnyRepoURL), web_store.go:436 (dies in the AddRepoToGroup refactor), web_store.go:491-500 AddOrgToGroup (ParseOrgURL), postgres.go:533-540 UpdateRepoURL (ParseAnyRepoURL; keep trailing NormalizeRepoName — pinned), web/server.go:1010 scanOrgRepos (ParseOrgURL). Leave alone: analysis.go ecosystem parsers, extractRepoPath (URL-rewrite path-piece), prelim's comparison-only normalizeRepoURL. Note: host-based detection is stricter than the old strings.Contains checks — document in commit.

Test plan (TDD — tests first per part)

- New source-contract: internal/db/repo_case_test.go (FindRepoByURL LOWER+platform gate+ORDER BY; UpsertRepo resolve-before-insert + 23505 retry + GitURL suffix trim), internal/db/web_store_addrepo_test.go (AddRepoToGroup calls FindRepoByURL+UpsertRepo, no raw INSERT, keeps status gate), internal/db/v025_32_repo_git_ci_test.go (migration fn name + call site + warn-only shape + dup-count-before-create + fail-closed lookup index), internal/db/repo_dedup_test.go (FK-coverage drift guard, repoint-not-delete pins, collecting-skip, MIN winner), cmd/aveloxis/dedup_repos_test.go (registration, flags, db fn calls), internal/db/repo_case_heal_test.go (EqualFold guard, UpdateRepoURLs reuse, occupancy check, dedup hint), internal/collector/staged_case_heal_test.go (Phase 0 hook, non-fatal).
- New integration (AVELOXIS_TEST_DB-gated, style of cntrb_id_merge_integration_test.go; local recipe: aveloxis.runlocal.json / scratch DB): repo_case_integration_test.go (case-variant upsert → same repo_id; exact preferred; platform-3 NOT matched; heal happy path + occupied-guard path), repo_dedup_integration_test.go (seeded pair with issues/PRs/reviews/commits/shared-message-owned-by-loser/user_repos/queue/staging → winner intact, message repointed, user_repos repointed, loser fully gone, idempotent re-run = 0, collecting pair skipped). Add a cross-user sharing case to repo_case_integration_test.go: seed a collected repo + group A linked to it; a SECOND group adds the case-variant URL via AddRepoToGroup → both groups' user_repos rows point at the same repo_id, total repos rows for that LOWER key stays 1, and no new queue row is created.
- Platform tests: repoInfoGraphQL selects nameWithOwner; REST/GitLab decode populates FullName; repourl_any_test.go ports prelim parse cases + generic fallback + org URLs.
- Existing tests affected: prelim_test.go:40-50 + prelim_edge_test.go:48-75 call parseOwnerName directly → port cases to repourl_any_test.go and remove/convert. These stay green (verify): reponame_normalize_test.go, scheduler/git_url_test.go (NormalizeRepoName stays first in UpsertRepo), group_approval_test.go (status gate kept), refresh_org_user_repos_test.go, add_repo_org_link_test.go, idempotent_test.go (new INSERTs carry ON CONFLICT).

Version, changelog, docs

- internal/db/version.go → 0.25.32; current-version line + changelog entry + Common Pitfalls note (repo_git case-insensitive resolution for platforms 1/2; unique index created only after dedup-repos drains; generic git stays byte-exact).
- docs/guide/commands.md: aveloxis dedup-repos section. docs/guide/troubleshooting.md: "Case-variant duplicate repositories" runbook (symptom, diagnosis SQL, fix sequence, the migrate WARN text).

Operator deployment 

1. aveloxis stop serve (optional but drains everything in one run — command skips collecting pairs otherwise).
2. Deploy v0.25.32; aveloxis migrate → creates lookup index, WARNs "1,220 case-dup groups — run aveloxis dedup-repos", skips unique index.
3. aveloxis dedup-repos --dry-run → review; then aveloxis dedup-repos --limit 50 canary → full run until 0 pairs.
4. aveloxis migrate again → unique index builds (hard backstop from here on).
5. aveloxis refresh-views (analytics stop double-counting immediately); aveloxis start all.

Risks / edge cases (handled in design)

- Concurrent collection: skip+report collecting pairs; per-pair tx re-checks loser queue row FOR UPDATE first.
- Winner with non-canonical case: harmless; Phase 3 self-heal fixes it on next collection.
- UpsertRepo race pre-index: best-effort until unique index exists; next migrate WARNs and dedup drains any stragglers; guaranteed post-index (23505 retry path).
- Suffix variants (.git/trailing /): production groups are pure case variants; UpsertRepo gains GitURL suffix-trim hardening; dry-run additionally reports (not acts on) suffix-variant groups.
- Loser-only messages: repointed to winner, re-linked by winner's next collection via ON CONFLICT — no data loss.

Verification

1. go test ./... green (full suite).
2. AVELOXIS_TEST_DB=<scratch> go test ./internal/db/ -run 'RepoCase|RepoDedup' -v — integration tier green on a scratch DB (never production).
3. End-to-end against scratch DB: seed an Azure/x+azure/x pair via two UpsertRepo calls on the OLD binary path (or SQL), run aveloxis migrate (expect WARN), dedup-repos --dry-run, dedup-repos, migrate (expect unique index), then UpsertRepo with the lowercase variant → returns winner repo_id, no new row.
4. Optionally verify prevention live: aveloxis add-repo https://github.com/azure/azure-sdk-tools against scratch → resolves to existing canonical row.
