### PR TITLE
Perf/mailing lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ syslog
 # v0.27.29: purl-spec canonical cases fixture
 !internal/collector/testdata/*.json
 !internal/collector/testdata/registries/*.json
+!internal/collector/testdata/manifest_corpus/*.json
 *code-workspace
 db.config.json
 aveloxis.chaoss.tv.json

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then run migrations:
 aveloxis migrate
 ```
 
-This creates 141 tables (100 in `aveloxis_data`, 37 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
+This creates 142 tables (100 in `aveloxis_data`, 38 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
 
 ### OAUTH App Setup
 You will need a github OAUTH application for login to work on the web view. And there's nothing available without login. You can also use GitLab's OAUTH, or configure both. 
@@ -542,9 +542,9 @@ Combine with `aveloxis prioritize <url>` if you want the re-collection to start 
 aveloxis migrate
 ```
 
-Creates 141 tables and 20 materialized views across three PostgreSQL schemas:
+Creates 142 tables and 20 materialized views across three PostgreSQL schemas:
 - **`aveloxis_data`** (100 tables + 20 materialized views) — all collected data plus analytics views
-- **`aveloxis_ops`** (37 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
+- **`aveloxis_ops`** (38 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
 - **`aveloxis_scan`** (4 tables) — scancode per-file license/copyright results and history
 - **`aveloxis_augur_data`** (6 views) — Augur compatibility layer for 8Knot. Contains views that alias Aveloxis column names to Augur conventions (e.g., `star_count` → `stars_count`, `pr_number` → `pr_src_number`). Only tables with column name differences have views here; identical tables resolve via search_path fallback to `aveloxis_data`.
 
@@ -949,7 +949,7 @@ Aveloxis creates 20 materialized views compatible with [8Knot](https://github.co
 Three schemas in PostgreSQL with full parity to Augur's `augur_data` and `augur_operations`, plus a dedicated schema for ScanCode results:
 
 - **`aveloxis_data`** (100 tables + 20 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 20 materialized views for 8Knot compatibility.
-- **`aveloxis_ops`** (37 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
+- **`aveloxis_ops`** (38 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
 - **`aveloxis_scan`** (4 tables) — ScanCode per-file license and copyright detection: `scancode_scans` (scan metadata), `scancode_file_results` (per-file SPDX license, copyrights, holders, packages as JSONB), plus `_history` tables for both.
 
 Tables omitted from Augur (junk): `_transfer_testing`, `_transfer_training`, `akl;fjlk;a` (renamed to `dei_badging`), `analysis_log`, `all`, `github_users_2`, `worker_oauth_copy1`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then run migrations:
 aveloxis migrate
 ```
 
-This creates 139 tables (98 in `aveloxis_data`, 34 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
+This creates 141 tables (100 in `aveloxis_data`, 37 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
 
 ### OAUTH App Setup
 You will need a github OAUTH application for login to work on the web view. And there's nothing available without login. You can also use GitLab's OAUTH, or configure both. 
@@ -542,9 +542,9 @@ Combine with `aveloxis prioritize <url>` if you want the re-collection to start 
 aveloxis migrate
 ```
 
-Creates 139 tables and 20 materialized views across three PostgreSQL schemas:
+Creates 141 tables and 20 materialized views across three PostgreSQL schemas:
 - **`aveloxis_data`** (100 tables + 20 materialized views) — all collected data plus analytics views
-- **`aveloxis_ops`** (35 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
+- **`aveloxis_ops`** (37 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
 - **`aveloxis_scan`** (4 tables) — scancode per-file license/copyright results and history
 - **`aveloxis_augur_data`** (6 views) — Augur compatibility layer for 8Knot. Contains views that alias Aveloxis column names to Augur conventions (e.g., `star_count` → `stars_count`, `pr_number` → `pr_src_number`). Only tables with column name differences have views here; identical tables resolve via search_path fallback to `aveloxis_data`.
 
@@ -949,7 +949,7 @@ Aveloxis creates 20 materialized views compatible with [8Knot](https://github.co
 Three schemas in PostgreSQL with full parity to Augur's `augur_data` and `augur_operations`, plus a dedicated schema for ScanCode results:
 
 - **`aveloxis_data`** (100 tables + 20 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 20 materialized views for 8Knot compatibility.
-- **`aveloxis_ops`** (35 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
+- **`aveloxis_ops`** (37 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
 - **`aveloxis_scan`** (4 tables) — ScanCode per-file license and copyright detection: `scancode_scans` (scan metadata), `scancode_file_results` (per-file SPDX license, copyrights, holders, packages as JSONB), plus `_history` tables for both.
 
 Tables omitted from Augur (junk): `_transfer_testing`, `_transfer_training`, `akl;fjlk;a` (renamed to `dei_badging`), `analysis_log`, `all`, `github_users_2`, `worker_oauth_copy1`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then run migrations:
 aveloxis migrate
 ```
 
-This creates 137 tables (98 in `aveloxis_data`, 34 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
+This creates 139 tables (98 in `aveloxis_data`, 34 in `aveloxis_ops`, 4 in `aveloxis_scan`) with full parity to Augur's schema. All DDL uses `CREATE ... IF NOT EXISTS` and `ON CONFLICT DO NOTHING`, so `migrate` is safe to run repeatedly.
 
 ### OAUTH App Setup
 You will need a github OAUTH application for login to work on the web view. And there's nothing available without login. You can also use GitLab's OAUTH, or configure both. 
@@ -542,8 +542,8 @@ Combine with `aveloxis prioritize <url>` if you want the re-collection to start 
 aveloxis migrate
 ```
 
-Creates 137 tables and 20 materialized views across three PostgreSQL schemas:
-- **`aveloxis_data`** (98 tables + 20 materialized views) — all collected data plus analytics views
+Creates 139 tables and 20 materialized views across three PostgreSQL schemas:
+- **`aveloxis_data`** (100 tables + 20 materialized views) — all collected data plus analytics views
 - **`aveloxis_ops`** (35 tables) — operational tables: collection queue, JSONB staging store, collection status, API credentials, users/auth, config, worker state
 - **`aveloxis_scan`** (4 tables) — scancode per-file license/copyright results and history
 - **`aveloxis_augur_data`** (6 views) — Augur compatibility layer for 8Knot. Contains views that alias Aveloxis column names to Augur conventions (e.g., `star_count` → `stars_count`, `pr_number` → `pr_src_number`). Only tables with column name differences have views here; identical tables resolve via search_path fallback to `aveloxis_data`.
@@ -948,7 +948,7 @@ Aveloxis creates 20 materialized views compatible with [8Knot](https://github.co
 
 Three schemas in PostgreSQL with full parity to Augur's `augur_data` and `augur_operations`, plus a dedicated schema for ScanCode results:
 
-- **`aveloxis_data`** (98 tables + 20 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 20 materialized views for 8Knot compatibility.
+- **`aveloxis_data`** (100 tables + 20 materialized views) — All collected data: repos, issues, PRs, commits (per-file), commit parents, commit messages, messages, events, releases, contributors, contributor identities/aliases/affiliations, dependencies/SBOM, sentiment/NLP analysis, LSTM anomaly detection, topic modeling, Facade aggregates (dm_repo_annual/monthly/weekly, dm_repo_group_annual/monthly/weekly), repo labor/complexity, DEI badging, CHAOSS metrics, network analysis, repo insights, and more. Plus 20 materialized views for 8Knot compatibility.
 - **`aveloxis_ops`** (35 tables) — Operational tables: collection queue, JSONB staging store, collection status (tracks core/secondary/facade/ML phases independently), API credentials, users/auth/sessions, config, worker history/jobs, network weighted tables.
 - **`aveloxis_scan`** (4 tables) — ScanCode per-file license and copyright detection: `scancode_scans` (scan metadata), `scancode_file_results` (per-file SPDX license, copyrights, holders, packages as JSONB), plus `_history` tables for both.
 

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -35,6 +35,7 @@
     "matview_rebuild_day": "saturday",
     "matview_rebuild_on_startup": false,
     "matview_rebuild_skip_dm_aggregates": false,
+    "activity_history_window_days": 180,
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "single",

--- a/aveloxis.example.json
+++ b/aveloxis.example.json
@@ -34,6 +34,7 @@
     "force_full": false,
     "matview_rebuild_day": "saturday",
     "matview_rebuild_on_startup": false,
+    "matview_rebuild_skip_dm_aggregates": false,
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "single",

--- a/docs/architecture/contributor-resolution.md
+++ b/docs/architecture/contributor-resolution.md
@@ -583,6 +583,23 @@ Per [R7](#r7-cached-resolution-on-the-hot-path), the `ContributorResolver` cache
 
 ---
 
+### Activity classification is GitHub-only (v0.27.57)
+
+The `gh_activity_class` / `gh_public_contribs_year` /
+`gh_restricted_contribs_year` / `gh_last_contribution_year` columns are
+populated from GitHub's GraphQL `contributionsCollection` — the only
+API surface on either forge that separates "publicly active" from
+"privately active but disclosed" (`restrictedContributionsCount`) from
+"quiet". GitLab has NO equivalent: a private-profile GitLab user's
+events feed is simply empty, with no disclosed-private-count concept,
+so gl-side contributors keep an empty `gh_activity_class` and any
+front end must treat empty as "unknown", not "inactive". This is a
+documented parity limitation, not a gap to close — the data does not
+exist on GitLab's API. Note also the deliberate honesty boundary on
+GitHub itself: `no-observable-activity` never claims "inactive",
+because truly-inactive is indistinguishable from
+active-only-in-private-with-disclosure-off (privacy by design).
+
 ## GitLab vs GitHub: column-by-column parity matrix (v0.20.3)
 
 Aveloxis collects contributor data from both GitHub and GitLab and stores them in the same `aveloxis_data.contributors` table. Some columns map cleanly between platforms; others are intentionally GitHub-only or GitLab-only. This matrix is the contract for what to expect when querying contributor data on a mixed-platform fleet.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -61,6 +61,7 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "force_full": false,
     "matview_rebuild_day": "saturday",
     "matview_rebuild_on_startup": false,
+    "matview_rebuild_skip_dm_aggregates": false,
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "sharded",
@@ -177,6 +178,7 @@ The `collection` block holds every knob for the staged-pipeline scheduler and it
 |---|---|---|---|
 | `collection.matview_rebuild_day` | string | `"saturday"` | Day of the week the scheduler refreshes the 22 materialized views. Values: `"sunday"`–`"saturday"`, or `"disabled"` / `"none"` / `"off"` to never auto-rebuild. Independent of `aveloxis refresh-views` which always refreshes on demand. |
 | `collection.matview_rebuild_on_startup` | boolean | `false` | When `true`, `aveloxis serve` rebuilds the matviews on every startup. Default `false` because the rebuild can take many minutes on large fleets and `migrate` already refreshes them on schema changes. |
+| `collection.matview_rebuild_skip_dm_aggregates` | boolean | `false` | When `true`, the weekly scheduler rebuild refreshes ONLY the materialized views and skips the `dm_` aggregate table pass (a per-repo loop that can run for days on fleet-scale databases — while it runs, new collection claims are paused). With the skip on, `dm_repo_*` / `dm_repo_group_*` tables update only when an operator runs `aveloxis refresh-views` or `aveloxis migrate`. To disable the weekly rebuild entirely (matviews AND aggregates), set `matview_rebuild_day` to `"disabled"`. |
 
 **REST → GraphQL refactor (v0.18.x phases)**
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -62,6 +62,7 @@ A full configuration with **every** supported option (current as of v0.20.12):
     "matview_rebuild_day": "saturday",
     "matview_rebuild_on_startup": false,
     "matview_rebuild_skip_dm_aggregates": false,
+    "activity_history_window_days": 180,
     "pr_child_mode": "graphql",
     "listing_mode": "graphql",
     "threading_mode": "sharded",
@@ -178,6 +179,7 @@ The `collection` block holds every knob for the staged-pipeline scheduler and it
 |---|---|---|---|
 | `collection.matview_rebuild_day` | string | `"saturday"` | Day of the week the scheduler refreshes the 22 materialized views. Values: `"sunday"`–`"saturday"`, or `"disabled"` / `"none"` / `"off"` to never auto-rebuild. Independent of `aveloxis refresh-views` which always refreshes on demand. |
 | `collection.matview_rebuild_on_startup` | boolean | `false` | When `true`, `aveloxis serve` rebuilds the matviews on every startup. Default `false` because the rebuild can take many minutes on large fleets and `migrate` already refreshes them on schema changes. |
+| `collection.activity_history_window_days` | integer | `180` | Span of each GitHub `contributionsCollection` window the daily contributor-history backfill queries (v0.27.58). Clamped to 365 (GitHub's hard 1-year window limit); non-positive falls back to 180. This is the STARTING span — when a window hits the 100-repositories-per-type cap or a contribution page cap, the worker halves the window recursively and logs the cap hit at INFO so loss rate is trackable. |
 | `collection.matview_rebuild_skip_dm_aggregates` | boolean | `false` | When `true`, the weekly scheduler rebuild refreshes ONLY the materialized views and skips the `dm_` aggregate table pass (a per-repo loop that can run for days on fleet-scale databases — while it runs, new collection claims are paused). With the skip on, `dm_repo_*` / `dm_repo_group_*` tables update only when an operator runs `aveloxis refresh-views` or `aveloxis migrate`. To disable the weekly rebuild entirely (matviews AND aggregates), set `matview_rebuild_day` to `"disabled"`. |
 
 **REST → GraphQL refactor (v0.18.x phases)**

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -29,8 +29,10 @@ GET /api/v1/public/stats
 ```
 
 Public (no token required, like `/health`) — the landing page's
-"repositories under analysis" number. Returns the count of
-non-archived repositories in the catalog, served from a 60-second
+"repositories under analysis" number. Returns the TOTAL repository
+count in the catalog (v0.27.68: archived repos included — they carry
+full collected history and analysis, and the number should agree
+with the monitor's queue view), served from a 60-second
 cache that keeps the last good value if the database hiccups. Still
 subject to the per-IP rate limiter.
 

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -390,7 +390,9 @@ private contributions when the user enabled disclosure, which is why
 it can exceed the per-repo sum). `months` defaults 24, caps 60;
 `bucket` accepts only `month` (400 otherwise — reserved for future
 granularities). `cntrbID` must be a UUID (400 otherwise); unknown
-contributors 404.
+contributors 404. Operational failures (database errors) surface as
+500, never 404 — a 404 always means "this id parsed but nobody has
+it" (v0.27.76).
 
 Requires a Bearer identity but NOT repo scope: person-level history
 spans repositories this instance doesn't track, so repo scope cannot

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -22,6 +22,22 @@ Returns the server status and version.
 {"status": "ok", "version": "0.9.0"}
 ```
 
+### Public repository count
+
+```
+GET /api/v1/public/stats
+```
+
+Public (no token required, like `/health`) — the landing page's
+"repositories under analysis" number. Returns the count of
+non-archived repositories in the catalog, served from a 60-second
+cache that keeps the last good value if the database hiccups. Still
+subject to the per-IP rate limiter.
+
+```json
+{"repos": 12483}
+```
+
 ### Repository Statistics
 
 ```
@@ -257,6 +273,118 @@ The derivation priority is deliberate: the curated domain map is updated by a ba
 - **Group of repos**: the two endpoints are per-repo. For an org-wide rollup, call them for each repo in the group and merge the responses (the `cntrb_id` column is stable across repos so dedup is trivial).
 - **Hide the `(unknown)` bucket**: filter on the client. The server returns it so the math reconciles with `/contributions/identities`.
 - **Different windows**: `?since=YYYY-MM-DD` and `?until=YYYY-MM-DD` are both accepted independently. Omit `until` for "everything since `since`".
+
+### Top contributors, ranked (v0.27.61)
+
+```
+GET /api/v1/repos/{repoID}/contributors/top
+GET /api/v1/repos/{repoID}/contributors/top?since=2024-01-01&until=2024-12-31&limit=20
+```
+
+The ranked "who does the work here" table behind the repo page's Top
+contributors card. Same `since`/`until` window semantics as the
+`/contributions/*` endpoints (default: trailing 2 years; `until` is
+inclusive); `limit` defaults to 20 and is capped at 100. Requires the
+same repo scope as every other per-repo endpoint; responses are served
+from a 60-second cache (the underlying data only changes per
+collection cycle).
+
+Response:
+
+```json
+{
+  "since": "2024-07-31T00:00:00Z",
+  "until": "0001-01-01T00:00:00Z",
+  "limit": 20,
+  "contributors": [
+    {
+      "cntrb_id": "01001234-...",
+      "login": "octocat",
+      "full_name": "Octo Cat",
+      "activity_class": "active",
+      "commits": 412, "issues": 38, "prs": 91, "reviews": 130, "comments": 505,
+      "total": 1176
+    }
+  ]
+}
+```
+
+What counts, per column: `commits` = DISTINCT commit hashes authored
+(windowed on the commit's author timestamp); `issues` = issues opened;
+`prs` = pull requests opened; `reviews` = PR reviews submitted;
+`comments` = unified messages (issue comments + PR conversation +
+inline review comments). `total` is the sum and the ranking key.
+
+Issue/PR **events** (labels, assignments, closes) deliberately do NOT
+count here even though they DO count for cohort membership in
+`/contributions/identities` — this endpoint ranks creative/review
+work; the identities endpoint enumerates everyone who touched the
+repo at all. `activity_class` is the v0.27.57 classification (empty =
+never checked or GitLab-side). Commits whose author was never resolved
+to a contributor identity are excluded — there is no identity to rank.
+
+### Where else are these contributors active? (v0.27.64)
+
+```
+GET /api/v1/repos/{repoID}/contributors/elsewhere
+GET /api/v1/repos/{repoID}/contributors/elsewhere?since=2026-02-01&limit=10
+```
+
+For the repo's top contributors (same ranking as `/contributors/top`;
+`limit` default 10, cap 25), their top-10 OTHER repositories from the
+v0.27.58 contributor daily-history tables (GitHub
+contributionsCollection data), aggregated over the window (`since`
+defaults to the trailing 180 days — the standard history window).
+Response rows per contributor:
+
+```json
+{
+  "since": "2026-02-01", "limit": 10,
+  "contributors": [
+    {
+      "cntrb_id": "0100...", "login": "octocat",
+      "backfilled_at": "2026-07-30T02:11:00Z",
+      "elsewhere": [
+        {"repo_full_name": "kubernetes/kubernetes", "repo_id": 4021,
+         "active_days": 14, "commits": 33, "issues": 2, "prs": 5, "reviews": 9},
+        {"repo_full_name": "torvalds/linux",
+         "active_days": 3, "commits": 4, "issues": 0, "prs": 0, "reviews": 0}
+      ]
+    }
+  ]
+}
+```
+
+**Reading `backfilled_at`** (the honesty rule): a `null` stamp means
+the v0.27.58 history backfill has not reached this contributor yet —
+their empty `elsewhere` array is "history pending", NOT "active
+nowhere else". Frontends must render the two differently. `repo_id`
+is present only when the repo is tracked on this instance
+(GitHub-side match; the history source is GitHub-only). The current
+repo is excluded case-insensitively (GitHub's canonical casing can
+differ from ours).
+
+### One contributor's cross-repo activity (v0.27.64)
+
+```
+GET /api/v1/contributors/{cntrbID}/activity
+GET /api/v1/contributors/{cntrbID}/activity?bucket=month&months=24
+```
+
+The person-level view: monthly per-repo activity buckets (top-10
+repos by total activity in the window) plus the contribution
+calendar's disclosed day-total series (`day_totals` — includes
+private contributions when the user enabled disclosure, which is why
+it can exceed the per-repo sum). `months` defaults 24, caps 60;
+`bucket` accepts only `month` (400 otherwise — reserved for future
+granularities). `cntrbID` must be a UUID (400 otherwise); unknown
+contributors 404.
+
+Requires a Bearer identity but NOT repo scope: person-level history
+spans repositories this instance doesn't track, so repo scope cannot
+express an authorization boundary for it — and it is not anonymous
+data, so a signed-in identity is the floor. Carries `backfilled_at`
+with the same semantics as `/contributors/elsewhere`.
 
 ### Knowing whether your coverage is complete
 
@@ -497,7 +625,7 @@ collected.
 ## Authentication: getting an API token
 
 When `api.require_auth` is `true`, every data endpoint (everything
-except `GET /api/v1/health`) requires a session token sent as
+except `GET /api/v1/health` and `GET /api/v1/public/stats`) requires a session token sent as
 `Authorization: Bearer <token>`. Exempt-CIDR clients (same box / LAN
 by default) bypass this for the read endpoints; the portal endpoints
 above always require a token regardless.
@@ -646,6 +774,20 @@ Token semantics:
   requests opened). Default limit is 50 (v0.27.14; was 20). There is
   no cap on the number of repos a user may star — the limit only
   bounds how many rows the home list returns per request.
+- `GET /api/v1/home/new-repos?days=30` — the "New Repositories" home
+  feed (v0.27.62): `{"days", "fleet": [...], "mine": [...]}` where
+  each row is `{repo_id, owner, name, org, added_at}`, newest-first,
+  up to 200 rows per arm. `fleet` = repos added inside the window
+  whose owner matches an org registered by an ADMIN user (the curated
+  what's-new-on-this-instance signal); `mine` = same, for orgs the
+  caller registered. Orgs whose owning group is rejected surface in
+  neither arm. `days` defaults to 30, capped at 90. Requires a Bearer
+  identity (discovery surface — not repo-scoped, same posture as
+  `/repos/search`). `added_at` is the v0.27.60 fleet-entry stamp;
+  rows created before that release carry a last-touch approximation,
+  so the feed is honest-noisy for one window after that deploy.
+  Known v1 edge: GitLab nested-group paths (`group/subgroup`) don't
+  equal `repo_owner` and fall out of the feed.
 - `GET /api/v1/repos/{repoID}/scorecard` — the current OpenSSF
   Scorecard results for the repo:
   `{"repo_id", "scanned", "as_of", "overall", "checks": [{"name", "score"}]}`.
@@ -759,6 +901,49 @@ Admin-only:
   exact same `PrioritizeRepo` store call the legacy :5555 monitor's
   `/api/prioritize/{repoID}` makes. 404 when the repo has no queue
   row; 400 for a non-numeric id. Returns `{ok: true, repo_id}`.
+
+## Collections (v0.27.63)
+
+Admin-curated groups-of-groups for the GUI home page ("Apache
+Graduated", "CNCF Sandbox", …). A collection joins to LIVE
+`user_groups` — never a frozen repo list — so admin org-groups that
+auto-grow via org scans keep their collections fresh for free. Only
+admin-owned groups may be members (link-time check). Mutations are
+POST-everywhere because the CORS `Allow-Methods` header only
+advertises GET/POST.
+
+Reads (any authenticated user):
+
+- `GET /api/v1/collections` — `{collections: [{collection_id, name,
+  description, position, groups, repos, created_at}]}`,
+  position-ordered, repo counts deduped across member groups.
+- `GET /api/v1/collections/{collectionID}?page&page_size` — member
+  groups (each with live repo count) + one page of the deduped repo
+  set: `{collection_id, groups, repos, total, page, page_size}`.
+  Page size defaults 50, caps 100; ordering is owner/name with
+  repo_id as the stable tiebreaker.
+- `POST /api/v1/collections/{collectionID}/copy` with `{group_id}`
+  (must be the caller's) or `{group_name}` (find-or-create for the
+  caller) — links every repo of the collection into that group and
+  returns `{added, group_id}` (repos already in the group no-op).
+  **Never enqueues collection and never creates add-requests**:
+  collection repos are already tracked, and approval only ever gates
+  NEW collection (v0.27.20). The caller's auth scope and home cache
+  are invalidated so the repos are visible on the next request.
+
+Admin mutations (requireAdmin):
+
+- `POST /api/v1/admin/collections` `{name, description, position}` →
+  `{collection_id}`. Name is globally UNIQUE.
+- `POST /api/v1/admin/collections/{collectionID}` `{name,
+  description, position}` — update in place.
+- `POST /api/v1/admin/collections/{collectionID}/delete` — removes
+  the collection; member links cascade, member groups are untouched.
+- `POST /api/v1/admin/collections/{collectionID}/groups`
+  `{group_id}` — link an ADMIN-OWNED group (400 for a group owned by
+  a non-admin; linking an already-linked group is an idempotent ok).
+- `POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove`
+  — unlink; the group and its repos are untouched.
 
 
 ## Window-boundary semantics (v0.27.39)

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -169,13 +169,34 @@ Response shape:
     "full_name": "Alice Anderson",
     "email": "alice@example.com",
     "profile_company": "Acme Corp",
-    "location": "Berlin"
+    "location": "Berlin",
+    "activity_class": "private-active",
+    "public_contribs_year": 0,
+    "restricted_contribs_year": 812,
+    "last_contribution_year": 2026
   },
   ...
 ]
 ```
 
 All string fields are normalized server-side: `""` represents "no value recorded" (no per-field null handling needed on the client). Ordering is by `login NULLS LAST, full_name NULLS LAST` so unidentifiable contributors sort to the bottom of the roster.
+
+**Activity classification fields** (v0.27.57, GitHub only — GitLab has no
+equivalent of `restrictedContributionsCount`, so gl-side contributors keep
+an empty `activity_class`): sourced from GitHub's GraphQL
+`contributionsCollection` over the trailing year and refreshed by a
+scheduler sweep on the breadth cooldown cadence.
+
+| `activity_class` | Meaning |
+|---|---|
+| `public-active` | Public contributions > 0 in the trailing year. |
+| `private-active` | Zero public, but the user disclosed private activity (`restricted_contribs_year` > 0 — the profile's "N contributions in private repositories"). |
+| `dormant` | Nothing observable this year; `last_contribution_year` shows when they were last active. |
+| `no-observable-activity` | Nothing, ever. Render this honestly — GitHub deliberately makes truly-inactive indistinguishable from active-only-in-private with disclosure off. |
+| `""` | Never checked yet, GitLab-side contributor, or the account was deleted/renamed at check time. |
+
+`public_contribs_year` is derived as calendar-total minus restricted
+(the calendar includes disclosed private contributions).
 
 **What counts as a contribution** (all in one window via the unified messages table and the standard work-tracking tables):
 

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -286,7 +286,17 @@ GET /api/v1/repos/{repoID}/contributors/top?since=2024-01-01&until=2024-12-31&li
 The ranked "who does the work here" table behind the repo page's Top
 contributors card. Same `since`/`until` window semantics as the
 `/contributions/*` endpoints (default: trailing 2 years; `until` is
-inclusive); `limit` defaults to 20 and is capped at 100. Requires the
+inclusive); `limit` defaults to 20 and is capped at 100.
+
+`?bots=hide` (v0.27.69) filters bot identities by three markers:
+`gh_type='Bot'` (GitHub App accounts like `dependabot[bot]`), the
+`[bot]` login suffix, and the hyphenated `-bot`/`-robot`
+machine-account convention (the `k8s-ci-robot` class, which GitHub
+types as a regular User — verified live). The separator requirement
+keeps human surnames (talbot) safe. Deliberately broader than the
+`contributor_retention` metric's bot exclusion, which is pinned to
+8Knot parity; this one is a display filter. The same parameter works
+on `/contributors/elsewhere` so the two surfaces stay consistent. Requires the
 same repo scope as every other per-repo endpoint; responses are served
 from a 60-second cache (the underlying data only changes per
 collection cycle).

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -927,8 +927,17 @@ advertises GET/POST.
 Reads (any authenticated user):
 
 - `GET /api/v1/collections` — `{collections: [{collection_id, name,
-  description, position, groups, repos, created_at}]}`,
-  position-ordered, repo counts deduped across member groups.
+  description, position, groups, repos, starred, created_at}]}`, repo
+  counts deduped across member groups. Ordering (v0.27.70): the
+  CALLER's starred collections first, then position, then name.
+  `starred` reflects the calling user only — stars are a per-user
+  sort preference, never a visibility control (every collection is
+  visible to every authenticated user).
+- `PUT /api/v1/collections/{collectionID}/star` /
+  `DELETE .../star` — star / unstar the collection for the signed-in
+  user (mirrors the repo-star routes). Both idempotent; PUT on a
+  nonexistent collection returns 404. Response
+  `{ok, starred}`.
 - `GET /api/v1/collections/{collectionID}?page&page_size` — member
   groups (each with live repo count) + one page of the deduped repo
   set: `{collection_id, groups, repos, total, page, page_size}`.

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -833,16 +833,21 @@ Per-user:
 - `POST /api/v1/groups` with `{"name": "..."}` — create a group.
   Non-admin users' groups start `pending` per the v0.19.0 approval
   workflow. Returns `{group_id}`.
-- `GET /api/v1/groups/{groupID}/repos?page=1&page_size=50` — one page
-  of the group's repos in a pagination envelope (v0.27.14):
-  `{repos: [...], total, page, page_size}` (`page_size` defaults to
-  50, capped at 100). Each repo row is
-  `{repo_id, owner, name, git_url, commits_all_time, issues_all_time,
-  prs_all_time, starred}` — the `*_all_time` counts are the forge's
-  own ALL-TIME totals from the latest repo_info snapshot (deliberately
-  not a windowed activity metric), fetched per page via the batched
-  stats cache; `starred` reflects the calling user's star state.
-  Non-admins may only read their own groups (403 otherwise).
+- `GET /api/v1/groups/{groupID}/repos?page=1&page_size=50&sort=name&dir=asc`
+  — one page of the group's repos in a pagination envelope:
+  `{repos: [...], total, page, page_size, sort, dir}` (`page_size`
+  defaults to 50, capped at 100). v0.27.75: the row shape and sort
+  semantics are IDENTICAL to the collection detail listing. Each repo
+  row is `{repo_id, owner, name, git_url, issues, prs, commits,
+  last_collected?, last_activity?, starred}` — the counts are the
+  collection queue's cached cumulative gathered totals (never a
+  per-request aggregation), `last_activity` is the forge's own
+  `last_updated` from the latest repo_info snapshot, and `starred`
+  reflects the calling user's star state. `sort` accepts `name`
+  (default), `issues`, `prs`, `commits`, `collected`, `activity`;
+  `dir` accepts `asc` (default) or `desc`; unknown values fall back
+  and the response echoes the effective sort. Non-admins may only
+  read their own groups (403 otherwise).
 - `POST /api/v1/groups/{groupID}/repos` with
   `{"url": "https://github.com/owner/repo", "kind": "repo"}` (or
   `"kind": "org"` with an org URL) — add a repo or track an org.

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -938,11 +938,20 @@ Reads (any authenticated user):
   user (mirrors the repo-star routes). Both idempotent; PUT on a
   nonexistent collection returns 404. Response
   `{ok, starred}`.
-- `GET /api/v1/collections/{collectionID}?page&page_size` — member
-  groups (each with live repo count) + one page of the deduped repo
-  set: `{collection_id, groups, repos, total, page, page_size}`.
-  Page size defaults 50, caps 100; ordering is owner/name with
-  repo_id as the stable tiebreaker.
+- `GET /api/v1/collections/{collectionID}?page&page_size&sort&dir` —
+  member groups (each with live repo count) + one page of the deduped
+  repo set: `{collection_id, groups, repos, total, page, page_size,
+  sort, dir}`. Page size defaults 50, caps 100. v0.27.74: rows carry
+  `issues`, `prs`, `commits` (the queue's CACHED cumulative counts —
+  the monitor's numbers, never per-request aggregation),
+  `last_collected`, `last_activity` (the FORGE's own last_updated
+  from the latest repo_info snapshot — deliberately not a live
+  per-table MAX, keeping page renders cheap at 3K-repo collection
+  scale), and the calling user's `starred` flag. `sort` ∈ name |
+  issues | prs | commits | collected | activity (allowlisted
+  server-side; unknown falls back to name), `dir` ∈ asc | desc;
+  repo_id is always the stable tiebreaker. The envelope echoes the
+  EFFECTIVE sort/dir.
 - `POST /api/v1/collections/{collectionID}/copy` with `{group_id}`
   (must be the caller's) or `{group_name}` (find-or-create for the
   caller) — links every repo of the collection into that group and

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -359,10 +359,10 @@ Creates or updates the database schema.
 aveloxis migrate
 ```
 
-Creates 139 tables and 20 materialized views across three PostgreSQL schemas:
+Creates 141 tables and 20 materialized views across three PostgreSQL schemas:
 
 - **`aveloxis_data`** (100 tables + 20 materialized views) -- all collected data
-- **`aveloxis_ops`** (35 tables) -- operational state
+- **`aveloxis_ops`** (37 tables) -- operational state
 - **`aveloxis_scan`** (4 tables) -- scancode per-file license/copyright results
 
 Also performs a data cleanup pass that nullifies garbage timestamps (year < 1970) across all tables, preventing BC-era dates from poisoning queries.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -359,9 +359,9 @@ Creates or updates the database schema.
 aveloxis migrate
 ```
 
-Creates 137 tables and 20 materialized views across three PostgreSQL schemas:
+Creates 139 tables and 20 materialized views across three PostgreSQL schemas:
 
-- **`aveloxis_data`** (98 tables + 20 materialized views) -- all collected data
+- **`aveloxis_data`** (100 tables + 20 materialized views) -- all collected data
 - **`aveloxis_ops`** (35 tables) -- operational state
 - **`aveloxis_scan`** (4 tables) -- scancode per-file license/copyright results
 

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -359,10 +359,10 @@ Creates or updates the database schema.
 aveloxis migrate
 ```
 
-Creates 141 tables and 20 materialized views across three PostgreSQL schemas:
+Creates 142 tables and 20 materialized views across three PostgreSQL schemas:
 
 - **`aveloxis_data`** (100 tables + 20 materialized views) -- all collected data
-- **`aveloxis_ops`** (37 tables) -- operational state
+- **`aveloxis_ops`** (38 tables) -- operational state
 - **`aveloxis_scan`** (4 tables) -- scancode per-file license/copyright results
 
 Also performs a data cleanup pass that nullifies garbage timestamps (year < 1970) across all tables, preventing BC-era dates from poisoning queries.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -804,11 +804,20 @@ crests so it doesn't compete with collection for the key pool.
 
 ## `aveloxis heal-vulnerabilities`
 
-One-shot healer for vulnerability rows stored before v0.27.4's
-two-phase OSV fetch (they carry `severity=UNKNOWN` and empty
-summaries — the querybatch endpoint only returns id stubs). Re-scans
-every repository that has vulnerability rows, filling severity, CVSS,
-summary, fix versions, aliases, and references from `/v1/vulns/{id}`.
+One-shot healer that re-scans every repository with stored
+vulnerability rows. Two healing classes it covers:
+
+- Rows stored before v0.27.4's two-phase OSV fetch (they carry
+  `severity=UNKNOWN` and empty summaries — the querybatch endpoint
+  only returns id stubs). The re-scan fills severity, CVSS, summary,
+  fix versions, aliases, and references from `/v1/vulns/{id}`.
+- False positives from malformed dependency versions (v0.27.71 — the
+  "6.0.3, fixed in 5.4" class: an unparseable version defeats OSV's
+  version matching and every advisory in the package's history is
+  reported). As of v0.27.72 the scan normalizes stored versions and
+  rebuilds purls at read time, so this command heals those findings
+  immediately after deploy — no need to wait for each repo's
+  analysis phase to rewrite its dependency rows.
 
 ```bash
 aveloxis heal-vulnerabilities              # all repos with findings

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -119,11 +119,21 @@ func (a *authenticator) invalidateAll() {
 	a.mu.Unlock()
 }
 
-// middleware enforces Bearer auth on every route except /api/v1/health
-// when require is set. Exempt-CIDR clients bypass (LAN tooling).
+// publicPaths bypass require_auth. This is the fail-closed boundary —
+// keep the list tiny, explicit, and EXACT-MATCH only (no prefixes):
+// health is the liveness probe; public/stats is the landing page's
+// anonymous repo count (v0.27.59, still per-IP rate limited).
+var publicPaths = map[string]bool{
+	"/api/v1/health":       true,
+	"/api/v1/public/stats": true,
+}
+
+// middleware enforces Bearer auth on every route except the
+// publicPaths allowlist when require is set. Exempt-CIDR clients
+// bypass (LAN tooling).
 func (a *authenticator) middleware(rl *rateLimiter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !a.require || r.URL.Path == "/api/v1/health" || rl.isExempt(rl.clientIP(r)) {
+		if !a.require || publicPaths[r.URL.Path] || rl.isExempt(rl.clientIP(r)) {
 			// Best-effort: attach auth info when a token IS presented,
 			// so scope checks apply even before require_auth flips on.
 			if tok := bearerToken(r); tok != "" {

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+)
+
+// Collections API (v0.27.63). Reads are for every authenticated user
+// (collections are the curated discovery surface on the home page);
+// mutation is admin-only. Mutations are POST-everywhere — the CORS
+// Allow-Methods header only advertises GET/POST (plus the star PUT/
+// DELETE special case), so DELETE/PATCH verbs would break the SPA.
+
+// handleCollectionsList — GET /collections: every collection with its
+// live group/repo counts, position-ordered.
+func (s *Server) handleCollectionsList(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	cols, err := s.store.ListCollections(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"collections": cols})
+}
+
+// handleCollectionDetail — GET /collections/{collectionID}?page&page_size:
+// the member groups + one page of the DEDUPED repo set.
+func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	pageSize, _ := strconv.Atoi(r.URL.Query().Get("page_size"))
+
+	groups, err := s.store.GetCollectionGroups(r.Context(), collID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	repos, total, err := s.store.GetCollectionRepos(r.Context(), collID, page, pageSize)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 50
+	}
+	jsonResponse(w, map[string]any{
+		"collection_id": collID,
+		"groups":        groups,
+		"repos":         repos,
+		"total":         total,
+		"page":          page,
+		"page_size":     pageSize,
+	})
+}
+
+// handleCollectionCopy — POST /collections/{collectionID}/copy
+// {group_id} or {group_name}: link every repo of the collection into
+// the caller's group. group_name find-or-creates a group for the
+// caller (normal creation rules); group_id must already be theirs.
+//
+// NEVER enqueues collection (pinned at the store layer): collection
+// repos are already tracked; approval gates NEW collection only.
+// Post-copy the auth scope cache and the caller's home cache are
+// invalidated so the new repos are visible on the very next request.
+func (s *Server) handleCollectionCopy(w http.ResponseWriter, r *http.Request) {
+	info, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		GroupID   int64  `json:"group_id"`
+		GroupName string `json:"group_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	groupID := req.GroupID
+	if groupID == 0 {
+		if req.GroupName == "" {
+			http.Error(w, "group_id or group_name required", http.StatusBadRequest)
+			return
+		}
+		groupID, err = s.store.FindOrCreateUserGroupByName(r.Context(), info.UserID, req.GroupName)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	added, err := s.store.CopyCollectionToGroup(r.Context(), collID, info.UserID, groupID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotGroupOwner) {
+			http.Error(w, "target group is not yours", http.StatusForbidden)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// The copy widened the caller's repo scope — bust both caches.
+	s.auth.invalidateAll()
+	s.homeCache.invalidate(info.UserID)
+	jsonResponse(w, map[string]any{"added": added, "group_id": groupID})
+}
+
+// ─── Admin mutations (requireAdmin, POST-everywhere) ────────────
+
+// handleAdminCollectionCreate — POST /admin/collections
+// {name, description, position}.
+func (s *Server) handleAdminCollectionCreate(w http.ResponseWriter, r *http.Request) {
+	info, ok := s.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Position    int    `json:"position"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	id, err := s.store.CreateCollection(r.Context(), req.Name, req.Description, req.Position, info.UserID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"collection_id": id})
+}
+
+// handleAdminCollectionUpdate — POST /admin/collections/{collectionID}
+// {name, description, position}.
+func (s *Server) handleAdminCollectionUpdate(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Position    int    `json:"position"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.UpdateCollection(r.Context(), collID, req.Name, req.Description, req.Position); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"ok": true})
+}
+
+// handleAdminCollectionDelete — POST /admin/collections/{collectionID}/delete.
+func (s *Server) handleAdminCollectionDelete(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.DeleteCollection(r.Context(), collID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"ok": true})
+}
+
+// handleAdminCollectionAddGroup — POST /admin/collections/{collectionID}/groups
+// {group_id}: link an admin-owned group into the collection.
+func (s *Server) handleAdminCollectionAddGroup(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		GroupID int64 `json:"group_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.GroupID == 0 {
+		http.Error(w, "group_id required", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.AddGroupToCollection(r.Context(), collID, req.GroupID); err != nil {
+		if errors.Is(err, db.ErrGroupNotAdminOwned) {
+			http.Error(w, "collection member groups must be admin-owned", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"ok": true})
+}
+
+// handleAdminCollectionRemoveGroup — POST
+// /admin/collections/{collectionID}/groups/{groupID}/remove.
+func (s *Server) handleAdminCollectionRemoveGroup(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	groupID, err := strconv.ParseInt(r.PathValue("groupID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid group_id", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.RemoveGroupFromCollection(r.Context(), collID, groupID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"ok": true})
+}

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -56,11 +56,17 @@ func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Echo the EFFECTIVE paging values (mirrors the store's clamps —
+	// the v0.27.65 split-clamp shape): an oversize page_size request
+	// returns 100 rows and must say 100, not the default.
 	if page < 1 {
 		page = 1
 	}
-	if pageSize < 1 || pageSize > 100 {
+	if pageSize < 1 {
 		pageSize = 50
+	}
+	if pageSize > 100 {
+		pageSize = 100
 	}
 	jsonResponse(w, map[string]any{
 		"collection_id": collID,

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -68,10 +68,16 @@ func (s *Server) handleStarCollection(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]any{"ok": true, "starred": r.Method != http.MethodDelete})
 }
 
-// handleCollectionDetail — GET /collections/{collectionID}?page&page_size:
-// the member groups + one page of the DEDUPED repo set.
+// handleCollectionDetail — GET
+// /collections/{collectionID}?page&page_size&sort&dir: the member
+// groups + one page of the DEDUPED repo set. v0.27.74: rows carry
+// cached issue/PR/commit counts, last_collected, the forge-reported
+// last_activity, and the caller's starred flag; sort/dir select the
+// server-side ordering (allowlisted in the store — unknown values
+// fall back to name asc).
 func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireUser(w, r); !ok {
+	info, ok := s.requireUser(w, r)
+	if !ok {
 		return
 	}
 	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
@@ -81,20 +87,22 @@ func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) 
 	}
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	pageSize, _ := strconv.Atoi(r.URL.Query().Get("page_size"))
+	sortKey := r.URL.Query().Get("sort")
+	sortDir := r.URL.Query().Get("dir")
 
 	groups, err := s.store.GetCollectionGroups(r.Context(), collID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	repos, total, err := s.store.GetCollectionRepos(r.Context(), collID, page, pageSize)
+	repos, total, err := s.store.GetCollectionRepos(r.Context(), collID, info.UserID, page, pageSize, sortKey, sortDir)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// Echo the EFFECTIVE paging values (mirrors the store's clamps —
-	// the v0.27.65 split-clamp shape): an oversize page_size request
-	// returns 100 rows and must say 100, not the default.
+	// Echo the EFFECTIVE paging/sort values (mirrors the store's
+	// clamps + allowlist — the v0.27.65 log-the-effective-value rule
+	// applied to response envelopes).
 	if page < 1 {
 		page = 1
 	}
@@ -104,6 +112,12 @@ func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) 
 	if pageSize > 100 {
 		pageSize = 100
 	}
+	if !db.CollectionRepoSortValid(sortKey) {
+		sortKey = "name"
+	}
+	if sortDir != "desc" {
+		sortDir = "asc"
+	}
 	jsonResponse(w, map[string]any{
 		"collection_id": collID,
 		"groups":        groups,
@@ -111,6 +125,8 @@ func (s *Server) handleCollectionDetail(w http.ResponseWriter, r *http.Request) 
 		"total":         total,
 		"page":          page,
 		"page_size":     pageSize,
+		"sort":          sortKey,
+		"dir":           sortDir,
 	})
 }
 

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -19,17 +19,53 @@ import (
 // DELETE special case), so DELETE/PATCH verbs would break the SPA.
 
 // handleCollectionsList — GET /collections: every collection with its
-// live group/repo counts, position-ordered.
+// live group/repo counts. The caller's starred collections sort first
+// (v0.27.70); everything else stays position-ordered.
 func (s *Server) handleCollectionsList(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireUser(w, r); !ok {
+	info, ok := s.requireUser(w, r)
+	if !ok {
 		return
 	}
-	cols, err := s.store.ListCollections(r.Context())
+	cols, err := s.store.ListCollections(r.Context(), info.UserID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	jsonResponse(w, map[string]any{"collections": cols})
+}
+
+// handleStarCollection stars (PUT) or unstars (DELETE) a collection
+// for the signed-in user (v0.27.70). Stars are a per-user SORT
+// preference — starred collections list first for the starrer — never
+// a visibility control, so no scope check applies (collections are
+// visible to every authenticated user by design). Mirrors the repo
+// star pattern (handleStarRepo) minus the scope/auto-add machinery.
+func (s *Server) handleStarCollection(w http.ResponseWriter, r *http.Request) {
+	info, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	collID, err := strconv.ParseInt(r.PathValue("collectionID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid collection_id", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodDelete {
+		err = s.store.UnstarCollection(r.Context(), info.UserID, collID)
+	} else {
+		// Guard against starring a nonexistent collection: the FK
+		// rejects it, but surface a clean 404 instead of a 500.
+		err = s.store.StarCollection(r.Context(), info.UserID, collID)
+		if err != nil && errors.Is(err, db.ErrCollectionNotFound) {
+			http.Error(w, "collection not found", http.StatusNotFound)
+			return
+		}
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]any{"ok": true, "starred": r.Method != http.MethodDelete})
 }
 
 // handleCollectionDetail — GET /collections/{collectionID}?page&page_size:

--- a/internal/api/contributor_elsewhere.go
+++ b/internal/api/contributor_elsewhere.go
@@ -54,15 +54,18 @@ func (s *Server) handleContributorsElsewhere(w http.ResponseWriter, r *http.Requ
 	if limit > 25 {
 		limit = 25
 	}
+	// v0.27.69: keep the cohort consistent with /contributors/top when
+	// the caller hides bots there.
+	excludeBots := r.URL.Query().Get("bots") == "hide"
 
-	key := fmt.Sprintf("elsewhere|%d|%s|%d", repoID, since.Format("2006-01-02"), limit)
+	key := fmt.Sprintf("elsewhere|%d|%s|%d|%t", repoID, since.Format("2006-01-02"), limit, excludeBots)
 	if body, ok := s.respCache.get(key); ok {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 		return
 	}
 
-	rows, err := s.store.ContributorsElsewhere(r.Context(), repoID, since, limit, 10)
+	rows, err := s.store.ContributorsElsewhere(r.Context(), repoID, since, limit, 10, excludeBots)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/api/contributor_elsewhere.go
+++ b/internal/api/contributor_elsewhere.go
@@ -5,12 +5,14 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // v0.27.64 — the read API over the v0.27.58 contributor daily
@@ -117,9 +119,16 @@ func (s *Server) handleContributorActivity(w http.ResponseWriter, r *http.Reques
 
 	view, err := s.store.ContributorActivity(r.Context(), cntrbID, months)
 	if err != nil {
-		// Unknown contributor surfaces as the lookup error — a 404 is
-		// the honest mapping (the id parsed but nobody has it).
-		http.Error(w, "contributor not found", http.StatusNotFound)
+		// Copilot review, PR #171: only a genuine no-rows lookup is
+		// "not found" — the id parsed but nobody has it. Every other
+		// error is an operational failure (DB down, query bug) and
+		// must surface as a logged 500, never masquerade as a 404.
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "contributor not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("contributor activity lookup failed", "cntrb_id", logSafe(cntrbID), "error", err)
+		http.Error(w, "contributor activity lookup failed", http.StatusInternalServerError)
 		return
 	}
 	body, err := json.Marshal(view)

--- a/internal/api/contributor_elsewhere.go
+++ b/internal/api/contributor_elsewhere.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// v0.27.64 — the read API over the v0.27.58 contributor daily
+// history. Two surfaces:
+//
+//   - GET /repos/{repoID}/contributors/elsewhere — "where else are
+//     this repo's top contributors active?" (authorizeRepo: it hangs
+//     off a repo view).
+//   - GET /contributors/{cntrbID}/activity — one person's cross-repo
+//     monthly view. requireUser, NOT repo scope: person-level data
+//     spans repos this instance doesn't even track, so repo scope
+//     cannot express it — and anonymous access can't either.
+//
+// Both ride the shared 60s response cache and both carry
+// backfilled_at so the frontend can render "history pending" instead
+// of lying with zeros.
+
+const elsewhereWindowDays = 180 // the v0.27.58 default history window
+
+func (s *Server) handleContributorsElsewhere(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	if !s.authorizeRepo(w, r, repoID) {
+		return
+	}
+	since := time.Now().AddDate(0, 0, -elsewhereWindowDays)
+	if sp := r.URL.Query().Get("since"); sp != "" {
+		if t, err := time.Parse("2006-01-02", sp); err == nil {
+			since = t
+		}
+	}
+	limit := 10
+	if lp := r.URL.Query().Get("limit"); lp != "" {
+		if n, err := strconv.Atoi(lp); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 25 {
+		limit = 25
+	}
+
+	key := fmt.Sprintf("elsewhere|%d|%s|%d", repoID, since.Format("2006-01-02"), limit)
+	if body, ok := s.respCache.get(key); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+		return
+	}
+
+	rows, err := s.store.ContributorsElsewhere(r.Context(), repoID, since, limit, 10)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, err := json.Marshal(map[string]any{
+		"since":        since.Format("2006-01-02"),
+		"limit":        limit,
+		"contributors": rows,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.respCache.put(key, body)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+func (s *Server) handleContributorActivity(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireUser(w, r); !ok {
+		return
+	}
+	cntrbID := r.PathValue("cntrbID")
+	if _, err := uuid.Parse(cntrbID); err != nil {
+		http.Error(w, "invalid cntrb_id (must be a UUID)", http.StatusBadRequest)
+		return
+	}
+	months := 24
+	if mp := r.URL.Query().Get("months"); mp != "" {
+		if n, err := strconv.Atoi(mp); err == nil && n > 0 {
+			months = n
+		}
+	}
+	if months > 60 {
+		months = 60
+	}
+	// bucket is accepted for forward compatibility; only month exists.
+	if b := r.URL.Query().Get("bucket"); b != "" && b != "month" {
+		http.Error(w, "unsupported bucket (only 'month')", http.StatusBadRequest)
+		return
+	}
+
+	key := fmt.Sprintf("cactivity|%s|%d", cntrbID, months)
+	if body, ok := s.respCache.get(key); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+		return
+	}
+
+	view, err := s.store.ContributorActivity(r.Context(), cntrbID, months)
+	if err != nil {
+		// Unknown contributor surfaces as the lookup error — a 404 is
+		// the honest mapping (the id parsed but nobody has it).
+		http.Error(w, "contributor not found", http.StatusNotFound)
+		return
+	}
+	body, err := json.Marshal(view)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.respCache.put(key, body)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}

--- a/internal/api/contributor_elsewhere_api_test.go
+++ b/internal/api/contributor_elsewhere_api_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+// v0.27.76 (Copilot review, PR #171): handleContributorActivity used
+// to map EVERY store error to 404, which turned DB outages and query
+// bugs into "contributor not found" — invisible to operators and
+// wrong to callers. This pin keeps the split: 404 exclusively for the
+// genuine no-rows lookup, logged 500 for everything else.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContributorActivityDistinguishesNotFoundFromFailure(t *testing.T) {
+	src := mustReadFile(t, "contributor_elsewhere.go")
+	body := extractFuncBody(t, src, "handleContributorActivity")
+	for _, needle := range []string{
+		"errors.Is(err, pgx.ErrNoRows)",
+		"http.StatusNotFound",
+		"http.StatusInternalServerError",
+		"s.logger.Error(",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("handleContributorActivity must contain %q — 404 only for the genuine no-rows case, logged 500 for operational failures", needle)
+		}
+	}
+	// The 404 must be gated INSIDE the ErrNoRows branch, not the bare
+	// error path: the not-found write has to appear AFTER the errors.Is
+	// check in source order.
+	if is, nf := strings.Index(body, "errors.Is(err, pgx.ErrNoRows)"), strings.Index(body, "http.StatusNotFound"); is < 0 || nf < is {
+		t.Error("the StatusNotFound write must sit inside the errors.Is(err, pgx.ErrNoRows) branch")
+	}
+}

--- a/internal/api/endpoint_smoke_test.go
+++ b/internal/api/endpoint_smoke_test.go
@@ -50,6 +50,7 @@ type smokeRecipe struct {
 // metrics.go. Path placeholders are filled from the seeded fixture.
 var smokeRecipes = map[string]smokeRecipe{
 	"GET /api/v1/health":                                    {},
+	"GET /api/v1/public/stats":                              {},
 	"GET /api/v1/metrics":                                   {},
 	"GET /api/v1/repos":                                     {},
 	"GET /api/v1/repos/search":                              {query: "q=smokerepo"},
@@ -67,6 +68,9 @@ var smokeRecipes = map[string]smokeRecipe{
 	"GET /api/v1/repos/{repoID}/contributions/identities":   {},
 	"GET /api/v1/repos/{repoID}/contributions/affiliations": {},
 	"GET /api/v1/repos/{repoID}/contributions/coverage":     {},
+	"GET /api/v1/repos/{repoID}/contributors/top":           {},
+	"GET /api/v1/repos/{repoID}/contributors/elsewhere":     {},
+	"GET /api/v1/contributors/{cntrbID}/activity":           {auth: "user"},
 	"GET /api/v1/compare":                                   {query: "entities=repo:{repoID}&metric=contributors"},
 	"GET /api/v1/compare/snapshot":                          {query: "entities=repo:{repoID}&metric=labor_investment"},
 	"GET /api/v1/entities/search":                           {query: "q=smokerepo", auth: "user"},
@@ -84,8 +88,19 @@ var smokeRecipes = map[string]smokeRecipe{
 	// code, pinned by portal_bulk_add_test.go).
 	"POST /api/v1/groups/{groupID}/repos": {auth: "user", body: `{"urls":["https://github.com/_avsmoke/{repoName}"],"kind":"repo"}`},
 	"GET /api/v1/home/repos":              {auth: "user"},
-	"PUT /api/v1/repos/{repoID}/star":     {auth: "user"},
-	"DELETE /api/v1/repos/{repoID}/star":  {auth: "user", after: "PUT /api/v1/repos/{repoID}/star"},
+	"GET /api/v1/home/new-repos":          {auth: "user"},
+	// v0.27.63 collections. Ordering via `after`: the group link and
+	// copy run before the delete so they exercise a live collection.
+	"GET /api/v1/collections":                                               {auth: "user"},
+	"GET /api/v1/collections/{collectionID}":                                {auth: "user"},
+	"POST /api/v1/collections/{collectionID}/copy":                          {auth: "user", body: `{"group_name":"smoke-coll-copy-{repoName}"}`, after: "POST /api/v1/admin/collections/{collectionID}/groups"},
+	"POST /api/v1/admin/collections":                                        {auth: "admin", body: `{"name":"smoke-coll-extra-{repoName}"}`},
+	"POST /api/v1/admin/collections/{collectionID}":                         {auth: "admin", body: `{"name":"smoke-coll-upd-{repoName}"}`, after: "POST /api/v1/collections/{collectionID}/copy"},
+	"POST /api/v1/admin/collections/{collectionID}/groups":                  {auth: "admin", body: `{"group_id":{groupID}}`},
+	"POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove": {auth: "admin", after: "POST /api/v1/collections/{collectionID}/copy"},
+	"POST /api/v1/admin/collections/{collectionID}/delete":                  {auth: "admin", after: "POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove"},
+	"PUT /api/v1/repos/{repoID}/star":                                       {auth: "user"},
+	"DELETE /api/v1/repos/{repoID}/star":                                    {auth: "user", after: "PUT /api/v1/repos/{repoID}/star"},
 
 	// Admin.
 	"GET /api/v1/admin/users":                                {auth: "admin"},
@@ -206,6 +221,8 @@ func TestEveryEndpointExecutes(t *testing.T) {
 		"{userID}", fmt.Sprint(fx.userID),
 		"{decision}", "approve",
 		"{requestID}", fmt.Sprint(fx.requestID),
+		"{collectionID}", fmt.Sprint(fx.collectionID),
+		"{cntrbID}", fx.cntrbID,
 		"{owner}", fx.owner,
 		"{repo}", fx.repoName,
 		"{repoName}", fx.repoName,
@@ -261,7 +278,17 @@ func TestEveryEndpointExecutes(t *testing.T) {
 	}
 
 	// Ordered pass first (recipes with dependencies), then the rest.
-	ordered := []string{"PUT /api/v1/repos/{repoID}/star", "DELETE /api/v1/repos/{repoID}/star"}
+	ordered := []string{
+		"PUT /api/v1/repos/{repoID}/star", "DELETE /api/v1/repos/{repoID}/star",
+		// v0.27.63 collections chain: link the group, copy from the
+		// live collection, unlink, then delete — so every mutation
+		// exercises a real state, not an already-deleted collection.
+		"POST /api/v1/admin/collections/{collectionID}/groups",
+		"POST /api/v1/collections/{collectionID}/copy",
+		"POST /api/v1/admin/collections/{collectionID}",
+		"POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove",
+		"POST /api/v1/admin/collections/{collectionID}/delete",
+	}
 	done := map[string]bool{}
 	for _, route := range ordered {
 		if r, ok := smokeRecipes[route]; ok {
@@ -278,14 +305,16 @@ func TestEveryEndpointExecutes(t *testing.T) {
 }
 
 type smokeFixture struct {
-	repoID    int64
-	groupID   int64
-	userID    int
-	owner     string
-	repoName  string
-	rgName    string
-	tokens    map[string]string // "user" and "admin" bearer tokens
-	requestID int64             // v0.27.20 pending add-request
+	repoID       int64
+	groupID      int64
+	userID       int
+	owner        string
+	repoName     string
+	rgName       string
+	tokens       map[string]string // "user" and "admin" bearer tokens
+	requestID    int64             // v0.27.20 pending add-request
+	collectionID int64             // v0.27.63 collections routes
+	cntrbID      string            // v0.27.64 contributor activity route
 }
 
 // seedSmokeFixture creates the minimal graph the recipes need: a repo
@@ -367,7 +396,29 @@ func seedSmokeFixture(t *testing.T, ctx context.Context, store *db.PostgresStore
 		INSERT INTO aveloxis_ops.collection_add_request_items (request_id, repo_url) VALUES ($1, $2)`,
 		fx.requestID, fmt.Sprintf("https://github.com/_avsmoke/%s", fx.repoName))
 
+	// v0.27.64: a contributor with a history-backfill stamp feeding
+	// the /contributors/{cntrbID}/activity route.
+	fx.cntrbID = "0100fade-d000-0000-0000-00000000000f"
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributors (cntrb_id, cntrb_login, gh_history_backfilled_at)
+		VALUES ($1::uuid, $2, NOW())
+		ON CONFLICT (cntrb_login) WHERE cntrb_login != '' DO NOTHING`,
+		fx.cntrbID, fmt.Sprintf("_avsmoke_c%d", suffix)); err != nil {
+		t.Fatal(err)
+	}
+
+	// v0.27.63: a collection feeding the collections routes. NOT
+	// pre-linked to the group — the add-group recipe links it live.
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.collections (name, description, created_by)
+		VALUES ($1, 'smoke collection', $2) RETURNING collection_id`,
+		fmt.Sprintf("_avsmoke_coll%d", suffix), fx.userID).Scan(&fx.collectionID); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM aveloxis_ops.collections WHERE created_by = $1`, fx.userID)
+		_, _ = pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_id = $1::uuid`, fx.cntrbID)
 		for _, q := range []string{
 			`DELETE FROM aveloxis_ops.user_repo_stars WHERE user_id = $1`,
 			`DELETE FROM aveloxis_ops.user_session_tokens WHERE user_id = $1`,

--- a/internal/api/endpoint_smoke_test.go
+++ b/internal/api/endpoint_smoke_test.go
@@ -101,6 +101,9 @@ var smokeRecipes = map[string]smokeRecipe{
 	"POST /api/v1/admin/collections/{collectionID}/delete":                  {auth: "admin", after: "POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove"},
 	"PUT /api/v1/repos/{repoID}/star":                                       {auth: "user"},
 	"DELETE /api/v1/repos/{repoID}/star":                                    {auth: "user", after: "PUT /api/v1/repos/{repoID}/star"},
+	// v0.27.70 collection stars — must run before the collection delete.
+	"PUT /api/v1/collections/{collectionID}/star":    {auth: "user"},
+	"DELETE /api/v1/collections/{collectionID}/star": {auth: "user", after: "PUT /api/v1/collections/{collectionID}/star"},
 
 	// Admin.
 	"GET /api/v1/admin/users":                                {auth: "admin"},
@@ -286,6 +289,9 @@ func TestEveryEndpointExecutes(t *testing.T) {
 		"POST /api/v1/admin/collections/{collectionID}/groups",
 		"POST /api/v1/collections/{collectionID}/copy",
 		"POST /api/v1/admin/collections/{collectionID}",
+		// v0.27.70 stars ride the live collection before it's deleted.
+		"PUT /api/v1/collections/{collectionID}/star",
+		"DELETE /api/v1/collections/{collectionID}/star",
 		"POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove",
 		"POST /api/v1/admin/collections/{collectionID}/delete",
 	}

--- a/internal/api/new_repos.go
+++ b/internal/api/new_repos.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// handleNewRepos (v0.27.62) — GET /home/new-repos?days=30
+//
+// The "New Repositories" home feed: repos that entered the fleet in
+// the trailing window, split into two arms — `fleet` (repos under
+// orgs registered by admin users: the curated what's-new-on-this-
+// instance signal) and `mine` (repos under orgs the CALLER
+// registered). Window default 30 days, capped at 90 (repos.added_at
+// is indexed DESC; a longer window is a browse, not a feed).
+//
+// requireUser (not repo scope): the feed spans the whole fleet by
+// design — it is discovery surface, same posture as /repos/search.
+// Responses ride the shared 60s body cache keyed per (user, days) —
+// the mine arm is user-specific so the key must carry the user.
+func (s *Server) handleNewRepos(w http.ResponseWriter, r *http.Request) {
+	info, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	days := 30
+	if dp := r.URL.Query().Get("days"); dp != "" {
+		if n, err := strconv.Atoi(dp); err == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 90 {
+		days = 90
+	}
+
+	key := fmt.Sprintf("newrepos|%d|%d", info.UserID, days)
+	if body, ok := s.respCache.get(key); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+		return
+	}
+
+	since := time.Now().AddDate(0, 0, -days)
+	fleet, mine, err := s.store.GetNewRepos(r.Context(), info.UserID, since, 200)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"days":  days,
+		"fleet": fleet,
+		"mine":  mine,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.respCache.put(key, body)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}

--- a/internal/api/portal.go
+++ b/internal/api/portal.go
@@ -159,35 +159,32 @@ func (s *Server) handleGroupRepos(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	page, pageSize := parsePortalPage(r)
-	repos, total, err := s.store.GetPortalGroupReposForUser(r.Context(), info.UserID, groupID, info.IsAdmin, pageSize, (page-1)*pageSize)
+	sortKey := r.URL.Query().Get("sort")
+	sortDir := r.URL.Query().Get("dir")
+	// v0.27.75: the store fills the whole row — cached queue counts,
+	// last_collected, forge-reported last_activity, and the caller's
+	// star state — and applies the allowlisted server-side sort (the
+	// collections table grammar, shared allowlist). No per-page
+	// annotation loop remains here.
+	repos, total, err := s.store.GetPortalGroupReposForUser(r.Context(), info.UserID, groupID, info.IsAdmin, page, pageSize, sortKey, sortDir)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
-	// v0.27.14: annotate the PAGE (never the whole group) with ALL-TIME
-	// counts from the latest repo_info snapshot via the batched-stats
-	// cache, plus the caller's star state. OPERATOR DECISION: all-time
-	// totals, NOT the 90-day activity metric (the v0.27.4 nginx-timeout
-	// class at fleet scale).
-	ids := make([]int64, 0, len(repos))
-	for _, g := range repos {
-		ids = append(ids, g.RepoID)
-	}
-	stats, _ := s.store.GetRepoStatsBatch(r.Context(), ids)
-	starred, _ := s.store.GetUserStarredRepoIDs(r.Context(), info.UserID)
-	for i := range repos {
-		if st, ok := stats[repos[i].RepoID]; ok && st != nil {
-			repos[i].CommitsAllTime = st.MetadataCommits
-			repos[i].IssuesAllTime = st.MetadataIssues
-			repos[i].PRsAllTime = st.MetadataPRs
-		}
-		repos[i].Starred = starred[repos[i].RepoID]
-	}
 	if repos == nil {
 		repos = []db.PortalGroupRepo{}
 	}
+	// Echo the EFFECTIVE sort values (mirrors the store's allowlist —
+	// the log-the-effective-value rule applied to response envelopes).
+	if !db.CollectionRepoSortValid(sortKey) {
+		sortKey = "name"
+	}
+	if sortDir != "desc" {
+		sortDir = "asc"
+	}
 	jsonResponse(w, map[string]any{
 		"repos": repos, "total": total, "page": page, "page_size": pageSize,
+		"sort": sortKey, "dir": sortDir,
 	})
 }
 

--- a/internal/api/portal_group_page_test.go
+++ b/internal/api/portal_group_page_test.go
@@ -4,14 +4,13 @@
 package api
 
 // v0.27.14 — the group page's repo listing paginates and carries
-// ALL-TIME counts + star state per row.
-//
-// OPERATOR DECISION (2026-07-15): the counts are the ALL-TIME totals
-// from the latest repo_info snapshot — deliberately NOT the 90-day
-// activity metric, which caused the v0.27.4 nginx-timeout incident at
-// fleet scale and would need per-group caching we don't want here.
-// Counts are fetched per PAGE only, via the existing batched-stats
-// machinery (GetRepoStatsBatch), never for the whole group.
+// per-row counts + star state.
+// v0.27.75 — the listing adopts the COLLECTIONS table grammar
+// (operator request 2026-08-02): cached queue counts, last_collected,
+// forge-reported last_activity, starred, and server-side sort through
+// the SAME allowlist as GetCollectionRepos. The counts remain
+// pre-cached values — never a per-request aggregation (the v0.27.4
+// nginx-timeout class).
 
 import (
 	"net/http/httptest"
@@ -43,31 +42,51 @@ func TestParsePortalPage(t *testing.T) {
 	}
 }
 
-// TestHandleGroupReposEnvelope pins the wiring: pagination flows to
-// the store, per-PAGE counts come from GetRepoStatsBatch, star state
-// from GetUserStarredRepoIDs, and the response is an envelope with
-// total/page/page_size (the GUI pager reads it).
+// TestHandleGroupReposEnvelope pins the v0.27.75 wiring: pagination
+// AND sort params flow to the store, the effective sort/dir are echoed
+// in the envelope alongside total/page/page_size, and the row shape is
+// the collections table grammar (cached counts + dates + starred from
+// the store — no per-page annotation loop in the handler).
 func TestHandleGroupReposEnvelope(t *testing.T) {
 	src := mustReadFile(t, "portal.go")
 	body := extractFuncBody(t, src, "handleGroupRepos")
 	for _, needle := range []string{
-		"parsePortalPage(", "GetRepoStatsBatch(", "GetUserStarredRepoIDs(",
-		`"total"`, `"page"`, `"page_size"`,
+		"parsePortalPage(", `Get("sort")`, `Get("dir")`,
+		"CollectionRepoSortValid(",
+		`"total"`, `"page"`, `"page_size"`, `"sort"`, `"dir"`,
 	} {
 		if !strings.Contains(body, needle) {
-			t.Errorf("handleGroupRepos must contain %q — pagination envelope + per-page counts + star annotation", needle)
+			t.Errorf("handleGroupRepos must contain %q — pagination + allowlisted sort with effective-value echo", needle)
 		}
 	}
-	// The all-time counts read the repo_info metadata totals — NOT any
-	// 90-day activity query (the v0.27.4 nginx-timeout class).
+	// The v0.27.14 per-page annotation loop is GONE — the store fills
+	// counts and stars in the listing query itself.
+	for _, banned := range []string{"GetRepoStatsBatch(", "GetUserStarredRepoIDs("} {
+		if strings.Contains(body, banned) {
+			t.Errorf("handleGroupRepos must NOT call %s — the store fills the whole row (v0.27.75)", banned)
+		}
+	}
 	storeSrc := mustReadFile(t, "../db/portal_store.go")
-	for _, needle := range []string{`json:"commits_all_time"`, `json:"issues_all_time"`, `json:"prs_all_time"`, `json:"starred"`} {
+	// The collections row shape, verbatim (v0.27.74 field names — the
+	// two GUI tables render from identical JSON).
+	for _, needle := range []string{
+		`json:"issues"`, `json:"prs"`, `json:"commits"`,
+		`json:"last_collected,omitempty"`, `json:"last_activity,omitempty"`, `json:"starred"`,
+	} {
 		if !strings.Contains(storeSrc, needle) {
-			t.Errorf("PortalGroupRepo must declare %s — labeled all-time so the GUI can say so", needle)
+			t.Errorf("PortalGroupRepo must declare %s — the collections table grammar", needle)
+		}
+	}
+	// Counts come from the queue's CACHED totals + the repo_info
+	// LATERAL; sort resolves through the SHARED allowlist. Never a
+	// windowed per-request aggregation (the v0.27.4 timeout class).
+	for _, needle := range []string{"last_issues", "last_updated", "user_repo_stars", "collectionRepoSorts"} {
+		if !strings.Contains(storeSrc, needle) {
+			t.Errorf("GetPortalGroupReposForUser must use %s — cached counts + shared sort allowlist", needle)
 		}
 	}
 	if strings.Contains(storeSrc, "90 days") || strings.Contains(storeSrc, "INTERVAL '90") {
-		t.Error("group-page counts must be ALL-TIME, never the 90-day activity metric (operator decision; v0.27.4 timeout incident)")
+		t.Error("group-page counts must be cached totals, never the 90-day activity metric (operator decision; v0.27.4 timeout incident)")
 	}
 }
 

--- a/internal/api/public_stats.go
+++ b/internal/api/public_stats.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// public_stats.go — the v0.27.59 public repo count backing the landing
+// page's bullseye target ("N repositories under analysis"). The
+// endpoint is on the publicPaths allowlist (auth.go) so an anonymous
+// landing page can read it even with require_auth on; the per-IP rate
+// limiter still applies. The count is a vanity number for engagement,
+// so the cache serves STALE on a failed refresh — the landing page
+// never renders an error for it.
+
+// publicStatsCache is a single-value TTL cache with stale-on-error
+// semantics (the QueueStatsCache posture applied to one integer).
+type publicStatsCache struct {
+	mu        sync.Mutex
+	ttl       time.Duration
+	load      func() (int, error)
+	value     int
+	haveValue bool
+	loadedAt  time.Time
+}
+
+func newPublicStatsCache(ttl time.Duration, load func() (int, error)) *publicStatsCache {
+	return &publicStatsCache{ttl: ttl, load: load}
+}
+
+func (c *publicStatsCache) get() (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.haveValue && time.Since(c.loadedAt) < c.ttl {
+		return c.value, nil
+	}
+	n, err := c.load()
+	if err != nil {
+		if c.haveValue {
+			return c.value, nil // stale beats an error for a vanity count
+		}
+		return 0, err
+	}
+	c.value, c.haveValue, c.loadedAt = n, true, time.Now()
+	return n, nil
+}
+
+// handlePublicStats serves GET /api/v1/public/stats → {"repos": N}.
+func (s *Server) handlePublicStats(w http.ResponseWriter, r *http.Request) {
+	n, err := s.publicStats.get()
+	if err != nil {
+		http.Error(w, "count unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, map[string]int{"repos": n})
+}

--- a/internal/api/public_stats_test.go
+++ b/internal/api/public_stats_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+// public_stats_test.go — TDD suite for the v0.27.59 public repo count
+// (the landing page's bullseye-target number). Contracts:
+//   - /api/v1/public/stats bypasses require_auth via an EXPLICIT
+//     publicPaths allowlist (the fail-closed boundary stays tiny and
+//     named — no prefix matching, no pattern magic);
+//   - a path NOT on the allowlist still 401s, even under /public/;
+//   - the count is served through a 60s single-value cache with
+//     stale-on-error semantics (the landing page never renders an
+//     error for a vanity number; a DB hiccup serves the last value).
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPublicStatsBypassesRequireAuth(t *testing.T) {
+	store := &fakeSessionStore{valid: map[string]bool{}}
+	h := authedChain(t, store, Options{RequireAuth: true}, okHandler())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/public/stats", nil)
+	req.RemoteAddr = "203.0.113.5:1" // NOT exempt
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("/api/v1/public/stats must bypass require_auth (publicPaths allowlist), got %d", rec.Code)
+	}
+}
+
+func TestPublicNamespaceIsNotBlanketPublic(t *testing.T) {
+	store := &fakeSessionStore{valid: map[string]bool{}}
+	h := authedChain(t, store, Options{RequireAuth: true}, okHandler())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/public/other", nil)
+	req.RemoteAddr = "203.0.113.5:1"
+	h.ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("only EXACT allowlisted paths bypass — /api/v1/public/other must 401, got %d (prefix matching would silently widen the fail-closed boundary)", rec.Code)
+	}
+}
+
+func TestPublicStatsCacheSingleLoadWithinTTL(t *testing.T) {
+	loads := 0
+	c := newPublicStatsCache(time.Minute, func() (int, error) {
+		loads++
+		return 12483, nil
+	})
+	for i := 0; i < 5; i++ {
+		n, err := c.get()
+		if err != nil || n != 12483 {
+			t.Fatalf("get %d: n=%d err=%v", i, n, err)
+		}
+	}
+	if loads != 1 {
+		t.Errorf("5 gets inside the TTL must load once, loaded %d times", loads)
+	}
+}
+
+func TestPublicStatsCacheServesStaleOnError(t *testing.T) {
+	loads := 0
+	c := newPublicStatsCache(0, func() (int, error) { // TTL 0 → reload every get
+		loads++
+		if loads == 1 {
+			return 12483, nil
+		}
+		return 0, errors.New("db down")
+	})
+	if n, _ := c.get(); n != 12483 {
+		t.Fatal("first load")
+	}
+	n, err := c.get() // loader errors now
+	if err != nil || n != 12483 {
+		t.Errorf("a failed refresh must serve the stale value (n=%d err=%v) — the landing page never renders an error for the count", n, err)
+	}
+	// Never-loaded + error → the error DOES surface (nothing to be stale with).
+	c2 := newPublicStatsCache(time.Minute, func() (int, error) { return 0, errors.New("down") })
+	if _, err := c2.get(); err == nil {
+		t.Error("no cached value and a failed load must surface the error")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -139,6 +139,10 @@ func NewWithOptions(store *db.PostgresStore, logger *slog.Logger, opts Options) 
 	s.mux.HandleFunc("GET /api/v1/collections", s.handleCollectionsList)
 	s.mux.HandleFunc("GET /api/v1/collections/{collectionID}", s.handleCollectionDetail)
 	s.mux.HandleFunc("POST /api/v1/collections/{collectionID}/copy", s.handleCollectionCopy)
+	// v0.27.70 — per-user collection stars (sort preference, mirrors
+	// the repo-star PUT/DELETE pattern).
+	s.mux.HandleFunc("PUT /api/v1/collections/{collectionID}/star", s.handleStarCollection)
+	s.mux.HandleFunc("DELETE /api/v1/collections/{collectionID}/star", s.handleStarCollection)
 	s.mux.HandleFunc("POST /api/v1/admin/collections", s.handleAdminCollectionCreate)
 	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}", s.handleAdminCollectionUpdate)
 	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}/delete", s.handleAdminCollectionDelete)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -42,6 +43,15 @@ type Server struct {
 	// endpoint. Both zero-valued when unconfigured.
 	mailer              *mailer.Mailer
 	autoApproveAddLimit int
+
+	// v0.27.59: single-value 60s cache for the public repo count.
+	publicStats *publicStatsCache
+
+	// v0.27.61: general 60s body cache for per-repo read endpoints
+	// (top contributors, contributor elsewhere). Same shape as
+	// cmpCache; separate instance so a compare-traffic flood can't
+	// evict the repo-page bodies (both maps are bounded at 1000).
+	respCache *compareCache
 }
 
 // New creates an API server with default middleware options
@@ -60,6 +70,12 @@ func NewWithOptions(store *db.PostgresStore, logger *slog.Logger, opts Options) 
 	s := &Server{store: store, logger: logger, mux: http.NewServeMux(),
 		mailer: opts.Mailer, autoApproveAddLimit: opts.AutoApproveAddLimit}
 	s.mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+	// v0.27.59: the landing page's public repo count — on the
+	// publicPaths allowlist (auth.go); 60s stale-on-error cache.
+	s.publicStats = newPublicStatsCache(time.Minute, func() (int, error) {
+		return store.CountActiveRepos(context.Background())
+	})
+	s.mux.HandleFunc("GET /api/v1/public/stats", s.handlePublicStats)
 	s.mux.HandleFunc("GET /api/v1/mailing-list/stats", s.handleMailingListStats)
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/stats", s.handleRepoStats)
 	s.mux.HandleFunc("GET /api/v1/repos/stats", s.handleRepoStatsBatch)
@@ -115,7 +131,27 @@ func NewWithOptions(store *db.PostgresStore, logger *slog.Logger, opts Options) 
 	s.mux.HandleFunc("PUT /api/v1/repos/{repoID}/star", s.handleStarRepo)
 	s.mux.HandleFunc("DELETE /api/v1/repos/{repoID}/star", s.handleStarRepo)
 	s.mux.HandleFunc("GET /api/v1/home/repos", s.handleHomeRepos)
+	// v0.27.62 — the "New Repositories" home feed (fleet + mine arms).
+	s.mux.HandleFunc("GET /api/v1/home/new-repos", s.handleNewRepos)
+	// v0.27.63 — collections (admin-curated groups-of-groups). Reads
+	// for every authenticated user; mutations admin-only and
+	// POST-everywhere (CORS Allow-Methods only advertises GET/POST).
+	s.mux.HandleFunc("GET /api/v1/collections", s.handleCollectionsList)
+	s.mux.HandleFunc("GET /api/v1/collections/{collectionID}", s.handleCollectionDetail)
+	s.mux.HandleFunc("POST /api/v1/collections/{collectionID}/copy", s.handleCollectionCopy)
+	s.mux.HandleFunc("POST /api/v1/admin/collections", s.handleAdminCollectionCreate)
+	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}", s.handleAdminCollectionUpdate)
+	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}/delete", s.handleAdminCollectionDelete)
+	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}/groups", s.handleAdminCollectionAddGroup)
+	s.mux.HandleFunc("POST /api/v1/admin/collections/{collectionID}/groups/{groupID}/remove", s.handleAdminCollectionRemoveGroup)
 	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/scorecard", s.handleRepoScorecard)
+	// v0.27.61 — ranked per-contributor activity for the repo page's
+	// "Top contributors" card.
+	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributors/top", s.handleTopContributors)
+	// v0.27.64 — cross-repo contributor history (the v0.27.58 daily
+	// tables): where-else matrix + person-level monthly view.
+	s.mux.HandleFunc("GET /api/v1/repos/{repoID}/contributors/elsewhere", s.handleContributorsElsewhere)
+	s.mux.HandleFunc("GET /api/v1/contributors/{cntrbID}/activity", s.handleContributorActivity)
 	s.registerMetricRoutes()
 	rl, err := newRateLimiter(opts)
 	if err != nil {
@@ -124,6 +160,7 @@ func NewWithOptions(store *db.PostgresStore, logger *slog.Logger, opts Options) 
 	s.limiter = rl
 	s.auth = newAuthenticator(store, opts.RequireAuth)
 	s.cmpCache = &compareCache{m: map[string]compareCacheEntry{}}
+	s.respCache = &compareCache{m: map[string]compareCacheEntry{}}
 	s.faCache = &firstActivityCache{m: map[string]time.Time{}}
 	return s, nil
 }

--- a/internal/api/top_contributors.go
+++ b/internal/api/top_contributors.go
@@ -47,15 +47,19 @@ func (s *Server) handleTopContributors(w http.ResponseWriter, r *http.Request) {
 	if limit > 100 {
 		limit = 100
 	}
+	// v0.27.69 — the "hide bots" checkbox: ?bots=hide filters bot
+	// identities (App accounts, [bot] logins, -bot/-robot machine
+	// accounts — the k8s-ci-robot class).
+	excludeBots := r.URL.Query().Get("bots") == "hide"
 
-	key := fmt.Sprintf("topcontrib|%d|%s|%s|%d", repoID, since.Format("2006-01-02"), until.Format("2006-01-02"), limit)
+	key := fmt.Sprintf("topcontrib|%d|%s|%s|%d|%t", repoID, since.Format("2006-01-02"), until.Format("2006-01-02"), limit, excludeBots)
 	if body, ok := s.respCache.get(key); ok {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 		return
 	}
 
-	rows, err := s.store.TopContributors(r.Context(), repoID, since, until, limit)
+	rows, err := s.store.TopContributors(r.Context(), repoID, since, until, limit, excludeBots)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/api/top_contributors.go
+++ b/internal/api/top_contributors.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// handleTopContributors (v0.27.61) — GET /repos/{repoID}/contributors/top
+//
+// The ranked per-contributor activity breakdown behind the repo page's
+// "Top contributors" card: ?since / ?until windows (parseWindow — same
+// semantics as the other contributions endpoints), ?limit rows
+// (default 20, capped at 100).
+//
+// Computed live from the base tables (repo_id-leading index slices —
+// the same cost class as the per-request /contributors metric), behind
+// the 60s response cache: the underlying data only changes per
+// collection cycle, so a shared dashboard hitting the same repo
+// repeatedly costs one query per minute. ORDER MATTERS: authorizeRepo
+// runs BEFORE the cache lookup — a cached body must never leak past
+// repo scope (pinned by test).
+func (s *Server) handleTopContributors(w http.ResponseWriter, r *http.Request) {
+	repoID, err := strconv.ParseInt(r.PathValue("repoID"), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid repo_id", http.StatusBadRequest)
+		return
+	}
+	if !s.authorizeRepo(w, r, repoID) {
+		return
+	}
+	since, until, ok := parseWindow(r)
+	if !ok {
+		http.Error(w, "since must be before until", http.StatusBadRequest)
+		return
+	}
+	limit := 20
+	if lp := r.URL.Query().Get("limit"); lp != "" {
+		if n, err := strconv.Atoi(lp); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	key := fmt.Sprintf("topcontrib|%d|%s|%s|%d", repoID, since.Format("2006-01-02"), until.Format("2006-01-02"), limit)
+	if body, ok := s.respCache.get(key); ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+		return
+	}
+
+	rows, err := s.store.TopContributors(r.Context(), repoID, since, until, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	envelope := map[string]any{
+		"since":        since,
+		"until":        until,
+		"limit":        limit,
+		"contributors": rows,
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.respCache.put(key, body)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}

--- a/internal/api/top_contributors_api_test.go
+++ b/internal/api/top_contributors_api_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// v0.27.61 — GET /repos/{repoID}/contributors/top: route registration,
+// the authz-before-cache ordering, and the limit clamp.
+
+func TestTopContributorsRouteRegistered(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), `GET /api/v1/repos/{repoID}/contributors/top`) {
+		t.Error("route GET /api/v1/repos/{repoID}/contributors/top not registered in server.go")
+	}
+	if !strings.Contains(string(src), "s.handleTopContributors") {
+		t.Error("route must dispatch to s.handleTopContributors")
+	}
+}
+
+// The response cache must NEVER be consulted before authorizeRepo: a
+// cached body for an authorized user must not leak to an unauthorized
+// one. Pin the ordering at the source level (authorizeRepo appears
+// before the first cache get inside the handler body).
+func TestTopContributorsAuthzBeforeCache(t *testing.T) {
+	src, err := os.ReadFile("top_contributors.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+	authz := strings.Index(body, "s.authorizeRepo(")
+	cacheGet := strings.Index(body, "s.respCache.get(")
+	if authz < 0 {
+		t.Fatal("handleTopContributors must call s.authorizeRepo")
+	}
+	if cacheGet < 0 {
+		t.Fatal("handleTopContributors must use the 60s response cache (s.respCache.get)")
+	}
+	if cacheGet < authz {
+		t.Error("response-cache lookup must come AFTER authorizeRepo — a cached body must never bypass repo scope")
+	}
+}
+
+// Limit: default 20, hard cap 100 (an unbounded limit walks the whole
+// contributor set through the identity join for no UI benefit).
+func TestTopContributorsLimitClamp(t *testing.T) {
+	src, err := os.ReadFile("top_contributors.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), "limit := 20") {
+		t.Error("default limit must be 20")
+	}
+	if !strings.Contains(string(src), "limit > 100") {
+		t.Error("limit must be capped at 100")
+	}
+}

--- a/internal/collector/analysis.go
+++ b/internal/collector/analysis.go
@@ -1246,6 +1246,17 @@ func (ac *AnalysisCollector) scanLibyear(ctx context.Context, repoID int64, work
 		ac.logger.Warn("libyear manifest walk failed — dependency scan may be incomplete", "dir", workDir, "error", err)
 	}
 
+	// v0.27.71: central version-hygiene choke point. Every parser's
+	// output passes through here before resolution, storage, and purl
+	// construction — a malformed version (line-continuation backslash,
+	// property interpolation, inline-table fragment, monorepo
+	// protocol) becomes "" (the honest 'unpinned' pathway) instead of
+	// silently defeating OSV version matching and registry lookups.
+	// See version_normalize.go for the incident history.
+	for i := range allDeps {
+		allDeps[i].Version = normalizeParsedVersion(allDeps[i].Manager, allDeps[i].Version)
+	}
+
 	// v0.27.45 (summary/19 P2, Go C1): relabel go.mod deps whose
 	// packages are imported ONLY from _test.go files as test-scope.
 	// Ungated — relabel only, adds no rows.
@@ -1435,12 +1446,38 @@ func parseRequirementsTxtVersions(path string) []libyearDep {
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
 			continue
 		}
+		// v0.27.71 (the zephyr false-CRITICAL incident): pip's
+		// hash-pinned format ends the pin line with a backslash
+		// continuation ("pyyaml==6.0.3 \"). The --hash continuation
+		// lines are already skipped by the "-" prefix filter above,
+		// but the backslash survived into the version — and from
+		// there into purls, where it defeated OSV's version matching
+		// (unparseable version → package-level match → the package's
+		// entire advisory history reported as findings).
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\\"))
+		// Inline comments, PEP 508 environment markers, and same-line
+		// pip args are not version content ("attrs==3.1.0  # Apache-2.0",
+		// "croniter==0.4.6 ; sys_platform == 'win32'").
+		if idx := strings.Index(line, " #"); idx > 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if idx := strings.Index(line, ";"); idx > 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if idx := strings.Index(line, " --"); idx > 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if line == "" {
+			continue
+		}
 		name := line
 		version := ""
 		for _, sep := range []string{"==", ">=", "~="} {
 			if idx := strings.Index(line, sep); idx > 0 {
 				name = strings.TrimSpace(line[:idx])
-				version = strings.TrimSpace(line[idx+len(sep):])
+				// cleanVersion handles compound ranges ("10,<11" → "10")
+				// that previously leaked whole into the version.
+				version = cleanVersion(strings.TrimSpace(line[idx+len(sep):]))
 				break
 			}
 		}
@@ -1477,7 +1514,18 @@ func cleanVersion(v string) string {
 	}
 
 	// Trim any whitespace left after operator removal (e.g., "~> 1.2" -> " 1.2").
-	return strings.TrimSpace(v)
+	v = strings.TrimSpace(v)
+
+	// v0.27.71: space-separated compound ranges keep the floor. pub
+	// ("'>=0.11.1 <0.12.0'"), npm hyphen ranges ("1.2.3 - 2.3.4"),
+	// and hex ("~> 3.0.0 and < 5.0.0") all separate bounds with
+	// spaces, which the comma/pipe split above never saw — the whole
+	// range leaked into versions and purls. No real version contains
+	// a space, so cutting at the first one is universally safe.
+	if idx := strings.IndexByte(v, ' '); idx > 0 {
+		v = strings.TrimSpace(v[:idx])
+	}
+	return v
 }
 
 // decodeIfUTF16 detects UTF-16 BOM and converts to UTF-8. Some Windows-created
@@ -1769,16 +1817,24 @@ func parseCargoVersions(path string) []libyearDep {
 		if inDeps && strings.Contains(trimmed, "=") {
 			parts := strings.SplitN(trimmed, "=", 2)
 			name := strings.TrimSpace(parts[0])
-			version := strings.Trim(strings.TrimSpace(parts[1]), "\"' {}")
-			// Handle table-style: serde = { version = "1.0", features = ["derive"] }
-			if strings.Contains(version, "version") {
-				for _, kv := range strings.Split(version, ",") {
+			raw := strings.TrimSpace(parts[1])
+			version := ""
+			if strings.HasPrefix(raw, "{") {
+				// v0.27.71: inline tables carry a version ONLY under an
+				// explicit version key. workspace-inherited
+				// ({ workspace = true }), path ({ path = ".." }), and
+				// git ({ git = "…" }) deps have none — the pre-fix code
+				// captured the whole table body as the "version"
+				// (13,471 production rows of "workspace = true").
+				for _, kv := range strings.Split(strings.Trim(raw, "{}"), ",") {
 					kv = strings.TrimSpace(kv)
 					if strings.HasPrefix(kv, "version") {
 						version = strings.Trim(strings.TrimPrefix(kv, "version"), " =\"")
 						break
 					}
 				}
+			} else {
+				version = strings.Trim(raw, "\"' ")
 			}
 			version = cleanVersion(version)
 			if name != "" {
@@ -1822,7 +1878,15 @@ func parseGemfileVersions(path string) []libyearDep {
 			name = strings.Trim(strings.TrimPrefix(strings.TrimSpace(parts[0]), "gem "), "\"' ")
 		}
 		if len(parts) >= 2 {
-			version = cleanVersion(strings.Trim(strings.TrimSpace(parts[1]), "\"' "))
+			// v0.27.71: only a QUOTED second argument is a version
+			// requirement ("~> 1.0", ">= 1.1"). Unquoted keyword
+			// options (require: false, path: "..", group: :x,
+			// platforms: [..]) were captured as versions —
+			// "require: false" was the #1 rubygems garbage version
+			// in production (1,212 rows).
+			if arg := strings.TrimSpace(parts[1]); strings.HasPrefix(arg, `"`) || strings.HasPrefix(arg, "'") {
+				version = cleanVersion(strings.Trim(arg, "\"' "))
+			}
 		}
 		scope := "runtime"
 		if len(groupStack) > 0 {
@@ -2293,6 +2357,14 @@ func parseBuildGradleVersions(content string) []libyearDep {
 		if strings.HasPrefix(line, "//") {
 			continue
 		}
+		// v0.27.71: project(":core:util") references are the repo's
+		// OWN modules, not external deps. The quoted ":"-separated
+		// module path split like a maven coordinate and emitted fake
+		// deps named ":core" with MODULE NAMES as versions (583+
+		// production rows on apereo/cas alone).
+		if strings.Contains(line, "project(") {
+			continue
+		}
 		for _, prefix := range prefixes {
 			if !strings.HasPrefix(line, prefix) {
 				continue
@@ -2665,9 +2737,14 @@ func parseMixExsVersions(content string) []libyearDep {
 			continue
 		}
 		name := strings.TrimPrefix(strings.TrimSpace(parts[0]), "{:")
-		// Extract version from second part, stripping quotes and braces.
-		versionPart := strings.Trim(strings.TrimSpace(parts[1]), "\"'}] ")
-		version := cleanVersion(versionPart)
+		// v0.27.71: only a QUOTED second element is a version
+		// requirement ("~> 1.7.0"). Keyword options (git:, github:,
+		// path:) mark source deps with no registry version — the
+		// pre-fix code captured the option text as the version.
+		version := ""
+		if p1 := strings.TrimSpace(parts[1]); strings.HasPrefix(p1, `"`) {
+			version = cleanVersion(strings.Trim(p1, "\"'}] "))
+		}
 		// v0.27.44 (summary/19 P1): Mix's only: option restricts a dep
 		// to specific envs. only: :test → test; anything mentioning
 		// :dev → dev (only: [:dev, :test] is a dev-tooling dep that
@@ -3005,16 +3082,30 @@ func parsePubspecVersions(content string) []libyearDep {
 	var deps []libyearDep
 	inDeps := false
 	depType := "runtime"
+	// v0.27.71: block-style deps nest their source under the name:
+	//
+	//	my_lib:
+	//	  path: ../
+	//
+	// The pre-fix parser emitted the SUB-KEYS as deps — a package
+	// named "path" at version "../" (90 production rows), fake "git"/
+	// "url"/"ref" packages. Track the indent of the first dep line in
+	// each section; anything deeper is a sub-key, not a dep. (Name
+	// filtering would be wrong: "path" is a real pub.dev package that
+	// legitimately appears at dep level.)
+	depIndent := -1
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "dependencies:" {
 			inDeps = true
 			depType = "runtime"
+			depIndent = -1
 			continue
 		}
 		if trimmed == "dev_dependencies:" {
 			inDeps = true
 			depType = "dev"
+			depIndent = -1
 			continue
 		}
 		if inDeps && len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
@@ -3024,6 +3115,13 @@ func parsePubspecVersions(content string) []libyearDep {
 			continue
 		}
 		if strings.Contains(trimmed, ":") && !strings.HasPrefix(trimmed, "#") {
+			indent := len(line) - len(strings.TrimLeft(line, " \t"))
+			if depIndent == -1 {
+				depIndent = indent
+			}
+			if indent > depIndent {
+				continue // sub-key of a block-style dep
+			}
 			parts := strings.SplitN(trimmed, ":", 2)
 			name := strings.TrimSpace(parts[0])
 			if name == "" || name == "flutter" || name == "flutter_test" {

--- a/internal/collector/commit_resolver_integration_test.go
+++ b/internal/collector/commit_resolver_integration_test.go
@@ -39,12 +39,12 @@ func TestCommitResolverIntegration_Strategy4ViaSharedResolver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	store, err := db.NewPostgresStore(ctx, dsn, lg)
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const (
 		repoGit = "https://github.com/_av_cr_test/repo"

--- a/internal/collector/local_canary_test.go
+++ b/internal/collector/local_canary_test.go
@@ -133,7 +133,7 @@ func TestLocalDevBuildDepsCanary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/collector/mailinglist_processor_integration_test.go
+++ b/internal/collector/mailinglist_processor_integration_test.go
@@ -40,12 +40,12 @@ func TestMailingListPipelineEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pool: %v", err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	store, err := db.NewPostgresStore(ctx, dsn, lg)
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/collector/manifest_corpus_test.go
+++ b/internal/collector/manifest_corpus_test.go
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+// v0.27.72 — the manifest-corpus regression net (the routine-testing
+// hardening from the zephyr malformed-version incident).
+//
+// testdata/manifest_corpus/ holds one small fixture per manifest kind,
+// each carrying BOTH legitimate declarations and the garbage corners
+// production taught us about (hash-pinned continuations, cargo inline
+// tables, gradle project() refs, ${}/$() interpolation, workspace:/
+// catalog: protocols, pubspec block sub-keys, keyword options).
+//
+// Two nets, run on every `go test ./...` (no DB, no network):
+//
+//  1. TestManifestCorpusGolden — parses every fixture through the SAME
+//     parser + normalizeParsedVersion pipeline the analysis walk runs,
+//     and compares the full output against golden.json. ANY behavior
+//     change in ANY parser — intended or not — shows up as a diff.
+//     Intended changes regenerate the golden:
+//
+//        AVELOXIS_UPDATE_GOLDEN=1 go test ./internal/collector/ -run TestManifestCorpusGolden
+//
+//     then REVIEW THE GOLDEN DIFF before committing — the golden diff
+//     IS the regression review.
+//
+//  2. TestManifestCorpusVersionHygiene — the invariant that survives
+//     careless golden regeneration: every version the pipeline emits
+//     is either "" (unpinned) or passes versionGateOK. A parser
+//     change that leaks garbage fails HERE even if someone blindly
+//     regenerated the golden.
+//
+// Extending coverage = drop a fixture file + add one dispatch line +
+// regenerate the golden.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+const corpusDir = "testdata/manifest_corpus"
+
+// corpusDep is the golden-file shape: the fields of libyearDep that
+// constitute parser output contract (Requirement included — it is the
+// raw-manifest display truth the GUI renders).
+type corpusDep struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Requirement string `json:"requirement"`
+	Type        string `json:"type"`
+	Manager     string `json:"manager"`
+}
+
+// parseCorpusFile dispatches a fixture to the same parser the analysis
+// walk uses for that filename, then applies the central normalizer
+// exactly as the walk does.
+func parseCorpusFile(t *testing.T, name string) []libyearDep {
+	t.Helper()
+	path := filepath.Join(corpusDir, name)
+	content := func() string {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return string(data)
+	}
+	var deps []libyearDep
+	switch name {
+	case "requirements.txt":
+		deps = parseRequirementsTxtVersions(path)
+	case "package.json":
+		var err error
+		deps, err = parsePackageJSONVersions(path)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+	case "Cargo.toml":
+		deps = parseCargoVersions(path)
+	case "Gemfile":
+		deps = parseGemfileVersions(path)
+	case "go.mod":
+		deps = parseGoModVersions(path)
+	case "composer.json":
+		var err error
+		deps, err = parseComposerJSONVersions(path)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+	case "pom.xml":
+		deps = parsePomXMLVersions(content())
+	case "build.gradle":
+		deps = parseBuildGradleVersions(content())
+	case "mix.exs":
+		deps = parseMixExsVersions(content())
+	case "pubspec.yaml":
+		deps = parsePubspecVersions(content())
+	case "packages.config":
+		deps = parseNuGetPackagesConfigVersions(content())
+	case "example.csproj":
+		deps = parseCsprojVersions(content())
+	case "Pipfile":
+		deps = parsePipfileVersions(content())
+	case "pyproject.toml":
+		deps = parsePyprojectVersionsFromContent(content())
+	case "build.sbt":
+		deps = parseBuildSbtVersions(content())
+	case "Package.swift":
+		deps = parsePackageSwiftVersions(content())
+	case "package.yaml":
+		deps = parseHaskellPackageYamlVersions(content())
+	case "workflow.yml":
+		deps = parseWorkflowUses(content())
+	default:
+		t.Fatalf("no parser dispatch for corpus fixture %q — add it to parseCorpusFile", name)
+	}
+	// The walk's central hygiene layer (v0.27.71).
+	for i := range deps {
+		deps[i].Version = normalizeParsedVersion(deps[i].Manager, deps[i].Version)
+	}
+	return deps
+}
+
+func corpusFixtures(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(corpusDir)
+	if err != nil {
+		t.Fatalf("corpus dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "golden.json" {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	if len(names) < 15 {
+		t.Fatalf("corpus has only %d fixtures — the regression net is supposed to cover every ecosystem (self-check against silent fixture loss)", len(names))
+	}
+	return names
+}
+
+func TestManifestCorpusGolden(t *testing.T) {
+	got := map[string][]corpusDep{}
+	for _, name := range corpusFixtures(t) {
+		deps := parseCorpusFile(t, name)
+		out := make([]corpusDep, 0, len(deps))
+		for _, d := range deps {
+			out = append(out, corpusDep(d))
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].Name != out[j].Name {
+				return out[i].Name < out[j].Name
+			}
+			return out[i].Requirement < out[j].Requirement
+		})
+		got[name] = out
+	}
+
+	goldenPath := filepath.Join(corpusDir, "golden.json")
+	if os.Getenv("AVELOXIS_UPDATE_GOLDEN") == "1" {
+		blob, err := json.MarshalIndent(got, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, append(blob, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("golden regenerated at %s — review the diff before committing", goldenPath)
+		return
+	}
+
+	blob, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("golden missing (%v) — generate with AVELOXIS_UPDATE_GOLDEN=1", err)
+	}
+	var want map[string][]corpusDep
+	if err := json.Unmarshal(blob, &want); err != nil {
+		t.Fatalf("golden unreadable: %v", err)
+	}
+
+	for name, wantDeps := range want {
+		gotDeps, ok := got[name]
+		if !ok {
+			t.Errorf("%s: fixture in golden but not parsed — dispatch or fixture removed?", name)
+			continue
+		}
+		if len(gotDeps) != len(wantDeps) {
+			t.Errorf("%s: %d deps, golden has %d\n got: %+v\nwant: %+v", name, len(gotDeps), len(wantDeps), gotDeps, wantDeps)
+			continue
+		}
+		for i := range wantDeps {
+			if gotDeps[i] != wantDeps[i] {
+				t.Errorf("%s[%d]:\n got: %+v\nwant: %+v\n(intended change? regenerate with AVELOXIS_UPDATE_GOLDEN=1 and REVIEW the diff)", name, i, gotDeps[i], wantDeps[i])
+			}
+		}
+	}
+	for name := range got {
+		if _, ok := want[name]; !ok {
+			t.Errorf("%s: new fixture has no golden entry — regenerate with AVELOXIS_UPDATE_GOLDEN=1", name)
+		}
+	}
+}
+
+// The golden-independent invariant: nothing the parser+normalizer
+// pipeline emits may carry a garbage version. This is what fails when
+// someone regenerates the golden without looking.
+func TestManifestCorpusVersionHygiene(t *testing.T) {
+	for _, name := range corpusFixtures(t) {
+		for _, d := range parseCorpusFile(t, name) {
+			if d.Manager == "githubactions" {
+				continue // refs are refs (v0.27.47), exempt by design
+			}
+			if d.Version != "" && !versionGateOK(d.Version) {
+				t.Errorf("%s: dep %s emitted garbage version %q — the parser+normalizer pipeline must only produce \"\" or gate-valid versions", name, d.Name, d.Version)
+			}
+			if d.Name == "" {
+				t.Errorf("%s: dep with empty name (version %q)", name, d.Version)
+			}
+		}
+	}
+}

--- a/internal/collector/process_progress.go
+++ b/internal/collector/process_progress.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import "log/slog"
+
+// process_progress.go — INFO-level progress visibility for the processing
+// phase (v0.27.53).
+//
+// Motivating incident (2026-07-29): pytorch/pytorch entered "processing
+// staged data" on 2026-07-25T11:18:45Z with 1.32M staged messages and then
+// emitted ZERO log lines for 4+ days while grinding healthily — the operator
+// had to fall back to live DB queries (staging processed-counts + the
+// locked_at heartbeat) to distinguish "working" from "dead". The
+// collection-side phases got progress lines in v0.22.4 ("review comments
+// progress" every 1000); processing was the remaining silent multi-day
+// phase. This tracker closes that gap without touching the processing logic
+// itself: ProcessRepo counts rows AFTER each successful processBatch and the
+// tracker decides when a line is due.
+
+// processProgressEvery is the row interval between "processing progress"
+// lines. Derivation, not a guess: batches are processBatchSize (500) rows,
+// so this is every 10th batch; at the pytorch incident's observed worst-case
+// rate (~500 rows/1–2 min) that is one line every ~10–20 minutes; and
+// typical incremental cycles stage well under 5,000 rows per entity type, so
+// the fleet's steady-state cycles emit no new lines at all (pinned by
+// TestProcessProgressBelowIntervalStaysSilent).
+const processProgressEvery = 5000
+
+// processProgress emits periodic progress lines for one (repo, entity type)
+// processing phase. Purely observational: it never returns errors and never
+// touches the store, so wiring it into ProcessRepo cannot alter processing
+// behavior.
+type processProgress struct {
+	logger     *slog.Logger
+	repoID     int64
+	entityType string
+	every      int
+	processed  int
+	lastLogged int
+}
+
+func newProcessProgress(logger *slog.Logger, repoID int64, entityType string, every int) *processProgress {
+	return &processProgress{logger: logger, repoID: repoID, entityType: entityType, every: every}
+}
+
+// add records n successfully processed rows and logs a progress line
+// whenever at least `every` rows have accumulated since the last line.
+func (p *processProgress) add(n int) {
+	p.processed += n
+	if p.processed-p.lastLogged >= p.every {
+		p.lastLogged = p.processed
+		p.logger.Info("processing progress",
+			"repo_id", p.repoID, "type", p.entityType, "rows", p.processed)
+	}
+}
+
+// finish logs a completion summary for phases big enough to have been worth
+// progress lines (>= every). Small phases — the overwhelming majority of
+// incremental cycles — stay completely silent so this feature adds no fleet
+// log volume.
+func (p *processProgress) finish() {
+	if p.processed >= p.every {
+		p.logger.Info("entity processed",
+			"repo_id", p.repoID, "type", p.entityType, "rows", p.processed)
+	}
+}

--- a/internal/collector/process_progress_test.go
+++ b/internal/collector/process_progress_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+// process_progress_test.go — TDD suite for the v0.27.53 processor progress
+// logging. Motivating incident (2026-07-29): pytorch/pytorch spent 4+ days
+// inside ProcessRepo with ZERO log output between "processing staged data"
+// (2026-07-25T11:18:45Z) and completion — 1.32M staged messages ground
+// through silently while the operator concluded the job was dead. The
+// collection-side phases got progress lines in v0.22.4; processing was the
+// remaining silent multi-day phase. These tests pin the tracker's behavior
+// (pure, buffer-backed logger — no DB needed) and the ProcessRepo wiring.
+
+import (
+	"bytes"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// newBufferLogger returns a slog.Logger writing to the returned buffer, at
+// INFO level, so tests can assert on exactly what operators would see.
+func newBufferLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})), &buf
+}
+
+// The tracker logs whenever at least `every` rows have accumulated since the
+// last progress line — the deterministic contract ProcessRepo relies on.
+func TestProcessProgressLogsAtInterval(t *testing.T) {
+	logger, buf := newBufferLogger()
+	p := newProcessProgress(logger, 4366, "message", 10)
+
+	p.add(12) // crosses 10 → one line at rows=12
+	if got := strings.Count(buf.String(), "processing progress"); got != 1 {
+		t.Fatalf("after add(12) with every=10: want 1 progress line, got %d\nlog: %s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "rows=12") {
+		t.Errorf("progress line must carry the cumulative row count (rows=12), got: %s", buf.String())
+	}
+
+	p.add(9) // 21 total, only 9 since last line → silent
+	if got := strings.Count(buf.String(), "processing progress"); got != 1 {
+		t.Fatalf("add(9) below the interval must not log (still 1 line), got %d", got)
+	}
+
+	p.add(1) // 22 total, 10 since last line → second line
+	if got := strings.Count(buf.String(), "processing progress"); got != 2 {
+		t.Fatalf("crossing the interval again must log a second line, got %d\nlog: %s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "rows=22") {
+		t.Errorf("second progress line must show rows=22, got: %s", buf.String())
+	}
+}
+
+// Small phases — the overwhelming majority of incremental cycles — must stay
+// completely silent so the fleet's log volume doesn't grow. This is the
+// guard against turning a diagnostic improvement into log spam.
+func TestProcessProgressBelowIntervalStaysSilent(t *testing.T) {
+	logger, buf := newBufferLogger()
+	p := newProcessProgress(logger, 4366, "release", processProgressEvery)
+	p.add(68)  // a typical release phase
+	p.add(400) // a typical incremental message phase
+	p.finish()
+	if buf.Len() != 0 {
+		t.Fatalf("phases below the interval must emit nothing (progress OR summary), got: %s", buf.String())
+	}
+}
+
+// Big phases get a completion summary with the total, so a pytorch-class run
+// leaves a durable "this phase processed N rows" record in the log.
+func TestProcessProgressFinishLogsSummaryForBigPhases(t *testing.T) {
+	logger, buf := newBufferLogger()
+	p := newProcessProgress(logger, 4366, "message", 10)
+	p.add(25)
+	p.finish()
+	if !strings.Contains(buf.String(), "entity processed") {
+		t.Fatalf("finish() after crossing the interval must log the summary line, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "rows=25") {
+		t.Errorf("summary must carry the phase total (rows=25), got: %s", buf.String())
+	}
+}
+
+// Operators grep by these keys; pin them so a refactor can't silently rename
+// them out from under runbooks.
+func TestProcessProgressLogKeys(t *testing.T) {
+	logger, buf := newBufferLogger()
+	p := newProcessProgress(logger, 4366, "review_comment", 5)
+	p.add(7)
+	out := buf.String()
+	for _, key := range []string{"repo_id=4366", "type=review_comment", "rows=7"} {
+		if !strings.Contains(out, key) {
+			t.Errorf("progress line must carry %q, got: %s", key, out)
+		}
+	}
+}
+
+// The interval must stay large enough that typical incremental cycles
+// (hundreds of rows per entity type) never log — the noise guard, expressed
+// as a floor rather than an exact pin so tuning stays possible.
+func TestProcessProgressIntervalIsNotNoisy(t *testing.T) {
+	if processProgressEvery < 1000 {
+		t.Fatalf("processProgressEvery = %d; below 1000 the fleet's incremental cycles would emit progress spam", processProgressEvery)
+	}
+}
+
+// Source-contract pins on the ProcessRepo wiring. The tracker must (a) be
+// constructed with the shared interval constant, (b) count rows ONLY after a
+// successful processBatch — a failed batch still propagates its error
+// unchanged and uncounted, so the pre-v0.27.53 error contract is untouched —
+// and (c) finish after the entity's drain completes.
+func TestProcessRepoWiresProgressTracker(t *testing.T) {
+	body := extractFuncBody(t, "staged.go", "func (p *Processor) ProcessRepo(")
+
+	if !strings.Contains(body, "newProcessProgress(") {
+		t.Fatal("ProcessRepo must construct the progress tracker via newProcessProgress(...)")
+	}
+	if !strings.Contains(body, "processProgressEvery") {
+		t.Error("ProcessRepo must pass the shared processProgressEvery interval to the tracker")
+	}
+	if !strings.Contains(body, ".finish()") {
+		t.Error("ProcessRepo must call finish() so big phases leave a completion summary")
+	}
+
+	// (b): the add must be guarded by processBatch success. Pin the exact
+	// shape: an early-return on processBatch error BEFORE the add call.
+	guarded := regexp.MustCompile(`(?s)processBatch\(ctx, repoID, platID, entityType, rows\); err != nil \{\s*return err\s*\}.*?\.add\(len\(rows\)\)`)
+	if !guarded.MatchString(body) {
+		t.Fatal("the handler must early-return processBatch errors unchanged and only then count rows (add after the error guard) — counting failed batches would misreport progress and reordering could alter error propagation")
+	}
+}

--- a/internal/collector/processor_integration_test.go
+++ b/internal/collector/processor_integration_test.go
@@ -38,7 +38,7 @@ func TestProcessorEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	store.SetMatviewSkip(true)
 	if err := db.RunMigrations(ctx, store, logger); err != nil {
 		t.Fatalf("RunMigrations: %v", err)

--- a/internal/collector/scan_normalize_integration_test.go
+++ b/internal/collector/scan_normalize_integration_test.go
@@ -74,12 +74,19 @@ func TestScanHealsMalformedPurlsEndToEnd(t *testing.T) {
 		}
 	})
 
-	// The exact pre-v0.27.71 production shapes, verbatim.
+	// The exact pre-v0.27.71 production shapes, verbatim. The third
+	// row is the v0.27.73 residual class from the 2026-08-01 heal run:
+	// a RAW pre-v0.27.29 purl (unescaped concatenation, literal "%i[")
+	// paired with a CLEAN current_version — normalization no-ops (the
+	// version doesn't change), so ONLY the wire gate keeps the garbage
+	// purl from 400ing the repo's entire OSV batch.
 	for _, lb := range []*db.LibyearRow{
 		{Name: "pyyaml", Requirement: `pyyaml==6.0.3 \`, PackageManager: "pypi",
 			CurrentVersion: `6.0.3 \`, Purl: `pkg:pypi/pyyaml@6.0.3 \`},
 		{Name: "serde", Requirement: "serde = { workspace = true }", PackageManager: "cargo",
 			CurrentVersion: "workspace = true", Purl: "pkg:cargo/serde@workspace = true"},
+		{Name: "tzinfo-data", Requirement: "gem 'tzinfo-data', platforms: %i[mingw]", PackageManager: "rubygems",
+			CurrentVersion: "1.2025.3", Purl: `pkg:gem/tzinfo-data@platforms: %i[mingw mswin]`},
 	} {
 		if err := store.InsertRepoLibyear(ctx, repoID, lb); err != nil {
 			t.Fatal(err)
@@ -132,7 +139,8 @@ func TestScanHealsMalformedPurlsEndToEnd(t *testing.T) {
 	osvVulnURLBase = srv.URL + "/v1/vulns/"
 	t.Cleanup(func() { osvBatchURL, osvVulnURLBase = oldBatch, oldVulns })
 
-	if _, err := ScanVulnerabilities(ctx, store, repoID, logger, nil, false); err != nil {
+	result, err := ScanVulnerabilities(ctx, store, repoID, logger, nil, false)
+	if err != nil {
 		t.Fatalf("ScanVulnerabilities: %v", err)
 	}
 
@@ -144,6 +152,9 @@ func TestScanHealsMalformedPurlsEndToEnd(t *testing.T) {
 	for _, p := range purls {
 		if strings.Contains(p, `\`) || strings.Contains(p, "workspace") || strings.Contains(p, " ") {
 			t.Errorf("malformed purl reached OSV: %q — the scan must normalize stored versions at read time", p)
+		}
+		if strings.Contains(p, "%i[") || strings.Contains(p, "tzinfo") {
+			t.Errorf("legacy raw purl reached OSV: %q — the v0.27.73 wire gate must drop it", p)
 		}
 		if p == "pkg:pypi/pyyaml@6.0.3" {
 			sawCleanPyyaml = true
@@ -157,6 +168,11 @@ func TestScanHealsMalformedPurlsEndToEnd(t *testing.T) {
 	}
 	if !sawCleanSerde {
 		t.Errorf("versionless pkg:cargo/serde never queried (workspace dep → unpinned); received: %v", purls)
+	}
+	// The raw-purl target was dropped by the wire gate — counted, and
+	// the scan SUCCEEDED anyway (pre-v0.27.73 it 400'd the whole repo).
+	if result.MalformedTargetsDropped != 1 {
+		t.Errorf("MalformedTargetsDropped = %d, want 1 (the raw tzinfo purl)", result.MalformedTargetsDropped)
 	}
 
 	// The stale false positive must be resolved by the complete scan

--- a/internal/collector/scan_normalize_integration_test.go
+++ b/internal/collector/scan_normalize_integration_test.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+// v0.27.72 — end-to-end proof that the vuln scan heals the
+// malformed-purl false positives WITHOUT waiting for analysis to
+// rewrite the dep rows (the heal-vulnerabilities story):
+//
+//   1. Seed dep rows carrying the EXACT production garbage — pyyaml
+//      at "6.0.3 \" with purl "pkg:pypi/pyyaml@6.0.3 \" (the zephyr
+//      incident shape) and a cargo dep at "workspace = true".
+//   2. Seed the false-positive finding those purls produced
+//      (GHSA-fixed-in-5.4 against pyyaml "6.0.3").
+//   3. Run ScanVulnerabilities against an httptest OSV that RECORDS
+//      every purl it receives and answers advisories only for the
+//      pre-fix malformed shapes.
+//   4. Assert OSV received the CLEAN purl (pkg:pypi/pyyaml@6.0.3) and
+//      the versionless cargo purl — never the garbage — and that the
+//      v0.27.4 lifecycle stamped resolved_at on the stale finding.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+func TestScanHealsMalformedPurlsEndToEnd(t *testing.T) {
+	dsn := os.Getenv("AVELOXIS_TEST_DB")
+	if dsn == "" {
+		t.Skip("AVELOXIS_TEST_DB not set")
+	}
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	store, err := db.NewPostgresStore(ctx, dsn, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(store.Close)
+
+	suffix := time.Now().UnixNano()
+	owner := "_avvulnheal"
+	repoName := fmt.Sprintf("zephyr%d", suffix)
+	repoID, err := store.UpsertRepo(ctx, &model.Repo{
+		Platform: model.PlatformGitHub,
+		GitURL:   fmt.Sprintf("https://github.com/%s/%s", owner, repoName),
+		Owner:    owner,
+		Name:     repoName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, stmt := range []string{
+			"DELETE FROM aveloxis_data.repo_deps_vulnerabilities WHERE repo_id = $1",
+			"DELETE FROM aveloxis_data.repo_deps_libyear WHERE repo_id = $1",
+			"DELETE FROM aveloxis_ops.collection_queue WHERE repo_id = $1",
+			"DELETE FROM aveloxis_data.repos WHERE repo_id = $1",
+		} {
+			_, _ = store.Pool().Exec(context.Background(), stmt, repoID)
+		}
+	})
+
+	// The exact pre-v0.27.71 production shapes, verbatim.
+	for _, lb := range []*db.LibyearRow{
+		{Name: "pyyaml", Requirement: `pyyaml==6.0.3 \`, PackageManager: "pypi",
+			CurrentVersion: `6.0.3 \`, Purl: `pkg:pypi/pyyaml@6.0.3 \`},
+		{Name: "serde", Requirement: "serde = { workspace = true }", PackageManager: "cargo",
+			CurrentVersion: "workspace = true", Purl: "pkg:cargo/serde@workspace = true"},
+	} {
+		if err := store.InsertRepoLibyear(ctx, repoID, lb); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The false positive the malformed purl produced: an ancient
+	// advisory (fixed in 5.4) recorded against a 6.x install.
+	if err := store.InsertVulnerabilityBatch(ctx, repoID, []*db.VulnerabilityRow{{
+		VulnID: "GHSA-fixed-in-54", PackageName: "pyyaml",
+		PackagePurl: `pkg:pypi/pyyaml@6.0.3 \`, Severity: "CRITICAL",
+		CVSSScore: 9.8, FixedVersion: "5.4", Source: "osv.dev",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu            sync.Mutex
+		receivedPurls []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Queries []struct {
+				Package struct {
+					Purl string `json:"purl"`
+				} `json:"package"`
+			} `json:"queries"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		results := make([]map[string]any, len(req.Queries))
+		for i, q := range req.Queries {
+			mu.Lock()
+			receivedPurls = append(receivedPurls, q.Package.Purl)
+			mu.Unlock()
+			// A REAL OSV would only match GHSA-fixed-in-54 for a
+			// version below 5.4 (or an unparseable one). The clean
+			// 6.0.3 purl matches nothing.
+			results[i] = map[string]any{"vulns": []map[string]string{}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+	})
+	mux.HandleFunc("GET /v1/vulns/{id}", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	oldBatch, oldVulns := osvBatchURL, osvVulnURLBase
+	osvBatchURL = srv.URL + "/v1/querybatch"
+	osvVulnURLBase = srv.URL + "/v1/vulns/"
+	t.Cleanup(func() { osvBatchURL, osvVulnURLBase = oldBatch, oldVulns })
+
+	if _, err := ScanVulnerabilities(ctx, store, repoID, logger, nil, false); err != nil {
+		t.Fatalf("ScanVulnerabilities: %v", err)
+	}
+
+	// OSV must have received the CLEAN purls — never the garbage.
+	mu.Lock()
+	purls := append([]string(nil), receivedPurls...)
+	mu.Unlock()
+	sawCleanPyyaml, sawCleanSerde := false, false
+	for _, p := range purls {
+		if strings.Contains(p, `\`) || strings.Contains(p, "workspace") || strings.Contains(p, " ") {
+			t.Errorf("malformed purl reached OSV: %q — the scan must normalize stored versions at read time", p)
+		}
+		if p == "pkg:pypi/pyyaml@6.0.3" {
+			sawCleanPyyaml = true
+		}
+		if p == "pkg:cargo/serde" {
+			sawCleanSerde = true
+		}
+	}
+	if !sawCleanPyyaml {
+		t.Errorf("clean pkg:pypi/pyyaml@6.0.3 never queried; received: %v", purls)
+	}
+	if !sawCleanSerde {
+		t.Errorf("versionless pkg:cargo/serde never queried (workspace dep → unpinned); received: %v", purls)
+	}
+
+	// The stale false positive must be resolved by the complete scan
+	// (v0.27.4 lifecycle) — the immediate-healing story for
+	// heal-vulnerabilities, no analysis re-run required.
+	var resolved *time.Time
+	if err := store.Pool().QueryRow(ctx,
+		`SELECT resolved_at FROM aveloxis_data.repo_deps_vulnerabilities
+		 WHERE repo_id = $1 AND vuln_id = 'GHSA-fixed-in-54'`, repoID).Scan(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if resolved == nil {
+		t.Error("the pre-fix false positive (fixed-in-5.4 against 6.0.3) must get resolved_at stamped by the clean scan")
+	}
+}

--- a/internal/collector/staged.go
+++ b/internal/collector/staged.go
@@ -1150,8 +1150,17 @@ func (p *Processor) ProcessRepo(ctx context.Context, repoID int64, platID int16)
 	}
 
 	for _, entityType := range entityTypes {
+		// v0.27.53: progress visibility only — the tracker counts rows
+		// AFTER a successful processBatch and never affects the error
+		// path. Before this, a pytorch-class repo (1.32M staged
+		// messages) spent 4+ days here with zero log output.
+		prog := newProcessProgress(p.logger, repoID, entityType, processProgressEvery)
 		if err := p.store.ProcessStaged(ctx, repoID, entityType, processBatchSize, func(rows []db.StagedRow) error {
-			return p.processBatch(ctx, repoID, platID, entityType, rows)
+			if err := p.processBatch(ctx, repoID, platID, entityType, rows); err != nil {
+				return err
+			}
+			prog.add(len(rows))
+			return nil
 		}); err != nil {
 			// v0.27.28: cancellation is the shutdown asking us to stop
 			// mid-flush — expected, resumable (staging rows stay
@@ -1165,6 +1174,7 @@ func (p *Processor) ProcessRepo(ctx context.Context, repoID int64, platID int16)
 			}
 			return err
 		}
+		prog.finish()
 	}
 
 	// v0.26.5: derive issues.closed_by_id from the latest 'closed'

--- a/internal/collector/testdata/manifest_corpus/Cargo.toml
+++ b/internal/collector/testdata/manifest_corpus/Cargo.toml
@@ -1,0 +1,10 @@
+[dependencies]
+serde = { workspace = true }
+tokio = { version = "1.38", features = ["full"] }
+local = { path = "../.." }
+fork = { git = "https://github.com/x/y" }
+anyhow = "1.0.86"
+wild = "*"
+
+[dev-dependencies]
+criterion = "0.5"

--- a/internal/collector/testdata/manifest_corpus/Gemfile
+++ b/internal/collector/testdata/manifest_corpus/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+gem "rails", "~> 7.1"
+gem "bootsnap", require: false
+gem "local_thing", path: "../shared"
+gem "jekyll-feed", group: :jekyll_plugins
+gem "pg", ">= 1.1", require: false
+group :test do
+  gem "rspec", "~> 3.13"
+end

--- a/internal/collector/testdata/manifest_corpus/Package.swift
+++ b/internal/collector/testdata/manifest_corpus/Package.swift
@@ -1,0 +1,5 @@
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+    ]
+)

--- a/internal/collector/testdata/manifest_corpus/Pipfile
+++ b/internal/collector/testdata/manifest_corpus/Pipfile
@@ -1,0 +1,7 @@
+[packages]
+requests = "==2.31.0"
+flask = "*"
+numpy = {version = "*", extras = ["dev"]}
+
+[dev-packages]
+pytest = "~=8.2"

--- a/internal/collector/testdata/manifest_corpus/build.gradle
+++ b/internal/collector/testdata/manifest_corpus/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(":core:cas-server-core-util-api")
+    implementation(project(":compiler:fir:tree"))
+    implementation "org.springframework:spring-core:6.1.0"
+    api 'com.google.guava:guava:33.0.0-jre'
+    testImplementation "org.junit.jupiter:junit-jupiter:5.10.2"
+}

--- a/internal/collector/testdata/manifest_corpus/build.sbt
+++ b/internal/collector/testdata/manifest_corpus/build.sbt
@@ -1,0 +1,2 @@
+libraryDependencies += "org.scala-lang" % "scala-library" % "2.13.14"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test

--- a/internal/collector/testdata/manifest_corpus/composer.json
+++ b/internal/collector/testdata/manifest_corpus/composer.json
@@ -1,0 +1,8 @@
+{
+  "require": {
+    "monolog/monolog": "^3.5",
+    "vendor/anything": "*",
+    "vendor/unstable": "2.1.0@beta",
+    "vendor/dev-only": "@dev"
+  }
+}

--- a/internal/collector/testdata/manifest_corpus/example.csproj
+++ b/internal/collector/testdata/manifest_corpus/example.csproj
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+</Project>

--- a/internal/collector/testdata/manifest_corpus/go.mod
+++ b/internal/collector/testdata/manifest_corpus/go.mod
@@ -1,0 +1,6 @@
+module example.com/corpus
+
+require (
+	golang.org/x/text v0.16.0
+	github.com/jackc/pgx/v5 v5.6.0
+)

--- a/internal/collector/testdata/manifest_corpus/golden.json
+++ b/internal/collector/testdata/manifest_corpus/golden.json
@@ -1,0 +1,500 @@
+{
+  "Cargo.toml": [
+    {
+      "name": "anyhow",
+      "version": "1.0.86",
+      "requirement": "anyhow = \"1.0.86\"",
+      "type": "runtime",
+      "manager": "cargo"
+    },
+    {
+      "name": "criterion",
+      "version": "0.5",
+      "requirement": "criterion = \"0.5\"",
+      "type": "dev",
+      "manager": "cargo"
+    },
+    {
+      "name": "fork",
+      "version": "",
+      "requirement": "fork = { git = \"https://github.com/x/y\" }",
+      "type": "runtime",
+      "manager": "cargo"
+    },
+    {
+      "name": "local",
+      "version": "",
+      "requirement": "local = { path = \"../..\" }",
+      "type": "runtime",
+      "manager": "cargo"
+    },
+    {
+      "name": "serde",
+      "version": "",
+      "requirement": "serde = { workspace = true }",
+      "type": "runtime",
+      "manager": "cargo"
+    },
+    {
+      "name": "tokio",
+      "version": "1.38",
+      "requirement": "tokio = { version = \"1.38\", features = [\"full\"] }",
+      "type": "runtime",
+      "manager": "cargo"
+    },
+    {
+      "name": "wild",
+      "version": "",
+      "requirement": "wild = \"*\"",
+      "type": "runtime",
+      "manager": "cargo"
+    }
+  ],
+  "Gemfile": [
+    {
+      "name": "bootsnap",
+      "version": "",
+      "requirement": "gem \"bootsnap\", require: false",
+      "type": "runtime",
+      "manager": "rubygems"
+    },
+    {
+      "name": "jekyll-feed",
+      "version": "",
+      "requirement": "gem \"jekyll-feed\", group: :jekyll_plugins",
+      "type": "runtime",
+      "manager": "rubygems"
+    },
+    {
+      "name": "local_thing",
+      "version": "",
+      "requirement": "gem \"local_thing\", path: \"../shared\"",
+      "type": "runtime",
+      "manager": "rubygems"
+    },
+    {
+      "name": "pg",
+      "version": "1.1",
+      "requirement": "gem \"pg\", \"\u003e= 1.1\", require: false",
+      "type": "runtime",
+      "manager": "rubygems"
+    },
+    {
+      "name": "rails",
+      "version": "7.1",
+      "requirement": "gem \"rails\", \"~\u003e 7.1\"",
+      "type": "runtime",
+      "manager": "rubygems"
+    },
+    {
+      "name": "rspec",
+      "version": "3.13",
+      "requirement": "gem \"rspec\", \"~\u003e 3.13\"",
+      "type": "test",
+      "manager": "rubygems"
+    }
+  ],
+  "Package.swift": [
+    {
+      "name": "swift-argument-parser",
+      "version": "1.3.0",
+      "requirement": "https://github.com/apple/swift-argument-parser",
+      "type": "runtime",
+      "manager": "swiftpm"
+    }
+  ],
+  "Pipfile": [
+    {
+      "name": "flask",
+      "version": "",
+      "requirement": "flask = \"*\"",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "numpy",
+      "version": "",
+      "requirement": "numpy = {version = \"*\", extras = [\"dev\"]}",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "requests",
+      "version": "2.31.0",
+      "requirement": "requests = \"==2.31.0\"",
+      "type": "runtime",
+      "manager": "pypi"
+    }
+  ],
+  "build.gradle": [
+    {
+      "name": "com.google.guava:guava",
+      "version": "33.0.0-jre",
+      "requirement": "com.google.guava:guava:33.0.0-jre",
+      "type": "runtime",
+      "manager": "maven"
+    },
+    {
+      "name": "org.junit.jupiter:junit-jupiter",
+      "version": "5.10.2",
+      "requirement": "org.junit.jupiter:junit-jupiter:5.10.2",
+      "type": "dev",
+      "manager": "maven"
+    },
+    {
+      "name": "org.springframework:spring-core",
+      "version": "6.1.0",
+      "requirement": "org.springframework:spring-core:6.1.0",
+      "type": "runtime",
+      "manager": "maven"
+    }
+  ],
+  "build.sbt": [
+    {
+      "name": "org.scala-lang:scala-library",
+      "version": "2.13.14",
+      "requirement": "libraryDependencies += \"org.scala-lang\" % \"scala-library\" % \"2.13.14\"",
+      "type": "runtime",
+      "manager": "maven"
+    },
+    {
+      "name": "org.scalatest:scalatest",
+      "version": "3.2.18",
+      "requirement": "libraryDependencies += \"org.scalatest\" %% \"scalatest\" % \"3.2.18\" % Test",
+      "type": "test",
+      "manager": "maven"
+    }
+  ],
+  "composer.json": [
+    {
+      "name": "monolog/monolog",
+      "version": "3.5",
+      "requirement": "^3.5",
+      "type": "runtime",
+      "manager": "packagist"
+    },
+    {
+      "name": "vendor/anything",
+      "version": "",
+      "requirement": "*",
+      "type": "runtime",
+      "manager": "packagist"
+    },
+    {
+      "name": "vendor/dev-only",
+      "version": "",
+      "requirement": "@dev",
+      "type": "runtime",
+      "manager": "packagist"
+    },
+    {
+      "name": "vendor/unstable",
+      "version": "2.1.0",
+      "requirement": "2.1.0@beta",
+      "type": "runtime",
+      "manager": "packagist"
+    }
+  ],
+  "example.csproj": [
+    {
+      "name": "Microsoft.Maui.Controls",
+      "version": "",
+      "requirement": "\u003cPackageReference Include=\"Microsoft.Maui.Controls\" Version=\"$(MauiVersion)\" /\u003e",
+      "type": "runtime",
+      "manager": "nuget"
+    },
+    {
+      "name": "System.Text.Json",
+      "version": "8.0.4",
+      "requirement": "\u003cPackageReference Include=\"System.Text.Json\" Version=\"8.0.4\" /\u003e",
+      "type": "runtime",
+      "manager": "nuget"
+    }
+  ],
+  "go.mod": [
+    {
+      "name": "github.com/jackc/pgx/v5",
+      "version": "v5.6.0",
+      "requirement": "github.com/jackc/pgx/v5 v5.6.0",
+      "type": "runtime",
+      "manager": "go"
+    },
+    {
+      "name": "golang.org/x/text",
+      "version": "v0.16.0",
+      "requirement": "golang.org/x/text v0.16.0",
+      "type": "runtime",
+      "manager": "go"
+    }
+  ],
+  "mix.exs": [
+    {
+      "name": "bamboo",
+      "version": "",
+      "requirement": "{:bamboo, git: \"https://github.com/pablo-co/bamboo_postmark.git\", tag: \"v1.0\"},",
+      "type": "runtime",
+      "manager": "hex"
+    },
+    {
+      "name": "burrito",
+      "version": "",
+      "requirement": "{:burrito, github: \"burrito-elixir/burrito\"},",
+      "type": "runtime",
+      "manager": "hex"
+    },
+    {
+      "name": "ex_unit_notifier",
+      "version": "1.3",
+      "requirement": "{:ex_unit_notifier, \"~\u003e 1.3\", only: :test}",
+      "type": "test",
+      "manager": "hex"
+    },
+    {
+      "name": "local_dep",
+      "version": "",
+      "requirement": "{:local_dep, path: \"../shared\"},",
+      "type": "runtime",
+      "manager": "hex"
+    },
+    {
+      "name": "phoenix",
+      "version": "1.7.0",
+      "requirement": "{:phoenix, \"~\u003e 1.7.0\"},",
+      "type": "runtime",
+      "manager": "hex"
+    },
+    {
+      "name": "ranged",
+      "version": "3.0.0",
+      "requirement": "{:ranged, \"\u003e= 3.0.0 and \u003c 5.0.0\"},",
+      "type": "runtime",
+      "manager": "hex"
+    }
+  ],
+  "package.json": [
+    {
+      "name": "anything",
+      "version": "",
+      "requirement": "*",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "express",
+      "version": "4.18.0",
+      "requirement": "^4.18.0",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "internal-a",
+      "version": "",
+      "requirement": "workspace:^",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "internal-b",
+      "version": "",
+      "requirement": "catalog:testing",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "local-tool",
+      "version": "",
+      "requirement": "file:../../../tools/eslint",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "typescript",
+      "version": "5.0.0",
+      "requirement": "\u003e=5.0.0 \u003c6.0.0",
+      "type": "runtime",
+      "manager": "npm"
+    },
+    {
+      "name": "vitest",
+      "version": "1.6.0",
+      "requirement": "~1.6.0",
+      "type": "dev",
+      "manager": "npm"
+    }
+  ],
+  "package.yaml": [
+    {
+      "name": "aeson",
+      "version": "2.1",
+      "requirement": "aeson \u003e= 2.1",
+      "type": "runtime",
+      "manager": "hackage"
+    },
+    {
+      "name": "base",
+      "version": "4.7",
+      "requirement": "base \u003e= 4.7 \u0026\u0026 \u003c 5",
+      "type": "runtime",
+      "manager": "hackage"
+    }
+  ],
+  "packages.config": [
+    {
+      "name": "BuildTool",
+      "version": "1.2.0",
+      "requirement": "\u003cpackage id=\"BuildTool\" version=\"1.2.0\" developmentDependency=\"true\" /\u003e",
+      "type": "build",
+      "manager": "nuget"
+    },
+    {
+      "name": "Newtonsoft.Json",
+      "version": "13.0.3",
+      "requirement": "\u003cpackage id=\"Newtonsoft.Json\" version=\"13.0.3\" /\u003e",
+      "type": "runtime",
+      "manager": "nuget"
+    }
+  ],
+  "pom.xml": [
+    {
+      "name": "com.example:sibling",
+      "version": "",
+      "requirement": "com.example:sibling:${project.version}",
+      "type": "runtime",
+      "manager": "maven"
+    },
+    {
+      "name": "org.springframework:spring-core",
+      "version": "6.1.0",
+      "requirement": "org.springframework:spring-core:6.1.0",
+      "type": "runtime",
+      "manager": "maven"
+    }
+  ],
+  "pubspec.yaml": [
+    {
+      "name": "from_git",
+      "version": "",
+      "requirement": "from_git:",
+      "type": "runtime",
+      "manager": "pub"
+    },
+    {
+      "name": "http",
+      "version": "0.11.1",
+      "requirement": "http: '\u003e=0.11.1 \u003c0.12.0'",
+      "type": "runtime",
+      "manager": "pub"
+    },
+    {
+      "name": "my_lib",
+      "version": "",
+      "requirement": "my_lib:",
+      "type": "runtime",
+      "manager": "pub"
+    },
+    {
+      "name": "path",
+      "version": "1.8.0",
+      "requirement": "path: ^1.8.0",
+      "type": "runtime",
+      "manager": "pub"
+    },
+    {
+      "name": "test",
+      "version": "1.24.0",
+      "requirement": "test: ^1.24.0",
+      "type": "dev",
+      "manager": "pub"
+    }
+  ],
+  "pyproject.toml": [
+    {
+      "name": "httpx",
+      "version": "0.27.0",
+      "requirement": "httpx\u003e=0.27.0",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "pydantic",
+      "version": "2.7.1",
+      "requirement": "pydantic==2.7.1",
+      "type": "runtime",
+      "manager": "pypi"
+    }
+  ],
+  "requirements.txt": [
+    {
+      "name": "attrs",
+      "version": "3.1.0",
+      "requirement": "attrs==3.1.0",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "croniter",
+      "version": "0.4.6",
+      "requirement": "croniter==0.4.6",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "django",
+      "version": "10",
+      "requirement": "django\u003e=10,\u003c11",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "flask",
+      "version": "",
+      "requirement": "flask",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "pyyaml",
+      "version": "6.0.3",
+      "requirement": "pyyaml==6.0.3",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "requests",
+      "version": "2.31.0",
+      "requirement": "requests[security]==2.31.0",
+      "type": "runtime",
+      "manager": "pypi"
+    },
+    {
+      "name": "urllib3",
+      "version": "2.7.0",
+      "requirement": "urllib3==2.7.0",
+      "type": "runtime",
+      "manager": "pypi"
+    }
+  ],
+  "workflow.yml": [
+    {
+      "name": "actions/checkout",
+      "version": "v4",
+      "requirement": "actions/checkout@v4",
+      "type": "build",
+      "manager": "githubactions"
+    },
+    {
+      "name": "actions/setup-go",
+      "version": "releases/v1",
+      "requirement": "actions/setup-go@releases/v1",
+      "type": "build",
+      "manager": "githubactions"
+    },
+    {
+      "name": "custom/action",
+      "version": "5c049362c2b3f4b8dd1ee0f6d0b7f2e9a0e8f7d6",
+      "requirement": "custom/action@5c049362c2b3f4b8dd1ee0f6d0b7f2e9a0e8f7d6",
+      "type": "build",
+      "manager": "githubactions"
+    }
+  ]
+}

--- a/internal/collector/testdata/manifest_corpus/mix.exs
+++ b/internal/collector/testdata/manifest_corpus/mix.exs
@@ -1,0 +1,10 @@
+defp deps do
+    [
+      {:phoenix, "~> 1.7.0"},
+      {:bamboo, git: "https://github.com/pablo-co/bamboo_postmark.git", tag: "v1.0"},
+      {:local_dep, path: "../shared"},
+      {:burrito, github: "burrito-elixir/burrito"},
+      {:ranged, ">= 3.0.0 and < 5.0.0"},
+      {:ex_unit_notifier, "~> 1.3", only: :test}
+    ]
+  end

--- a/internal/collector/testdata/manifest_corpus/package.json
+++ b/internal/collector/testdata/manifest_corpus/package.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "express": "^4.18.0",
+    "internal-a": "workspace:^",
+    "internal-b": "catalog:testing",
+    "anything": "*",
+    "local-tool": "file:../../../tools/eslint",
+    "typescript": ">=5.0.0 <6.0.0"
+  },
+  "devDependencies": {
+    "vitest": "~1.6.0"
+  }
+}

--- a/internal/collector/testdata/manifest_corpus/package.yaml
+++ b/internal/collector/testdata/manifest_corpus/package.yaml
@@ -1,0 +1,3 @@
+dependencies:
+- base >= 4.7 && < 5
+- aeson >= 2.1

--- a/internal/collector/testdata/manifest_corpus/packages.config
+++ b/internal/collector/testdata/manifest_corpus/packages.config
@@ -1,0 +1,4 @@
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" />
+  <package id="BuildTool" version="1.2.0" developmentDependency="true" />
+</packages>

--- a/internal/collector/testdata/manifest_corpus/pom.xml
+++ b/internal/collector/testdata/manifest_corpus/pom.xml
@@ -1,0 +1,14 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>sibling</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/collector/testdata/manifest_corpus/pubspec.yaml
+++ b/internal/collector/testdata/manifest_corpus/pubspec.yaml
@@ -1,0 +1,14 @@
+name: my_app
+dependencies:
+  path: ^1.8.0
+  my_lib:
+    path: ../
+  from_git:
+    git:
+      url: https://github.com/x/y.git
+      ref: main
+  http: '>=0.11.1 <0.12.0'
+  flutter:
+    sdk: flutter
+dev_dependencies:
+  test: ^1.24.0

--- a/internal/collector/testdata/manifest_corpus/pyproject.toml
+++ b/internal/collector/testdata/manifest_corpus/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+dependencies = [
+    "httpx>=0.27.0",
+    "pydantic==2.7.1",
+]

--- a/internal/collector/testdata/manifest_corpus/requirements.txt
+++ b/internal/collector/testdata/manifest_corpus/requirements.txt
@@ -1,0 +1,11 @@
+# zephyr-style hash-pinned block
+pyyaml==6.0.3 \
+    --hash=sha256:aaaa \
+    --hash=sha256:bbbb
+urllib3==2.7.0 \
+    --hash=sha256:cccc
+croniter==0.4.6 ; sys_platform == 'win32'
+attrs==3.1.0  # Apache-2.0
+django>=10,<11
+requests[security]==2.31.0
+flask

--- a/internal/collector/testdata/manifest_corpus/workflow.yml
+++ b/internal/collector/testdata/manifest_corpus/workflow.yml
@@ -1,0 +1,6 @@
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@releases/v1
+      - uses: custom/action@5c049362c2b3f4b8dd1ee0f6d0b7f2e9a0e8f7d6

--- a/internal/collector/version_hygiene_test.go
+++ b/internal/collector/version_hygiene_test.go
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// v0.27.71 — version hygiene. The 2026-08-01 zephyr incident: pip's
+// hash-pinned requirements format ends every pin line with a backslash
+// continuation ("pyyaml==6.0.3 \"), the parser kept the backslash in
+// the version, and the malformed purl (pkg:pypi/pyyaml@6.0.3 \)
+// defeated OSV's version matching — OSV degraded to package-level
+// matching and returned the package's ENTIRE advisory history, so
+// zephyr showed "6.0.3, fixed in 5.4" CRITICALs. The fleet survey
+// found the same class in five more shapes (production counts):
+//
+//	backslash continuation   pypi     21K dep rows → 33K open FP findings
+//	property interpolation   maven/nuget ${..} $(..)  → 7.4K open
+//	inline-table capture     cargo "workspace = true" (13.5K rows), git/path
+//	option capture           rubygems "require: false", hex "git: .."
+//	block sub-key fake deps  pub "path: ../" rows named "path"
+//	wildcard / protocols     "*", workspace:^, catalog:, file:..
+//
+// Two defense layers, both pinned here:
+//  1. Parser fixes at the source (requirements.txt, Cargo.toml,
+//     Gemfile, mix.exs, pubspec.yaml, cleanVersion space ranges).
+//  2. normalizeParsedVersion — the central choke point applied to
+//     EVERY parser's output in the analysis walk, so future parser
+//     slop can never reach purls/registry lookups again.
+
+// ─── Layer 2: the central normalizer ────────────────────────────
+
+func TestNormalizeParsedVersionTable(t *testing.T) {
+	cases := []struct {
+		manager, in, want string
+	}{
+		// The zephyr shape: trailing continuation backslash.
+		{"pypi", `6.0.3 \`, "6.0.3"},
+		{"pypi", `2.7.0 \`, "2.7.0"},
+		// Legit versions pass through untouched.
+		{"pypi", "6.0.3", "6.0.3"},
+		{"pypi", "1!2.0", "1!2.0"}, // PEP 440 epoch
+		{"go", "v0.0.0-20260101000000-abcdef123456", "v0.0.0-20260101000000-abcdef123456"},
+		{"maven", "1.0.0.Final", "1.0.0.Final"},
+		{"maven", "2.0-SNAPSHOT", "2.0-SNAPSHOT"},
+		{"npm", "2.0.0-rc.1+build.5", "2.0.0-rc.1+build.5"},
+		{"nuget", "1.0.0-preview.7", "1.0.0-preview.7"},
+		// Property interpolation (maven ${..}, msbuild $(..)) — the
+		// manifest literally can't tell us the version.
+		{"maven", "${project.version}", ""},
+		{"maven", "${spring.version}", ""},
+		{"nuget", "$(MauiVersion)", ""},
+		// Template/placeholder garbage.
+		{"pypi", "{{latest-pypi-version}}", ""},
+		{"pypi", "%s", ""},
+		{"pypi", `{version = "*"`, ""},
+		// Cargo inline-table fragments (belt — the parser fix is the
+		// suspenders).
+		{"cargo", "workspace = true", ""},
+		{"cargo", `git = "https://github.com/p-hoffmann/trexsql-rs"`, ""},
+		{"cargo", `path = "../.."`, ""},
+		// npm monorepo protocols.
+		{"npm", "workspace:^", ""},
+		{"npm", "workspace:.", ""},
+		{"npm", "workspace:*", ""},
+		{"npm", "catalog:", ""},
+		{"npm", "catalog:testing", ""},
+		{"npm", "file:../../../tools/eslint", ""},
+		{"npm", "/tmp/prisma-0.0.0.tgz", ""},
+		// Wildcards mean "any version" — unpinned, not a version.
+		{"npm", "*", ""},
+		{"pypi", "*", ""},
+		{"packagist", "1.0.*@dev", ""},
+		// Packagist stability flags.
+		{"packagist", "@dev", ""},
+		{"packagist", "@stable", ""},
+		{"packagist", "2.1.0@beta", "2.1.0"},
+		// Space-separated compound ranges keep the floor.
+		{"pub", "0.11.1 <0.12.0", "0.11.1"},
+		{"npm", "16.14.0 <20.0.0", "16.14.0"},
+		{"hex", "3.0.0 and < 5.0.0", "3.0.0"},
+		// Comma ranges keep the floor (requirements.txt "10,<11").
+		{"pypi", "10,<11", "10"},
+		// Option/keyword capture (belt for the Gemfile/mix fixes).
+		{"rubygems", "require: false", ""},
+		{"rubygems", `path: "../`, ""},
+		{"rubygems", ":require => false", ""},
+		{"hex", `git: "https://github.com/plausible/clickhouse_ecto.git`, ""},
+		{"hex", `github: "burrito-elixir/burrito`, ""},
+		{"hex", `path: path("ibrowse")`, ""},
+		{"pub", "../", ""},
+		{"pub", "../../../lib/dart", ""},
+		// Env markers / comments that leak past a parser.
+		{"pypi", `0.4.6 ; sys_platform == 'win32'`, "0.4.6"},
+		{"pypi", "3.1.0 # Apache-2.0", "3.1.0"},
+		// Digit-less tokens are never usable versions.
+		{"maven", "RELEASE", ""},
+		{"npm", "latest", ""},
+		// Empty stays empty.
+		{"pypi", "", ""},
+	}
+	for _, c := range cases {
+		if got := normalizeParsedVersion(c.manager, c.in); got != c.want {
+			t.Errorf("normalizeParsedVersion(%q, %q) = %q, want %q", c.manager, c.in, got, c.want)
+		}
+	}
+}
+
+// GitHub Actions refs are refs, not registry versions — "releases/v1"
+// is a legitimate pin evaluated client-side (actionRefAffected,
+// v0.27.47). The normalizer must never touch them.
+func TestNormalizeParsedVersionExemptsGitHubActions(t *testing.T) {
+	for _, ref := range []string{"releases/v1", "release/v1", "gha/v0", "v4", "5c049362c2b3f4b8dd1ee0f6d0b7f2e9a0e8f7d6"} {
+		if got := normalizeParsedVersion("githubactions", ref); got != ref {
+			t.Errorf("normalizeParsedVersion(githubactions, %q) = %q — Actions refs must pass through verbatim", ref, got)
+		}
+	}
+}
+
+// The choke point must actually be wired into the analysis walk —
+// a normalizer nobody calls protects nothing.
+func TestAnalysisWalkAppliesNormalizer(t *testing.T) {
+	src, err := os.ReadFile("analysis.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), "normalizeParsedVersion(allDeps[i].Manager, allDeps[i].Version)") {
+		t.Error("the analysis manifest walk must pass every parsed dep through " +
+			"normalizeParsedVersion before resolution/storage — the central " +
+			"hygiene layer of the v0.27.71 malformed-version fix")
+	}
+}
+
+// ─── Layer 1: cleanVersion space-separated ranges ───────────────
+
+func TestCleanVersionSpaceSeparatedRanges(t *testing.T) {
+	cases := map[string]string{
+		">=0.11.1 <0.12.0":  "0.11.1",
+		"0.11.1 <0.12.0":    "0.11.1",
+		"1.2.3 - 2.3.4":     "1.2.3", // npm hyphen range
+		"~> 1.2":            "1.2",   // must NOT regress the operator-then-space shape
+		"3.0.0 and < 5.0.0": "3.0.0",
+	}
+	for in, want := range cases {
+		if got := cleanVersion(in); got != want {
+			t.Errorf("cleanVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ─── Layer 1: requirements.txt (the zephyr shape) ───────────────
+
+func TestRequirementsTxtHashPinnedFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.txt")
+	content := "pyyaml==6.0.3 \\\n" +
+		"    --hash=sha256:aaaa \\\n" +
+		"    --hash=sha256:bbbb\n" +
+		"urllib3==2.7.0 \\\n" +
+		"    --hash=sha256:cccc\n" +
+		"croniter==0.4.6 ; sys_platform == 'win32'\n" +
+		"attrs==3.1.0  # Apache-2.0\n" +
+		"django>=10,<11\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps := parseRequirementsTxtVersions(path)
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	want := map[string]string{
+		"pyyaml":   "6.0.3",
+		"urllib3":  "2.7.0",
+		"croniter": "0.4.6",
+		"attrs":    "3.1.0",
+		"django":   "10",
+	}
+	for name, v := range want {
+		if got[name] != v {
+			t.Errorf("requirements.txt %s: version = %q, want %q (full parse: %v)", name, got[name], v, got)
+		}
+	}
+}
+
+// ─── Layer 1: Cargo.toml inline tables ──────────────────────────
+
+func TestCargoInlineTableDeps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Cargo.toml")
+	content := `[dependencies]
+serde = { workspace = true }
+tokio = { version = "1.38", features = ["full"] }
+local = { path = "../.." }
+fork = { git = "https://github.com/x/y" }
+anyhow = "1.0.86"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps := parseCargoVersions(path)
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	if got["serde"] != "" {
+		t.Errorf("workspace-inherited dep captured version %q, want \"\" — 'workspace = true' is not a version (13,471 production rows)", got["serde"])
+	}
+	if got["local"] != "" {
+		t.Errorf("path dep captured version %q, want \"\"", got["local"])
+	}
+	if got["fork"] != "" {
+		t.Errorf("git dep captured version %q, want \"\"", got["fork"])
+	}
+	if got["tokio"] != "1.38" {
+		t.Errorf("inline-table version key = %q, want \"1.38\"", got["tokio"])
+	}
+	if got["anyhow"] != "1.0.86" {
+		t.Errorf("scalar version = %q, want \"1.0.86\"", got["anyhow"])
+	}
+}
+
+// ─── Layer 1: Gemfile option arguments ──────────────────────────
+
+func TestGemfileOptionArgsAreNotVersions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Gemfile")
+	content := `source "https://rubygems.org"
+gem "rails", "~> 7.1"
+gem "bootsnap", require: false
+gem "local_thing", path: "../shared"
+gem "jekyll-feed", group: :jekyll_plugins
+gem "pg", ">= 1.1", require: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps := parseGemfileVersions(path)
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	if got["rails"] != "7.1" {
+		t.Errorf("rails version = %q, want \"7.1\"", got["rails"])
+	}
+	if got["pg"] != "1.1" {
+		t.Errorf("pg version = %q, want \"1.1\" (quoted requirement before options)", got["pg"])
+	}
+	for _, name := range []string{"bootsnap", "local_thing", "jekyll-feed"} {
+		if got[name] != "" {
+			t.Errorf("%s: keyword option captured as version %q, want \"\" — "+
+				"'require: false' was the #1 rubygems garbage version in production (1,212 rows)", name, got[name])
+		}
+	}
+}
+
+// ─── Layer 1: mix.exs non-version options ───────────────────────
+
+func TestMixExsNonVersionOptsAreNotVersions(t *testing.T) {
+	content := `defp deps do
+    [
+      {:phoenix, "~> 1.7.0"},
+      {:bamboo, git: "https://github.com/pablo-co/bamboo_postmark.git", tag: "v1.0"},
+      {:local_dep, path: "../shared"},
+      {:burrito, github: "burrito-elixir/burrito"},
+      {:ranged, ">= 3.0.0 and < 5.0.0"}
+    ]
+  end
+`
+	deps := parseMixExsVersions(content)
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	if got["phoenix"] != "1.7.0" {
+		t.Errorf("phoenix version = %q, want \"1.7.0\"", got["phoenix"])
+	}
+	if got["ranged"] != "3.0.0" {
+		t.Errorf("ranged version = %q, want \"3.0.0\" (space-range floor)", got["ranged"])
+	}
+	for _, name := range []string{"bamboo", "local_dep", "burrito"} {
+		if got[name] != "" {
+			t.Errorf("%s: option captured as version %q, want \"\"", name, got[name])
+		}
+	}
+}
+
+// ─── Layer 1: pubspec.yaml block-style sub-keys ─────────────────
+
+// Block-style deps nest their source under the dep name:
+//
+//	my_lib:
+//	  path: ../
+//
+// The pre-v0.27.71 parser emitted the SUB-KEYS as deps: a package
+// named "path" at version "../" (90 production rows). The fix tracks
+// the dep indent level — deeper lines are sub-keys, not deps. The
+// real pub.dev package NAMED "path" ("path: ^1.8.0" at dep level)
+// must keep working.
+func TestPubspecBlockSubKeysAreNotDeps(t *testing.T) {
+	content := `name: my_app
+dependencies:
+  path: ^1.8.0
+  my_lib:
+    path: ../
+  from_git:
+    git:
+      url: https://github.com/x/y.git
+      ref: main
+  http: '>=0.11.1 <0.12.0'
+dev_dependencies:
+  test: ^1.24.0
+`
+	deps := parsePubspecVersions(content)
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	if got["path"] != "1.8.0" {
+		t.Errorf("the real 'path' package at dep level = %q, want \"1.8.0\"", got["path"])
+	}
+	if got["http"] != "0.11.1" {
+		t.Errorf("http range floor = %q, want \"0.11.1\"", got["http"])
+	}
+	if got["test"] != "1.24.0" {
+		t.Errorf("dev dep test = %q, want \"1.24.0\"", got["test"])
+	}
+	if _, exists := got["url"]; exists {
+		t.Error("block sub-key 'url' emitted as a dep — sub-keys of block-style deps are not packages")
+	}
+	if _, exists := got["ref"]; exists {
+		t.Error("block sub-key 'ref' emitted as a dep")
+	}
+	for _, d := range deps {
+		if d.Name == "my_lib" && d.Version != "" {
+			t.Errorf("block-style path dep my_lib version = %q, want \"\"", d.Version)
+		}
+		if d.Name == "git" || (d.Name == "path" && d.Version == "../") {
+			t.Errorf("sub-key emitted as dep: %s@%s", d.Name, d.Version)
+		}
+	}
+}
+
+// ─── Layer 1: gradle project() references ───────────────────────
+
+// `implementation project(":core:cas-server-core-util-api")` is a
+// reference to the repo's OWN module, not an external dependency.
+// The pre-v0.27.71 parser split the quoted path on ":" and emitted a
+// fake maven dep named ":core" with the MODULE NAME as its version
+// (583+ production rows for apereo/cas alone).
+func TestGradleProjectRefsAreNotDeps(t *testing.T) {
+	content := `dependencies {
+    implementation project(":core:cas-server-core-util-api")
+    implementation(project(":compiler:fir:tree"))
+    testImplementation project(':solr:core')
+    implementation "org.springframework:spring-core:6.1.0"
+    api 'com.google.guava:guava:33.0.0-jre'
+}
+`
+	deps := parseBuildGradleVersions(content)
+	for _, d := range deps {
+		if strings.HasPrefix(d.Name, ":") {
+			t.Errorf("project() reference emitted as dep: %s@%s — intra-repo modules are not external deps", d.Name, d.Version)
+		}
+	}
+	got := map[string]string{}
+	for _, d := range deps {
+		got[d.Name] = d.Version
+	}
+	if got["org.springframework:spring-core"] != "6.1.0" {
+		t.Errorf("external coord = %q, want \"6.1.0\"", got["org.springframework:spring-core"])
+	}
+	if got["com.google.guava:guava"] != "33.0.0-jre" {
+		t.Errorf("external coord = %q, want \"33.0.0-jre\"", got["com.google.guava:guava"])
+	}
+}
+
+// ─── Scan-side purl rebuild (heal-vulnerabilities path) ─────────
+
+// purlReplaceVersion swaps or strips a purl's version segment so the
+// vuln scan can rebuild purls from normalized versions at READ time —
+// what lets `aveloxis heal-vulnerabilities` clean up the malformed-
+// purl false positives IMMEDIATELY, without waiting for each repo's
+// analysis phase to re-run.
+func TestPurlReplaceVersion(t *testing.T) {
+	cases := []struct{ purl, version, want string }{
+		{`pkg:pypi/pyyaml@6.0.3 \`, "6.0.3", "pkg:pypi/pyyaml@6.0.3"},
+		{"pkg:cargo/serde@workspace = true", "", "pkg:cargo/serde"},
+		{"pkg:npm/express@4.18.0", "4.19.2", "pkg:npm/express@4.19.2"},
+		// npm scope marker '@' must not be mistaken for the version
+		// separator.
+		{"pkg:npm/%40scope/name@1.0", "2.0", "pkg:npm/%40scope/name@2.0"},
+		{"pkg:npm/%40scope/name", "1.0", "pkg:npm/%40scope/name@1.0"},
+		{"pkg:pypi/flask", "", "pkg:pypi/flask"},
+		{"", "1.0", ""},
+	}
+	for _, c := range cases {
+		if got := purlReplaceVersion(c.purl, c.version); got != c.want {
+			t.Errorf("purlReplaceVersion(%q, %q) = %q, want %q", c.purl, c.version, got, c.want)
+		}
+	}
+}
+
+// The scan must normalize stored versions at read time — stored dep
+// rows keep garbage until each repo's ANALYSIS re-runs, and without
+// this layer heal-vulnerabilities would re-send the malformed purls.
+func TestScanVulnerabilitiesNormalizesStoredVersions(t *testing.T) {
+	src, err := os.ReadFile("vulnerability.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "normalizeParsedVersion(") {
+		t.Error("ScanVulnerabilities must normalize dep versions read from the store " +
+			"(v0.27.72) — heal-vulnerabilities re-scans from the deps table, which " +
+			"carries pre-fix garbage until analysis re-runs")
+	}
+	if !strings.Contains(code, "purlReplaceVersion(") {
+		t.Error("ScanVulnerabilities must rebuild purls from the normalized version " +
+			"— normalizing the version without the purl leaves the malformed purl in the query")
+	}
+}

--- a/internal/collector/version_hygiene_test.go
+++ b/internal/collector/version_hygiene_test.go
@@ -425,3 +425,70 @@ func TestScanVulnerabilitiesNormalizesStoredVersions(t *testing.T) {
 			"— normalizing the version without the purl leaves the malformed purl in the query")
 	}
 }
+
+// ─── v0.27.73: the OSV wire gate ────────────────────────────────
+
+// The 2026-08-01 heal run: 81 repos failed with OSV 400s like
+// `invalid URL escape "%i["` — pre-v0.27.29 RAW purls (built by
+// concatenation before the canonical escaper) that survived in
+// legacy-era dep rows. One malformed query 400s the ENTIRE repo
+// batch, and OSV's "error in query at index N" names no purl, so
+// diagnosis requires production forensics. wireValidPurl is the
+// last-line syntactic gate: anything that would 400 at OSV is
+// dropped (and NAMED in the log) instead of sinking the repo.
+func TestWireValidPurl(t *testing.T) {
+	valid := []string{
+		"pkg:pypi/pyyaml@6.0.3",
+		"pkg:pypi/numpy@%25s", // escape-valid (decodes to the garbage %s, but syntactically sendable)
+		"pkg:gem/tzinfo-data@platforms:%20%25i[mingw%20mswin%20x64_mingw%20jruby]",
+		"pkg:npm/%40scope/name@1.0.0",
+		"pkg:pypi/flask", // versionless (unpinned / self-advisory)
+		"pkg:golang/golang.org/x/text@v0.16.0",
+	}
+	for _, p := range valid {
+		if !wireValidPurl(p) {
+			t.Errorf("wireValidPurl(%q) = false, want true", p)
+		}
+	}
+	invalid := []string{
+		// The exact production 400 shapes (raw pre-escaper purls).
+		`pkg:gem/tzinfo-data@platforms: %i[mingw mswin x64_mingw jruby]`,
+		"pkg:pypi/numpy@%s",
+		"pkg:gem/foo@1.0 %= bar",
+		"pkg:gem/foo@100%",
+		// Missing / blank name regions ("purl is missing name").
+		"pkg:pypi/",
+		"pkg:pypi/%20",
+		"pkg:pypi/%20@1.0",
+		// Whitespace anywhere is never wire-safe.
+		"pkg:gem/foo bar@1.0",
+		// Not a purl at all.
+		"",
+		"nonsense",
+	}
+	for _, p := range invalid {
+		if wireValidPurl(p) {
+			t.Errorf("wireValidPurl(%q) = true, want false", p)
+		}
+	}
+}
+
+// The gate must be WIRED: ScanVulnerabilities filters targets through
+// it before the OSV batch, logging what it drops (the "index N"
+// anonymity of OSV's error is what made the 2026-08-01 investigation
+// take hours — the log must NAME the dropped purl).
+func TestScanVulnerabilitiesGatesWirePurls(t *testing.T) {
+	src, err := os.ReadFile("vulnerability.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(src)
+	if !strings.Contains(code, "wireValidPurl(") {
+		t.Error("ScanVulnerabilities must filter targets through wireValidPurl — " +
+			"one malformed purl 400s the ENTIRE repo batch at OSV (81 repos on the 2026-08-01 heal run)")
+	}
+	if !strings.Contains(code, "dropping malformed scan target") {
+		t.Error("dropped targets must be logged with the offending purl NAMED " +
+			"(OSV's 'error in query at index N' identifies nothing)")
+	}
+}

--- a/internal/collector/version_normalize.go
+++ b/internal/collector/version_normalize.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+// Package collector — version_normalize.go: the central version-
+// hygiene choke point (v0.27.71).
+//
+// Background (the 2026-08-01 zephyr incident): pip's hash-pinned
+// requirements format ends pin lines with a backslash continuation
+// ("pyyaml==6.0.3 \"). The parser kept the backslash, the purl became
+// pkg:pypi/pyyaml@6.0.3 \, and OSV — unable to parse the version —
+// degraded to package-level matching and returned the package's
+// ENTIRE advisory history. zephyr rendered "6.0.3, fixed in 5.4"
+// CRITICALs. A fleet survey found the same class in five more shapes
+// across ecosystems (cargo inline tables, maven/msbuild property
+// interpolation, Gemfile/mix option capture, pub block sub-keys, npm
+// workspace protocols).
+//
+// The manifest parsers were fixed at the source, but 14 ecosystems ×
+// N syntax corners is exactly the surface where slop recurs — so this
+// normalizer runs over EVERY parsed dep in the analysis walk, after
+// parsing and before resolution/storage/purl construction. A version
+// that can't survive normalization becomes "" — the established
+// 'unpinned' pathway (honest classification, versionless purl) —
+// instead of a garbage string that silently defeats OSV version
+// matching AND the registry libyear lookups.
+//
+// The Requirement field is never touched: it stays the raw manifest
+// truth (the v0.27.11 display philosophy). Only Version — our
+// RESOLUTION of the requirement — is normalized.
+package collector
+
+import "strings"
+
+// nonVersionProtocols are value prefixes that mark a dependency
+// source, not a registry version: npm/pnpm monorepo protocols
+// (workspace:, catalog:, file:, link:, portal:, npm: aliases) and
+// the git/path/url forms that leak out of option-style manifests.
+var nonVersionProtocols = []string{
+	"workspace:", "catalog:", "file:", "link:", "portal:", "npm:",
+	"git:", "github:", "path:", "http://", "https://",
+}
+
+// normalizeParsedVersion sanitizes one parser-produced version string.
+// Returns the cleaned version, or "" when the input carries no usable
+// registry version (property interpolation, monorepo protocols,
+// wildcards, structural garbage).
+//
+// githubactions is exempt wholesale: its "versions" are git refs
+// ("releases/v1", 40-hex SHAs) evaluated client-side against advisory
+// ranges (actionRefAffected, v0.27.47) — ref syntax must pass through
+// verbatim.
+func normalizeParsedVersion(manager, version string) string {
+	if manager == "githubactions" {
+		return version
+	}
+	v := strings.TrimSpace(version)
+	// Line-continuation backslash (the zephyr shape). Belt — the
+	// requirements.txt parser also strips it — but this layer is what
+	// guarantees no OTHER parser can ever leak one again.
+	v = strings.TrimSpace(strings.TrimSuffix(v, "\\"))
+	v = strings.Trim(v, "\"'")
+	if v == "" {
+		return ""
+	}
+	// Property interpolation (maven ${spring.version}, msbuild
+	// $(MauiVersion)), template placeholders ({{latest-pypi-version}}),
+	// and inline-table fragments ({version = "*") all carry braces or
+	// parens — never valid in any registry's version grammar.
+	if strings.ContainsAny(v, "{}()") {
+		return ""
+	}
+	lower := strings.ToLower(v)
+	for _, proto := range nonVersionProtocols {
+		if strings.HasPrefix(lower, proto) {
+			return ""
+		}
+	}
+	// Packagist stability suffix: "2.1.0@beta" → "2.1.0"; a bare
+	// "@dev" collapses to "".
+	if at := strings.LastIndex(v, "@"); at >= 0 {
+		switch suffix := strings.ToLower(v[at+1:]); {
+		case suffix == "dev" || suffix == "stable" || suffix == "beta" || suffix == "alpha" || strings.HasPrefix(suffix, "rc"):
+			v = v[:at]
+		}
+	}
+	// Operator strip + compound-range floor (commas, pipes, spaces).
+	v = cleanVersion(v)
+	if v == "" || strings.Contains(v, "*") {
+		// Wildcards mean "any version" — that's unpinned, not a pin.
+		return ""
+	}
+	if !versionGateOK(v) {
+		return ""
+	}
+	return v
+}
+
+// versionGateOK is the final validity gate: a usable registry version
+// starts with an alphanumeric, contains at least one digit, and uses
+// only the characters real version grammars use (semver, PEP 440
+// epochs, maven qualifiers, Go pseudo-versions). Everything else —
+// quotes, colons, slashes, equals, brackets — is structural garbage
+// from a manifest corner some parser mis-captured.
+func versionGateOK(v string) bool {
+	hasDigit := false
+	for i, r := range v {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+		case r == '.' || r == '+' || r == '_' || r == '~' || r == '!' || r == '-':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}

--- a/internal/collector/vuln_targets.go
+++ b/internal/collector/vuln_targets.go
@@ -224,6 +224,55 @@ func purlWithVersion(purl, version string) string {
 	return purl + "@" + version
 }
 
+// wireValidPurl (v0.27.73) is the last-line syntactic gate before a
+// purl goes to OSV. The 2026-08-01 heal run failed 81 repos with 400s
+// (`invalid URL escape "%i["`, `"purl is missing name"`) because
+// legacy dep rows carried RAW pre-v0.27.29 purls — built by string
+// concatenation before the canonical escaper — and ONE malformed
+// query 400s the repo's ENTIRE batch. OSV's error names only "query
+// at index N", so the offending purl is invisible without production
+// forensics. Anything failing this gate is dropped and NAMED in the
+// log instead of sinking the repo.
+//
+// Rules (syntactic only — semantic hygiene is normalizeParsedVersion's
+// job upstream): "pkg:type/…" shape; no whitespace or control bytes;
+// every '%' begins a valid two-hex escape; the name region (after the
+// type, before any version separator) must be non-blank once %20s are
+// discounted.
+func wireValidPurl(p string) bool {
+	if !strings.HasPrefix(p, "pkg:") {
+		return false
+	}
+	rest := p[len("pkg:"):]
+	slash := strings.IndexByte(rest, '/')
+	if slash <= 0 || slash == len(rest)-1 {
+		return false
+	}
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if c == ' ' || c == '\t' || c < 0x20 {
+			return false
+		}
+		if c == '%' {
+			if i+2 >= len(p) || !isHexByte(p[i+1]) || !isHexByte(p[i+2]) {
+				return false
+			}
+		}
+	}
+	nameRegion := rest[slash+1:]
+	if at := strings.LastIndex(nameRegion, "@"); at >= 0 && !strings.Contains(nameRegion[at:], "/") {
+		nameRegion = nameRegion[:at]
+	}
+	if strings.Trim(strings.ReplaceAll(nameRegion, "%20", " "), " /") == "" {
+		return false
+	}
+	return true
+}
+
+func isHexByte(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
 // purlReplaceVersion (v0.27.72) swaps a purl's version segment for a
 // NORMALIZED one, or strips it entirely when version is "" (the
 // unpinned pathway). This is the scan-side half of the v0.27.71

--- a/internal/collector/vuln_targets.go
+++ b/internal/collector/vuln_targets.go
@@ -223,3 +223,25 @@ func purlWithVersion(purl, version string) string {
 	}
 	return purl + "@" + version
 }
+
+// purlReplaceVersion (v0.27.72) swaps a purl's version segment for a
+// NORMALIZED one, or strips it entirely when version is "" (the
+// unpinned pathway). This is the scan-side half of the v0.27.71
+// version-hygiene fix: stored dep rows keep pre-fix garbage versions
+// until each repo's analysis re-runs, so the scan rebuilds purls from
+// normalizeParsedVersion output at READ time — which is what lets
+// `aveloxis heal-vulnerabilities` clean up the malformed-purl false
+// positives immediately after deploy. Same scope-marker rule as
+// purlWithVersion.
+func purlReplaceVersion(purl, version string) string {
+	if purl == "" {
+		return ""
+	}
+	if at := strings.LastIndex(purl, "@"); at > 0 && !strings.Contains(purl[at:], "/") {
+		purl = purl[:at]
+	}
+	if version == "" {
+		return purl
+	}
+	return purl + "@" + purlEscapeSegment(version)
+}

--- a/internal/collector/vulnerability.go
+++ b/internal/collector/vulnerability.go
@@ -79,6 +79,9 @@ type VulnerabilityResult struct {
 	OSVQueryMisses    int
 	OSVDetailHits     int // v0.27.21 C0: vuln details served from cache
 	OSVDetailMisses   int
+	// v0.27.73: targets dropped by the wire gate (wireValidPurl) —
+	// legacy raw purls that would have 400'd the whole OSV batch.
+	MalformedTargetsDropped int
 }
 
 // ScanVulnerabilities queries OSV.dev for known vulnerabilities in a repo's
@@ -270,11 +273,51 @@ func ScanVulnerabilities(ctx context.Context, store *db.PostgresStore, repoID in
 		return &VulnerabilityResult{VulnsResolved: int(resolved), SelfDepsExcluded: selfExcluded}, nil
 	}
 
+	// v0.27.73: the wire gate. Legacy dep rows can still carry RAW
+	// pre-v0.27.29 purls (unescaped concatenation), and one malformed
+	// query 400s the repo's ENTIRE OSV batch — 81 repos on the
+	// 2026-08-01 fleet heal. Drop what OSV would reject, and NAME it:
+	// OSV's own error ("query at index N") identifies nothing.
+	// Name+ecosystem targets (GitHub Actions) skip the purl check but
+	// must carry a non-blank name. A dropped target's stale findings
+	// resolve via the seen-set below — correct: garbage-born findings.
+	dropped := 0
+	valid := purls[:0]
+	for _, p := range purls {
+		t := purlToTarget[p]
+		ok := wireValidPurl(p)
+		if t.OSVQueryEcosystem != "" {
+			ok = strings.TrimSpace(t.OSVQueryName) != ""
+		}
+		if !ok {
+			dropped++
+			logger.Warn("dropping malformed scan target — would 400 the whole OSV batch",
+				"repo_id", repoID, "purl", p, "dep", t.Dep.Name, "kind", t.Kind)
+			delete(purlToTarget, p)
+			continue
+		}
+		valid = append(valid, p)
+	}
+	purls = valid
+	if len(purls) == 0 {
+		resolved, markErr := store.MarkStaleVulnerabilitiesResolved(ctx, repoID, nil)
+		if markErr != nil {
+			logger.Warn("failed to resolve stale vulnerabilities on all-malformed repo",
+				"repo_id", repoID, "error", markErr)
+		}
+		logger.Info("all scan targets malformed — nothing sendable",
+			"repo_id", repoID, "dropped", dropped, "vulns_resolved", resolved)
+		return &VulnerabilityResult{VulnsResolved: int(resolved), SelfDepsExcluded: selfExcluded,
+			MalformedTargetsDropped: dropped}, nil
+	}
+
 	logger.Info("scanning dependencies for vulnerabilities",
-		"repo_id", repoID, "deps", len(purls), "transitive", transitiveCount)
+		"repo_id", repoID, "deps", len(purls), "transitive", transitiveCount,
+		"malformed_dropped", dropped)
 
 	result := &VulnerabilityResult{TotalDepsScanned: len(purls), SelfDepsExcluded: selfExcluded,
-		TransitivePurls: transitiveCount, SelfAdvisoryPurls: selfCount}
+		TransitivePurls: transitiveCount, SelfAdvisoryPurls: selfCount,
+		MalformedTargetsDropped: dropped}
 
 	// v0.27.21 C0: serve purl answers from the cache where possible and
 	// query OSV only for the misses. Negative results (no vulns) are

--- a/internal/collector/vulnerability.go
+++ b/internal/collector/vulnerability.go
@@ -123,6 +123,22 @@ func ScanVulnerabilities(ctx context.Context, store *db.PostgresStore, repoID in
 		return nil, fmt.Errorf("loading dependencies: %w", err)
 	}
 
+	// v0.27.72: normalize STORED versions at read time and rebuild
+	// the purl when normalization changed anything. Dep rows written
+	// before the v0.27.71 parser fixes carry garbage versions
+	// ("6.0.3 \", "workspace = true", "${project.version}") whose
+	// purls defeat OSV version matching (unparseable version →
+	// package-level match → the package's entire advisory history as
+	// findings — the zephyr incident). Analysis rewrites the rows on
+	// each repo's next cycle, but heal-vulnerabilities and the scan
+	// itself must not depend on that ordering.
+	for i := range deps {
+		if norm := normalizeParsedVersion(deps[i].PackageManager, deps[i].CurrentVersion); norm != deps[i].CurrentVersion {
+			deps[i].CurrentVersion = norm
+			deps[i].Purl = purlReplaceVersion(deps[i].Purl, norm)
+		}
+	}
+
 	// These two reads gate purl ACCURACY; failing open (scanning
 	// without them) would re-add self-dep noise or floor-scan locked
 	// deps, then flip resolved_at back and forth across scans — so a

--- a/internal/config/activity_history_window_test.go
+++ b/internal/config/activity_history_window_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+// activity_history_window_test.go — TDD for the v0.27.58
+// activity_history_window_days knob (operator decision 2026-07-30:
+// "parameterizable windows, with the default being 180 day windows").
+// The GitHub contributionsCollection window may not exceed one year,
+// so the accessor clamps at 365; non-positive falls back to the 180
+// default. Per the config-knobs-end-to-end rule, the value→behavior
+// path (config JSON → window spans actually generated) is tested in
+// internal/platform/github/history_windows_test.go.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestActivityHistoryWindowDaysDefault(t *testing.T) {
+	var c CollectionConfig
+	if got := c.ActivityHistoryWindowDaysOrDefault(); got != 180 {
+		t.Errorf("zero-value accessor = %d, want 180", got)
+	}
+	if DefaultConfig().Collection.ActivityHistoryWindowDays != 180 {
+		t.Error("DefaultConfig must set activity_history_window_days to 180")
+	}
+}
+
+func TestActivityHistoryWindowDaysClamps(t *testing.T) {
+	c := CollectionConfig{ActivityHistoryWindowDays: 500}
+	if got := c.ActivityHistoryWindowDaysOrDefault(); got != 365 {
+		t.Errorf("window above the GitHub 1-year API limit must clamp to 365, got %d", got)
+	}
+	c.ActivityHistoryWindowDays = -3
+	if got := c.ActivityHistoryWindowDaysOrDefault(); got != 180 {
+		t.Errorf("non-positive window must fall back to the 180 default, got %d", got)
+	}
+	c.ActivityHistoryWindowDays = 90
+	if got := c.ActivityHistoryWindowDaysOrDefault(); got != 90 {
+		t.Errorf("in-range value must pass through, got %d", got)
+	}
+}
+
+func TestActivityHistoryWindowDaysJSONTag(t *testing.T) {
+	var c CollectionConfig
+	if err := json.Unmarshal([]byte(`{"activity_history_window_days": 90}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.ActivityHistoryWindowDays != 90 {
+		t.Error(`the JSON key must be "activity_history_window_days"`)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,6 +208,18 @@ type CollectionConfig struct {
 	// Default: "saturday". Views are rebuilt once per week on this day.
 	MatviewRebuildDay string `json:"matview_rebuild_day"`
 
+	// MatviewRebuildSkipDMAggregates skips the dm_ aggregate table
+	// refresh (RefreshAllRepoAggregates) inside the weekly scheduler
+	// rebuild, keeping only the materialized-view step. v0.27.56 —
+	// added after the 2026-07-27→30 incident where the dm_ step (a
+	// 93K-repo × two-pass per-repo loop) ran 3+ days holding
+	// MatviewRebuildActive, silently pausing all collection claims.
+	// Deliberately does NOT affect `aveloxis refresh-views` or
+	// `aveloxis migrate` — those are explicit operator commands.
+	// The FULL weekly-rebuild off-switch is matview_rebuild_day:
+	// "disabled".
+	MatviewRebuildSkipDMAggregates bool `json:"matview_rebuild_skip_dm_aggregates"`
+
 	// MatviewRebuildOnStartup controls whether materialized views are created/refreshed
 	// during schema migration (startup). For large databases this can take minutes.
 	// Default: false — views are created on first migrate but not refreshed on every startup.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,6 +220,15 @@ type CollectionConfig struct {
 	// "disabled".
 	MatviewRebuildSkipDMAggregates bool `json:"matview_rebuild_skip_dm_aggregates"`
 
+	// ActivityHistoryWindowDays is the span of each GitHub
+	// contributionsCollection window the v0.27.58 daily-history
+	// backfill queries (operator decision 2026-07-30: parameterizable,
+	// default 180). GitHub validates from/to at max one year, so the
+	// accessor clamps at 365; the subdivision-on-cap logic halves
+	// windows below this at runtime when a window hits the 100-repo or
+	// page caps, so this is the STARTING span, not a guarantee.
+	ActivityHistoryWindowDays int `json:"activity_history_window_days"`
+
 	// MatviewRebuildOnStartup controls whether materialized views are created/refreshed
 	// during schema migration (startup). For large databases this can take minutes.
 	// Default: false — views are created on first migrate but not refreshed on every startup.
@@ -1218,6 +1227,20 @@ func (c *Config) SlogLevel() slog.Level {
 
 // MatviewRebuildWeekday returns the time.Weekday for the configured matview
 // rebuild day, or -1 if disabled.
+// ActivityHistoryWindowDaysOrDefault returns the configured history
+// window span, clamped to GitHub's 1-year contributionsCollection
+// limit (365); non-positive values fall back to the 180-day default.
+func (c *CollectionConfig) ActivityHistoryWindowDaysOrDefault() int {
+	switch {
+	case c.ActivityHistoryWindowDays <= 0:
+		return 180
+	case c.ActivityHistoryWindowDays > 365:
+		return 365
+	default:
+		return c.ActivityHistoryWindowDays
+	}
+}
+
 func (c *CollectionConfig) MatviewRebuildWeekday() int {
 	switch strings.ToLower(c.MatviewRebuildDay) {
 	case "sunday":
@@ -1263,11 +1286,12 @@ func DefaultConfig() *Config {
 			APIInternalURL: "http://127.0.0.1:8383",
 		},
 		Collection: CollectionConfig{
-			DaysUntilRecollect:      1,
-			Workers:                 12,
-			RepoCloneDir:            defaultCloneDir(),
-			MatviewRebuildDay:       "saturday",
-			MatviewRebuildOnStartup: false,
+			DaysUntilRecollect:        1,
+			Workers:                   12,
+			RepoCloneDir:              defaultCloneDir(),
+			MatviewRebuildDay:         "saturday",
+			ActivityHistoryWindowDays: 180,
+			MatviewRebuildOnStartup:   false,
 			// v0.26.0 (tech-debt Action 3, phase A): GraphQL is the
 			// default for GitHub PR-child fetch and issue+PR listing —
 			// the flip the v0.19.0 sunset plan scheduled but never

--- a/internal/config/json_surface_test.go
+++ b/internal/config/json_surface_test.go
@@ -23,6 +23,7 @@ var frozenCollectionKeys = []string{
 	"force_full",
 	"matview_rebuild_day",
 	"matview_rebuild_on_startup",
+	"matview_rebuild_skip_dm_aggregates",
 	"pr_child_mode",
 	"listing_mode",
 	"threading_mode",

--- a/internal/config/json_surface_test.go
+++ b/internal/config/json_surface_test.go
@@ -24,6 +24,7 @@ var frozenCollectionKeys = []string{
 	"matview_rebuild_day",
 	"matview_rebuild_on_startup",
 	"matview_rebuild_skip_dm_aggregates",
+	"activity_history_window_days",
 	"pr_child_mode",
 	"listing_mode",
 	"threading_mode",

--- a/internal/config/matview_dm_skip_test.go
+++ b/internal/config/matview_dm_skip_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package config
+
+// matview_dm_skip_test.go — TDD suite for the v0.27.56
+// matview_rebuild_skip_dm_aggregates knob.
+//
+// Motivating incident (2026-07-27→30, aveloxis_large): the weekly
+// rebuild's SECOND step — RefreshAllRepoAggregates, a 93,222-repo ×
+// two-pass per-repo DELETE+INSERT loop — ran for 3+ days while
+// MatviewRebuildActive stayed set, silently pausing all collection
+// claims with 74K repos due. The matview step itself took ~20h; the
+// dm_ step was the multi-day tail. This knob lets operators keep the
+// weekly matview refresh but skip the dm_ aggregate pass entirely
+// (dm_ tables then update only via `aveloxis refresh-views` /
+// `aveloxis migrate`, which are explicit operator commands and
+// deliberately NOT gated by this knob). The full rebuild off-switch
+// already exists: matview_rebuild_day: "disabled".
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMatviewSkipDMAggregatesField(t *testing.T) {
+	var c CollectionConfig
+	c.MatviewRebuildSkipDMAggregates = true // compile-time field pin
+	if !c.MatviewRebuildSkipDMAggregates {
+		t.Fatal("field must be settable")
+	}
+}
+
+// Zero-value = false = pre-v0.27.56 behavior, so operators who never
+// touch aveloxis.json see no change. A plain bool (not *bool) is
+// deliberate: the default IS the zero value, no absent-vs-false
+// distinction needed.
+func TestMatviewSkipDMAggregatesJSONRoundTrip(t *testing.T) {
+	var absent CollectionConfig
+	if err := json.Unmarshal([]byte(`{}`), &absent); err != nil {
+		t.Fatal(err)
+	}
+	if absent.MatviewRebuildSkipDMAggregates {
+		t.Error("absent key must default to false (dm_ refresh stays part of the weekly rebuild)")
+	}
+	var set CollectionConfig
+	if err := json.Unmarshal([]byte(`{"matview_rebuild_skip_dm_aggregates": true}`), &set); err != nil {
+		t.Fatal(err)
+	}
+	if !set.MatviewRebuildSkipDMAggregates {
+		t.Error("matview_rebuild_skip_dm_aggregates: true must parse into the field")
+	}
+}
+
+// The scheduler's weekly rebuild must consult the knob AND log the
+// skip (log-the-effective-value rule: operators reading the log must
+// see that the dm_ step was skipped by config, not silently absent).
+// The gate must sit around the RefreshAllRepoAggregates call — the
+// matview step is deliberately not affected by this knob.
+func TestRebuildMatviewsConsultsSkipKnob(t *testing.T) {
+	src, err := os.ReadFile("../scheduler/scheduler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+	idx := strings.Index(body, "func (s *Scheduler) rebuildMatviews(")
+	if idx < 0 {
+		t.Fatal("cannot find rebuildMatviews")
+	}
+	body = body[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	if !strings.Contains(body, "MatviewRebuildSkipDMAggregates") {
+		t.Fatal("rebuildMatviews must consult Collection.MatviewRebuildSkipDMAggregates around the dm_ aggregate step")
+	}
+	if !strings.Contains(body, "RefreshAllRepoAggregates") {
+		t.Fatal("rebuildMatviews lost its RefreshAllRepoAggregates call — the knob must gate it, not delete it")
+	}
+	skipPos := strings.Index(body, "MatviewRebuildSkipDMAggregates")
+	refreshPos := strings.Index(body, "RefreshAllRepoAggregates")
+	if skipPos > refreshPos {
+		t.Error("the skip check must come BEFORE the RefreshAllRepoAggregates call so a skipped run never starts the multi-day loop")
+	}
+	if !strings.Contains(body, "skipped by config") && !strings.Contains(body, "skipped (matview_rebuild_skip_dm_aggregates") {
+		t.Error("the skip path must log that the dm_ step was skipped by config — silence here reads as 'the rebuild forgot the aggregates'")
+	}
+}

--- a/internal/db/allocation_bounds_test.go
+++ b/internal/db/allocation_bounds_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// v0.27.65 — store-layer allocation backstops (CodeQL
+// go/uncontrolled-allocation-size on the v0.27.61/63 PR). Every store
+// method whose caller-supplied limit/pageSize feeds a `make` capacity
+// (or a SQL LIMIT) must clamp its OWN upper bound: API handlers cap
+// too, but the store is the shared surface and must not rely on every
+// future caller remembering. The clamps use bare single-comparison
+// guards (`x > 100`) — the barrier shape the scanner's upper-bound
+// analysis recognizes; a compound `a || b` reassignment was flagged
+// even though it bounded the value.
+
+func TestTopContributorsClampsUpperLimitInStore(t *testing.T) {
+	body := extractStoreFunc(t, "contributions.go", "func (s *PostgresStore) TopContributors(")
+	if !strings.Contains(body, "limit > 100") {
+		t.Error("TopContributors must clamp limit > 100 at the STORE layer — the API cap alone leaves the shared surface unbounded (CodeQL go/uncontrolled-allocation-size)")
+	}
+}
+
+func TestGetCollectionReposClampsPageSizeWithBareGuards(t *testing.T) {
+	body := extractStoreFunc(t, "collections_store.go", "func (s *PostgresStore) GetCollectionRepos(")
+	if !strings.Contains(body, "pageSize > 100") {
+		t.Error("GetCollectionRepos must clamp pageSize with a bare `pageSize > 100` guard (scanner-recognizable upper bound)")
+	}
+	if strings.Contains(body, "pageSize < 1 || pageSize > 100") {
+		t.Error("GetCollectionRepos must NOT combine the clamps into one compound condition — CodeQL's upper-bound barrier misses that shape (2026-07-31 finding)")
+	}
+}
+
+// extractStoreFunc returns the source of one function body: from its
+// signature to the next top-level `func ` (or EOF).
+func extractStoreFunc(t *testing.T, file, sig string) string {
+	t.Helper()
+	src := readSourceFile(t, file)
+	start := strings.Index(src, sig)
+	if start < 0 {
+		t.Fatalf("%s: signature %q not found", file, sig)
+	}
+	rest := src[start+len(sig):]
+	end := strings.Index(rest, "\nfunc ")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end]
+}

--- a/internal/db/allocation_bounds_test.go
+++ b/internal/db/allocation_bounds_test.go
@@ -23,6 +23,13 @@ func TestTopContributorsClampsUpperLimitInStore(t *testing.T) {
 	if !strings.Contains(body, "limit > 100") {
 		t.Error("TopContributors must clamp limit > 100 at the STORE layer — the API cap alone leaves the shared surface unbounded (CodeQL go/uncontrolled-allocation-size)")
 	}
+	// Round 2: the make() capacity must be a CONSTANT, never the
+	// user-derived limit — the scanner doesn't credit clamp-and-
+	// continue reassignments as barriers, and a constant hint costs
+	// nothing (append grows past it).
+	if strings.Contains(body, "make([]TopContributor, 0, limit)") {
+		t.Error("TopContributors allocation capacity must be a constant, not `limit` — the taint path to make() is what CodeQL flags (2026-07-31 round 2)")
+	}
 }
 
 func TestGetCollectionReposClampsPageSizeWithBareGuards(t *testing.T) {
@@ -32,6 +39,10 @@ func TestGetCollectionReposClampsPageSizeWithBareGuards(t *testing.T) {
 	}
 	if strings.Contains(body, "pageSize < 1 || pageSize > 100") {
 		t.Error("GetCollectionRepos must NOT combine the clamps into one compound condition — CodeQL's upper-bound barrier misses that shape (2026-07-31 finding)")
+	}
+	// Round 2: constant capacity, never the user-derived pageSize.
+	if strings.Contains(body, "make([]CollectionRepo, 0, pageSize)") {
+		t.Error("GetCollectionRepos allocation capacity must be a constant, not `pageSize` — the taint path to make() is what CodeQL flags (2026-07-31 round 2)")
 	}
 }
 

--- a/internal/db/analytics_values_groundtruth_test.go
+++ b/internal/db/analytics_values_groundtruth_test.go
@@ -38,7 +38,7 @@ func bucketDate(points []WeeklyPoint, y int, m time.Month, d int) float64 {
 
 func TestMetricSeriesExactValuesFromSeededData(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 	carol := seed.contributor("_avgt-carol", "User", 0)
 
@@ -116,7 +116,7 @@ func TestMetricSeriesExactValuesFromSeededData(t *testing.T) {
 // rounding, not implementation slack).
 func TestLaborInvestmentMatchesPublishedCOCOMO(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 
 	_, err := store.pool.Exec(ctx, `

--- a/internal/db/apache_lists_bridge_test.go
+++ b/internal/db/apache_lists_bridge_test.go
@@ -37,7 +37,7 @@ func TestApacheListBridgeStoreMethodsExist(t *testing.T) {
 // worker can write bodies with a NOT-NULL repo_id).
 func TestApacheListBridgeEndToEnd(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID, err := store.UpsertRepo(ctx, &model.Repo{
 		Platform: model.PlatformGitHub, GitURL: "https://github.com/apache/bridgetest",

--- a/internal/db/aveloxis_status_store_test.go
+++ b/internal/db/aveloxis_status_store_test.go
@@ -28,7 +28,7 @@ func TestSchemaDeclaresAveloxisStatus(t *testing.T) {
 // TestAveloxisStatusUpsert exercises set → get → re-set (one row per status_name).
 func TestAveloxisStatusUpsert(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	clean := func() {
 		store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.aveloxis_status WHERE status_name='_av_test_sc'`)
 	}

--- a/internal/db/breadth_batch_mark_test.go
+++ b/internal/db/breadth_batch_mark_test.go
@@ -142,7 +142,7 @@ func TestBreadthIndexMatchesClaimQueryOrder(t *testing.T) {
 // that subset is stamped.
 func TestMarkBreadthAttemptedBatchStampsAll(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	slug := fmt.Sprintf("avbreadthbatch_%d", time.Now().UnixNano())
 	var ids []string
@@ -190,7 +190,7 @@ func TestMarkBreadthAttemptedBatchStampsAll(t *testing.T) {
 // the index landed with the NULLS FIRST ordering in its definition.
 func TestBreadthIndexExistsAfterMigrate(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	store.SetMatviewSkip(true)
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)

--- a/internal/db/breadth_jitter_test.go
+++ b/internal/db/breadth_jitter_test.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// breadth_jitter_test.go — TDD suite for the v0.27.55 breadth-cooldown
+// jitter.
+//
+// Motivating diagnosis (2026-07-29, aveloxis_large): breadth throughput
+// was violently bimodal — 300-560K contributors marked on some days,
+// 411-7K on others — because a hard cooldown cliff makes each day's
+// eligible supply an exact echo of the marks one cooldown-period
+// earlier. Cohorts bunched by historical events (the v0.27.8 backlog
+// chew, pre-v0.27.8 famine days) re-bunch forever. Jittering each row's
+// effective cooldown by ±BreadthCooldownJitterFrac diffuses the bunches:
+// every period adds an independent uniform offset, so cohort spread
+// grows period over period and the feast/famine sawtooth decays toward
+// the uniform pool/cooldown daily rate.
+//
+// Soundness invariants pinned here:
+//   1. factor range symmetric around 1.0 → the operator's configured
+//      cadence is preserved in expectation;
+//   2. rows older than (1+frac)×cooldown are ALWAYS claimable (jitter
+//      can delay a row, never strand it);
+//   3. rows fresher than (1−frac)×cooldown are NEVER claimable (jitter
+//      shortens the cooldown boundedly, never defeats it);
+//   4. the boundary zone is genuinely probabilistic;
+//   5. never-attempted rows (NULL stamp) keep absolute priority and the
+//      ORDER BY / LIMIT contract is unchanged.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBreadthCooldownJitterFracValue pins the constant and its safety
+// bounds. 0.10 is derived, not a guess: ±10% of the production 14-day
+// cooldown is ±1.4 days — wide enough that adjacent feast cohorts leak
+// into the 1-2-day famine valleys within a single period, narrow enough
+// that every row's actual cadence stays within 10% of the operator's
+// configured knob. The bounds check guards the class: at frac >= 0.5
+// the lower edge reaches (1-0.5)x → a half-cooldown re-scan, and
+// beyond it the multiplier can go non-positive, making rows eligible
+// immediately after marking.
+func TestBreadthCooldownJitterFracValue(t *testing.T) {
+	if BreadthCooldownJitterFrac != 0.10 {
+		t.Errorf("BreadthCooldownJitterFrac = %v, want 0.10 — if this was tuned deliberately, update this pin and the derivation comment together", BreadthCooldownJitterFrac)
+	}
+	if BreadthCooldownJitterFrac <= 0 || BreadthCooldownJitterFrac >= 0.5 {
+		t.Fatalf("BreadthCooldownJitterFrac = %v is outside (0, 0.5): at 0 the jitter is a no-op and the feast/famine echo returns; at >= 0.5 the effective cooldown can reach zero or below", BreadthCooldownJitterFrac)
+	}
+}
+
+// TestBreadthClaimQueryHasSymmetricJitter pins the SQL shape: the
+// cooldown branch must multiply the interval by
+// (1 - $3 + random() * 2 * $3) — uniform over [1-frac, 1+frac], mean
+// exactly 1.0 — and the constant must be what's passed. The NULL
+// branch, ordering, and LIMIT must survive untouched (core claim logic
+// unchanged).
+func TestBreadthClaimQueryHasSymmetricJitter(t *testing.T) {
+	src := readSourceFile(t, "breadth_store.go")
+	idx := strings.Index(src, "func (s *PostgresStore) GetContributorsForBreadth(")
+	if idx < 0 {
+		t.Fatal("cannot find GetContributorsForBreadth")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+
+	flat := strings.Join(strings.Fields(body), " ")
+	if !strings.Contains(flat, "$2::interval * (1.0 - $3::float8 + random() * 2.0 * $3::float8)") {
+		t.Error("claim query must jitter the cooldown as $2::interval * (1.0 - $3::float8 + random() * 2.0 * $3::float8) — uniform over [1-frac, 1+frac] with mean exactly 1.0, so the configured cadence is preserved in expectation; an asymmetric range would silently shift the operator's cooldown")
+	}
+	if !strings.Contains(flat, "BreadthCooldownJitterFrac") {
+		t.Error("the jitter parameter must be the shared BreadthCooldownJitterFrac constant, not an inline literal")
+	}
+	// Unchanged core contract.
+	for _, needle := range []string{
+		"cntrb_last_breadth_at IS NULL",
+		"ORDER BY cntrb_last_breadth_at ASC NULLS FIRST",
+		"LIMIT $1",
+	} {
+		if !strings.Contains(flat, needle) {
+			t.Errorf("claim query lost %q — the jitter must not alter the NULL-priority / ordering / limit contract", needle)
+		}
+	}
+}
+
+// seedJitterContributor inserts a synthetic contributor whose
+// cntrb_last_breadth_at is NOW() - age, computed DB-side so Go/DB clock
+// skew cannot blur the boundary. age == 0 means never attempted (NULL).
+func seedJitterContributor(t *testing.T, store *PostgresStore, login string, age time.Duration) string {
+	t.Helper()
+	ctx := t.Context()
+	// Re-runs: clear any leftover row with this login first.
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	stamp := "NULL"
+	if age > 0 {
+		stamp = fmt.Sprintf("NOW() - '%s'::interval", age.String())
+	}
+	var id string
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.contributors
+			(cntrb_id, cntrb_login, gh_login, cntrb_last_breadth_at, data_collection_date)
+		VALUES (gen_random_uuid(), $1, $1, `+stamp+`, NOW())
+		RETURNING cntrb_id::text`, login).Scan(&id); err != nil {
+		t.Fatalf("seed %s: %v", login, err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	})
+	return id
+}
+
+// claimIDs runs GetContributorsForBreadth with a limit exceeding the
+// whole scratch pool (so LIMIT truncation can never mask presence or
+// absence) and returns the claimed IDs as a set.
+func claimIDs(t *testing.T, store *PostgresStore, cooldown time.Duration) map[string]bool {
+	t.Helper()
+	ctx := t.Context()
+	var poolN int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_data.contributors
+		WHERE gh_login IS NOT NULL AND gh_login != '' AND COALESCE(cntrb_deleted, 0) = 0`).Scan(&poolN); err != nil {
+		t.Fatal(err)
+	}
+	out, err := store.GetContributorsForBreadth(ctx, poolN+10, cooldown)
+	if err != nil {
+		t.Fatalf("GetContributorsForBreadth: %v", err)
+	}
+	ids := make(map[string]bool, len(out))
+	for _, c := range out {
+		ids[c.ID] = true
+	}
+	return ids
+}
+
+// TestBreadthJitterEligibilityBounds seeds three contributors around a
+// 240h cooldown — well past the upper jitter edge (2×cooldown), well
+// inside the lower edge (0.5×cooldown), and never-attempted — and
+// asserts over repeated claims that jitter delays but never strands,
+// shortens but never defeats, and NULL priority survives.
+func TestBreadthJitterEligibilityBounds(t *testing.T) {
+	store, _ := v0251Connect(t)
+	defer store.Close()
+	cooldown := 240 * time.Hour
+
+	pastID := seedJitterContributor(t, store, "_avjitter_well_past", 2*cooldown)
+	freshID := seedJitterContributor(t, store, "_avjitter_well_inside", cooldown/2)
+	nullID := seedJitterContributor(t, store, "_avjitter_never", 0)
+
+	for i := 0; i < 10; i++ {
+		ids := claimIDs(t, store, cooldown)
+		if !ids[pastID] {
+			t.Fatalf("call %d: contributor aged 2x cooldown missing from claim — jitter's upper bound is (1+%v)x cooldown, so anything older must ALWAYS be eligible; a row jitter can strand never converges", i, BreadthCooldownJitterFrac)
+		}
+		if ids[freshID] {
+			t.Fatalf("call %d: contributor aged 0.5x cooldown was claimed — jitter's lower bound is (1-%v)x cooldown, so anything fresher must NEVER be eligible; otherwise jitter defeats the cooldown instead of smoothing it", i, BreadthCooldownJitterFrac)
+		}
+		if !ids[nullID] {
+			t.Fatalf("call %d: never-attempted contributor missing — NULLS FIRST priority must survive the jitter", i)
+		}
+	}
+}
+
+// TestBreadthJitterBoundaryIsProbabilistic seeds a contributor at
+// exactly the cooldown age — the midpoint of the jitter window, where
+// each claim should include it with probability ~0.5 — and asserts
+// both outcomes occur across 40 claims. Without jitter this row is
+// deterministically claimed every time (its age creeps past the hard
+// cliff), so the "absent at least once" half is the assertion that
+// fails on the pre-jitter query. P(all 40 calls agree) ≈ 2×2⁻⁴⁰ —
+// not a flake source.
+func TestBreadthJitterBoundaryIsProbabilistic(t *testing.T) {
+	store, _ := v0251Connect(t)
+	defer store.Close()
+	cooldown := 240 * time.Hour
+	borderID := seedJitterContributor(t, store, "_avjitter_boundary", cooldown)
+
+	seen, missed := 0, 0
+	for i := 0; i < 40; i++ {
+		if claimIDs(t, store, cooldown)[borderID] {
+			seen++
+		} else {
+			missed++
+		}
+	}
+	if seen == 0 {
+		t.Errorf("boundary-aged contributor never claimed in 40 calls — jitter window looks shifted or the row is stranded (want ~50/50 at the midpoint)")
+	}
+	if missed == 0 {
+		t.Errorf("boundary-aged contributor claimed in all 40 calls — the cooldown boundary is still a deterministic cliff, so the feast/famine echo this jitter exists to break is still intact")
+	}
+}

--- a/internal/db/breadth_jitter_test.go
+++ b/internal/db/breadth_jitter_test.go
@@ -145,7 +145,7 @@ func claimIDs(t *testing.T, store *PostgresStore, cooldown time.Duration) map[st
 // shortens but never defeats, and NULL priority survives.
 func TestBreadthJitterEligibilityBounds(t *testing.T) {
 	store, _ := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	cooldown := 240 * time.Hour
 
 	pastID := seedJitterContributor(t, store, "_avjitter_well_past", 2*cooldown)
@@ -176,7 +176,7 @@ func TestBreadthJitterEligibilityBounds(t *testing.T) {
 // not a flake source.
 func TestBreadthJitterBoundaryIsProbabilistic(t *testing.T) {
 	store, _ := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	cooldown := 240 * time.Hour
 	borderID := seedJitterContributor(t, store, "_avjitter_boundary", cooldown)
 

--- a/internal/db/breadth_store.go
+++ b/internal/db/breadth_store.go
@@ -34,6 +34,30 @@ type ContributorRepoRow struct {
 	CreatedAt time.Time
 }
 
+// BreadthCooldownJitterFrac is the ± fraction by which each row's
+// effective breadth cooldown is randomized per claim, uniform over
+// [1-frac, 1+frac] × cooldown (mean exactly 1.0, so the configured
+// cadence is preserved in expectation).
+//
+// Why (v0.27.55, diagnosed 2026-07-29 on aveloxis_large): a hard
+// cooldown cliff makes each day's eligible supply an exact echo of the
+// marks one cooldown-period earlier — cohorts bunched by history (the
+// v0.27.8 backlog chew produced 560K-mark days; pre-v0.27.8 famines
+// produced 411-mark days) re-bunched every period forever, so daily
+// breadth throughput sawtoothed between ~500K and ~400 while claim
+// capacity sat idle. The jitter adds an independent uniform offset
+// every period, so cohort spread grows period over period and the
+// sawtooth decays toward the uniform pool/cooldown daily rate.
+//
+// 0.10 is derived, not a guess: ±10% of the production 14-day cooldown
+// is ±1.4 days — wide enough that feast cohorts leak into the 1-2-day
+// famine valleys within one period, narrow enough that every row's
+// actual cadence stays within 10% of the operator's knob. Must stay in
+// (0, 0.5): at 0 the echo returns; at >= 0.5 the multiplier's lower
+// edge reaches zero and rows become re-eligible immediately after
+// marking.
+const BreadthCooldownJitterFrac = 0.10
+
 // GetContributorsForBreadth returns contributors that need breadth
 // collection, prioritizing those never attempted (NULL
 // cntrb_last_breadth_at) then those past the cooldown window.
@@ -60,6 +84,12 @@ func (s *PostgresStore) GetContributorsForBreadth(ctx context.Context, limit int
 	if cooldown <= 0 {
 		cooldown = 7 * 24 * time.Hour
 	}
+	// v0.27.55: the cooldown is jittered PER ROW PER CLAIM, uniform
+	// over [1-frac, 1+frac] — see BreadthCooldownJitterFrac for the
+	// full derivation. random() is volatile so each cycle re-rolls
+	// every candidate; the ordered index scan on
+	// idx_contributors_last_breadth still serves the ORDER BY, with
+	// the jitter applied as a per-tuple filter.
 	rows, err := s.pool.Query(ctx, `
 		SELECT cntrb_id::text, gh_login, COALESCE(gh_user_id, 0)
 		FROM aveloxis_data.contributors
@@ -67,9 +97,9 @@ func (s *PostgresStore) GetContributorsForBreadth(ctx context.Context, limit int
 		  AND gh_login != ''
 		  AND COALESCE(cntrb_deleted, 0) = 0
 		  AND (cntrb_last_breadth_at IS NULL
-		       OR cntrb_last_breadth_at < NOW() - $2::interval)
+		       OR cntrb_last_breadth_at < NOW() - ($2::interval * (1.0 - $3::float8 + random() * 2.0 * $3::float8)))
 		ORDER BY cntrb_last_breadth_at ASC NULLS FIRST
-		LIMIT $1`, limit, cooldown.String())
+		LIMIT $1`, limit, cooldown.String(), BreadthCooldownJitterFrac)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/cntrb_id_cascade.go
+++ b/internal/db/cntrb_id_cascade.go
@@ -49,6 +49,12 @@ var cntrbIDChildFKs = []cntrbIDChildFK{
 	// adding it here ensures the v0.22.1 migration helper covers it
 	// on legacy databases where the table is created post-fact.
 	{"contributor_login_history", "cntrb_id", "contributor_login_history_cntrb_id_fkey"},
+	// v0.27.58: the daily activity-history tables are cntrb_id
+	// children; schema declarations carry the full house clause, these
+	// entries keep the v0.22.1 migration helper + cascade coverage
+	// complete on legacy databases.
+	{"contributor_activity_days", "cntrb_id", "contributor_activity_days_cntrb_id_fkey"},
+	{"contributor_activity_day_totals", "cntrb_id", "contributor_activity_day_totals_cntrb_id_fkey"},
 }
 
 // ensureOnUpdateCascadeOnCntrbIDFKs is the v0.22.1 idempotent

--- a/internal/db/cntrb_id_cascade_integration_test.go
+++ b/internal/db/cntrb_id_cascade_integration_test.go
@@ -47,7 +47,7 @@ func TestCntrbIDCascadeIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {
@@ -108,7 +108,7 @@ func TestCntrbIDCascadeActuallyCascades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {

--- a/internal/db/cntrb_id_merge_integration_test.go
+++ b/internal/db/cntrb_id_merge_integration_test.go
@@ -40,7 +40,7 @@ func TestMergeCntrbIDCollisionsBatchEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {

--- a/internal/db/cntrb_id_migrate_integration_test.go
+++ b/internal/db/cntrb_id_migrate_integration_test.go
@@ -40,7 +40,7 @@ func TestMigrateCntrbIDsBatchEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {
@@ -261,7 +261,7 @@ func TestPrecheckCntrbIDCascadeReturnsEmptyOnHealthySchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {

--- a/internal/db/collections_store.go
+++ b/internal/db/collections_store.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // Collections (v0.27.63) are admin-curated groups-of-groups for the
@@ -30,12 +32,19 @@ import (
 // candidate member group is not owned by an admin user.
 var ErrGroupNotAdminOwned = errors.New("collection member groups must be admin-owned")
 
+// ErrCollectionNotFound is returned by StarCollection when the target
+// collection does not exist (surfaced from the FK violation so the
+// API can 404 instead of 500).
+var ErrCollectionNotFound = errors.New("collection not found")
+
 // ErrNotGroupOwner is returned by CopyCollectionToGroup when the
 // target group does not belong to the calling user.
 var ErrNotGroupOwner = errors.New("target group is not owned by the calling user")
 
 // CollectionSummary is one row in the collections list: the
-// collection plus its live group/repo cardinality.
+// collection plus its live group/repo cardinality and whether the
+// CALLING user starred it (v0.27.70 — stars are per-user sort
+// preference, never visibility).
 type CollectionSummary struct {
 	CollectionID int64     `json:"collection_id"`
 	Name         string    `json:"name"`
@@ -43,6 +52,7 @@ type CollectionSummary struct {
 	Position     int       `json:"position"`
 	GroupCount   int       `json:"groups"`
 	RepoCount    int       `json:"repos"`
+	Starred      bool      `json:"starred"`
 	CreatedAt    time.Time `json:"created_at"`
 }
 
@@ -147,18 +157,24 @@ func (s *PostgresStore) RemoveGroupFromCollection(ctx context.Context, collectio
 	return nil
 }
 
-// ListCollections returns every collection ordered by position (then
-// name), each with its live group count and DEDUPED repo count.
-func (s *PostgresStore) ListCollections(ctx context.Context) ([]CollectionSummary, error) {
+// ListCollections returns every collection with its live group count
+// and DEDUPED repo count. Ordering (v0.27.70): the CALLER's starred
+// collections first, then position, then name — stars are a per-user
+// sort preference; every collection stays visible to everyone.
+// userID 0 (no identity) yields the unstarred ordering.
+func (s *PostgresStore) ListCollections(ctx context.Context, userID int) ([]CollectionSummary, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT c.collection_id, c.name, c.description, c.position, c.created_at,
 		       COUNT(DISTINCT cg.group_id)::int  AS groups,
-		       COUNT(DISTINCT ur.repo_id)::int   AS repos
+		       COUNT(DISTINCT ur.repo_id)::int   AS repos,
+		       (ucs.user_id IS NOT NULL)         AS starred
 		FROM aveloxis_ops.collections c
 		LEFT JOIN aveloxis_ops.collection_groups cg USING (collection_id)
 		LEFT JOIN aveloxis_ops.user_repos ur ON ur.group_id = cg.group_id
-		GROUP BY c.collection_id
-		ORDER BY c.position, c.name`)
+		LEFT JOIN aveloxis_ops.user_collection_stars ucs
+		    ON ucs.collection_id = c.collection_id AND ucs.user_id = $1
+		GROUP BY c.collection_id, ucs.user_id
+		ORDER BY (ucs.user_id IS NOT NULL) DESC, c.position, c.name`, userID)
 	if err != nil {
 		return nil, fmt.Errorf("ListCollections: %w", err)
 	}
@@ -168,12 +184,40 @@ func (s *PostgresStore) ListCollections(ctx context.Context) ([]CollectionSummar
 	for rows.Next() {
 		var cs CollectionSummary
 		if err := rows.Scan(&cs.CollectionID, &cs.Name, &cs.Description, &cs.Position, &cs.CreatedAt,
-			&cs.GroupCount, &cs.RepoCount); err != nil {
+			&cs.GroupCount, &cs.RepoCount, &cs.Starred); err != nil {
 			return nil, fmt.Errorf("ListCollections scan: %w", err)
 		}
 		out = append(out, cs)
 	}
 	return out, rows.Err()
+}
+
+// StarCollection / UnstarCollection (v0.27.70) — the per-user sort
+// preference. Both idempotent.
+func (s *PostgresStore) StarCollection(ctx context.Context, userID int, collectionID int64) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO aveloxis_ops.user_collection_stars (user_id, collection_id)
+		VALUES ($1, $2) ON CONFLICT DO NOTHING`, userID, collectionID)
+	if err != nil {
+		// The collection FK is DEFERRABLE, so a nonexistent target
+		// surfaces as 23503 at the statement's implicit commit.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ErrCollectionNotFound
+		}
+		return fmt.Errorf("StarCollection: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) UnstarCollection(ctx context.Context, userID int, collectionID int64) error {
+	_, err := s.pool.Exec(ctx, `
+		DELETE FROM aveloxis_ops.user_collection_stars
+		WHERE user_id = $1 AND collection_id = $2`, userID, collectionID)
+	if err != nil {
+		return fmt.Errorf("UnstarCollection: %w", err)
+	}
+	return nil
 }
 
 // GetCollectionGroups returns the member groups of a collection in

--- a/internal/db/collections_store.go
+++ b/internal/db/collections_store.go
@@ -247,7 +247,13 @@ func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int
 	}
 	defer rows.Close()
 
-	out := make([]CollectionRepo, 0, pageSize)
+	// CONSTANT capacity hint (CodeQL go/uncontrolled-allocation-size,
+	// round 2): pageSize is clamped above, but the scanner doesn't
+	// credit clamp-and-continue reassignments as barriers. Capacity
+	// is only a pre-allocation hint — append grows past it on a
+	// 100-row page — so a constant severs the taint path outright.
+	// Do NOT change this back to `pageSize`.
+	out := make([]CollectionRepo, 0, 50)
 	for rows.Next() {
 		var cr CollectionRepo
 		if err := rows.Scan(&cr.RepoID, &cr.Owner, &cr.Name, &cr.GitURL); err != nil {

--- a/internal/db/collections_store.go
+++ b/internal/db/collections_store.go
@@ -211,8 +211,18 @@ func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int
 	if page < 1 {
 		page = 1
 	}
-	if pageSize < 1 || pageSize > 100 {
+	// Two single-comparison clamps rather than one compound
+	// condition (CodeQL go/uncontrolled-allocation-size,
+	// 2026-07-31): semantically identical, but the bare
+	// `pageSize > 100` guard is the barrier shape the scanner's
+	// upper-bound analysis recognizes — the OR-combined
+	// reassignment was flagged as an uncontrolled allocation size
+	// even though it bounded the value.
+	if pageSize < 1 {
 		pageSize = 50
+	}
+	if pageSize > 100 {
+		pageSize = 100
 	}
 
 	var total int

--- a/internal/db/collections_store.go
+++ b/internal/db/collections_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -69,6 +70,40 @@ type CollectionRepo struct {
 	Owner  string `json:"owner"`
 	Name   string `json:"name"`
 	GitURL string `json:"git_url"`
+	// v0.27.74 — the collection detail table's data columns. Counts
+	// come from collection_queue's CACHED cumulative totals
+	// (v0.19.11/v0.21.2 — the same values the monitor renders), never
+	// per-request aggregation (the v0.27.4 nginx-timeout class).
+	// LastActivity is the FORGE's own last_updated from the latest
+	// repo_info snapshot — the deliberate cost/benefit balance: a real
+	// per-table MAX(created_at) sweep would scan issues/commits for
+	// every page render.
+	Issues        int64      `json:"issues"`
+	PRs           int64      `json:"prs"`
+	Commits       int64      `json:"commits"`
+	LastCollected *time.Time `json:"last_collected,omitempty"`
+	LastActivity  *time.Time `json:"last_activity,omitempty"`
+	Starred       bool       `json:"starred"`
+}
+
+// CollectionRepoSortValid reports whether key is an allowlisted sort
+// for GetCollectionRepos (the API echoes the effective sort).
+func CollectionRepoSortValid(key string) bool {
+	_, ok := collectionRepoSorts[key]
+	return ok
+}
+
+// collectionRepoSorts is the ALLOWLIST of sortable columns for
+// GetCollectionRepos — the sort expression is interpolated into the
+// ORDER BY, so it must never carry caller-controlled text. Numeric and
+// date sorts sink NULL/never-collected rows with NULLS LAST.
+var collectionRepoSorts = map[string]string{
+	"name":      "r.repo_owner %s, r.repo_name %s",
+	"issues":    "COALESCE(q.last_issues, 0) %s",
+	"prs":       "COALESCE(q.last_prs, 0) %s",
+	"commits":   "COALESCE(q.last_commits, 0) %s",
+	"collected": "q.last_collected %s NULLS LAST",
+	"activity":  "ri.last_updated %s NULLS LAST",
 }
 
 // CreateCollection inserts a new collection. Name is UNIQUE — a
@@ -251,7 +286,7 @@ func (s *PostgresStore) GetCollectionGroups(ctx context.Context, collectionID in
 // repo set (a repo in two member groups appears once), ordered by
 // owner/name with repo_id as the stable tiebreaker (the v0.18.7
 // pagination lesson), plus the total deduped count.
-func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int64, page, pageSize int) ([]CollectionRepo, int, error) {
+func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int64, userID, page, pageSize int, sortKey, sortDir string) ([]CollectionRepo, int, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -278,14 +313,42 @@ func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int
 		return nil, 0, fmt.Errorf("GetCollectionRepos count: %w", err)
 	}
 
+	// v0.27.74 — server-side sort (pagination makes client-side sort
+	// meaningless: it would only reorder the current page). Both the
+	// key and direction resolve through fixed allowlists BEFORE any
+	// interpolation; unknown values fall back to the default.
+	sortExpr, ok := collectionRepoSorts[sortKey]
+	if !ok {
+		sortExpr = collectionRepoSorts["name"]
+	}
+	dir := "ASC"
+	if sortDir == "desc" {
+		dir = "DESC"
+	}
+	orderBy := strings.ReplaceAll(sortExpr, "%s", dir) + ", r.repo_id"
+
 	rows, err := s.pool.Query(ctx, `
-		SELECT DISTINCT r.repo_id, r.repo_owner, r.repo_name, r.repo_git
-		FROM aveloxis_ops.collection_groups cg
-		JOIN aveloxis_ops.user_repos ur USING (group_id)
-		JOIN aveloxis_data.repos r ON r.repo_id = ur.repo_id
-		WHERE cg.collection_id = $1
-		ORDER BY r.repo_owner, r.repo_name, r.repo_id
-		LIMIT $2 OFFSET $3`, collectionID, pageSize, (page-1)*pageSize)
+		SELECT r.repo_id, r.repo_owner, r.repo_name, r.repo_git,
+		       COALESCE(q.last_issues, 0), COALESCE(q.last_prs, 0), COALESCE(q.last_commits, 0),
+		       q.last_collected, ri.last_updated,
+		       (ucs.user_id IS NOT NULL) AS starred
+		FROM (
+			SELECT DISTINCT ur.repo_id
+			FROM aveloxis_ops.collection_groups cg
+			JOIN aveloxis_ops.user_repos ur USING (group_id)
+			WHERE cg.collection_id = $1
+		) member
+		JOIN aveloxis_data.repos r ON r.repo_id = member.repo_id
+		LEFT JOIN aveloxis_ops.collection_queue q ON q.repo_id = r.repo_id
+		LEFT JOIN LATERAL (
+			SELECT last_updated FROM aveloxis_data.repo_info
+			WHERE repo_id = r.repo_id
+			ORDER BY data_collection_date DESC LIMIT 1
+		) ri ON TRUE
+		LEFT JOIN aveloxis_ops.user_repo_stars ucs
+			ON ucs.repo_id = r.repo_id AND ucs.user_id = $2
+		ORDER BY `+orderBy+`
+		LIMIT $3 OFFSET $4`, collectionID, userID, pageSize, (page-1)*pageSize)
 	if err != nil {
 		return nil, 0, fmt.Errorf("GetCollectionRepos: %w", err)
 	}
@@ -300,7 +363,8 @@ func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int
 	out := make([]CollectionRepo, 0, 50)
 	for rows.Next() {
 		var cr CollectionRepo
-		if err := rows.Scan(&cr.RepoID, &cr.Owner, &cr.Name, &cr.GitURL); err != nil {
+		if err := rows.Scan(&cr.RepoID, &cr.Owner, &cr.Name, &cr.GitURL,
+			&cr.Issues, &cr.PRs, &cr.Commits, &cr.LastCollected, &cr.LastActivity, &cr.Starred); err != nil {
 			return nil, 0, fmt.Errorf("GetCollectionRepos scan: %w", err)
 		}
 		out = append(out, cr)

--- a/internal/db/collections_store.go
+++ b/internal/db/collections_store.go
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Collections (v0.27.63) are admin-curated groups-of-groups for the
+// GUI home page: "Apache Graduated", "CNCF Sandbox", … Each collection
+// joins to LIVE user_groups through collection_groups — never a frozen
+// repo list — so admin org-groups that auto-grow via org scans keep
+// their collections fresh for free.
+//
+// Two invariants enforced here:
+//   - Only ADMIN-owned groups may join a collection (link-time check):
+//     collections are fleet-curation surface, and linking an arbitrary
+//     user's group would let that user mutate what everyone sees.
+//   - Copying a collection into a user's group NEVER enqueues
+//     collection and never creates add-requests (v0.27.20 interplay):
+//     collection repos are already tracked, so the copy is a pure
+//     user_repos INSERT…SELECT — approval only ever gates NEW
+//     collection. Pinned by a comment-stripped negative test.
+
+// ErrGroupNotAdminOwned is returned by AddGroupToCollection when the
+// candidate member group is not owned by an admin user.
+var ErrGroupNotAdminOwned = errors.New("collection member groups must be admin-owned")
+
+// ErrNotGroupOwner is returned by CopyCollectionToGroup when the
+// target group does not belong to the calling user.
+var ErrNotGroupOwner = errors.New("target group is not owned by the calling user")
+
+// CollectionSummary is one row in the collections list: the
+// collection plus its live group/repo cardinality.
+type CollectionSummary struct {
+	CollectionID int64     `json:"collection_id"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description"`
+	Position     int       `json:"position"`
+	GroupCount   int       `json:"groups"`
+	RepoCount    int       `json:"repos"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// CollectionGroup is one member group in a collection detail view.
+type CollectionGroup struct {
+	GroupID   int64  `json:"group_id"`
+	Name      string `json:"name"`
+	RepoCount int    `json:"repos"`
+}
+
+// CollectionRepo is one deduped repo row in a collection detail view.
+type CollectionRepo struct {
+	RepoID int64  `json:"repo_id"`
+	Owner  string `json:"owner"`
+	Name   string `json:"name"`
+	GitURL string `json:"git_url"`
+}
+
+// CreateCollection inserts a new collection. Name is UNIQUE — a
+// duplicate surfaces as the constraint error for the handler to map.
+func (s *PostgresStore) CreateCollection(ctx context.Context, name, description string, position int, createdBy int) (int64, error) {
+	var id int64
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.collections (name, description, position, created_by)
+		VALUES ($1, $2, $3, $4) RETURNING collection_id`,
+		name, description, position, createdBy).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("CreateCollection: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateCollection updates name/description/position in place.
+func (s *PostgresStore) UpdateCollection(ctx context.Context, collectionID int64, name, description string, position int) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_ops.collections
+		SET name = $2, description = $3, position = $4
+		WHERE collection_id = $1`, collectionID, name, description, position)
+	if err != nil {
+		return fmt.Errorf("UpdateCollection: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("UpdateCollection: collection %d not found", collectionID)
+	}
+	return nil
+}
+
+// DeleteCollection removes the collection; collection_groups rows
+// cascade (ON DELETE CASCADE). Member user_groups are untouched.
+func (s *PostgresStore) DeleteCollection(ctx context.Context, collectionID int64) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collections WHERE collection_id = $1`, collectionID)
+	if err != nil {
+		return fmt.Errorf("DeleteCollection: %w", err)
+	}
+	return nil
+}
+
+// AddGroupToCollection links an ADMIN-OWNED group into the
+// collection. The owner check happens in the same statement as the
+// insert (INSERT…SELECT gated on u.admin) so there is no
+// check-then-act race; zero rows inserted with a non-admin owner
+// surfaces ErrGroupNotAdminOwned.
+func (s *PostgresStore) AddGroupToCollection(ctx context.Context, collectionID, groupID int64) error {
+	tag, err := s.pool.Exec(ctx, `
+		INSERT INTO aveloxis_ops.collection_groups (collection_id, group_id)
+		SELECT $1, g.group_id
+		FROM aveloxis_ops.user_groups g
+		JOIN aveloxis_ops.users u ON u.user_id = g.user_id
+		WHERE g.group_id = $2 AND u.admin
+		ON CONFLICT DO NOTHING`, collectionID, groupID)
+	if err != nil {
+		return fmt.Errorf("AddGroupToCollection: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Either the group isn't admin-owned or the link already
+		// exists. Disambiguate for a useful error.
+		var isAdminOwned bool
+		if err := s.pool.QueryRow(ctx, `
+			SELECT COALESCE(u.admin, FALSE)
+			FROM aveloxis_ops.user_groups g
+			JOIN aveloxis_ops.users u ON u.user_id = g.user_id
+			WHERE g.group_id = $1`, groupID).Scan(&isAdminOwned); err != nil {
+			return fmt.Errorf("AddGroupToCollection: group %d not found", groupID)
+		}
+		if !isAdminOwned {
+			return ErrGroupNotAdminOwned
+		}
+		// Already linked — idempotent success.
+	}
+	return nil
+}
+
+// RemoveGroupFromCollection unlinks a member group. The group itself
+// (and its repos) are untouched.
+func (s *PostgresStore) RemoveGroupFromCollection(ctx context.Context, collectionID, groupID int64) error {
+	_, err := s.pool.Exec(ctx, `
+		DELETE FROM aveloxis_ops.collection_groups
+		WHERE collection_id = $1 AND group_id = $2`, collectionID, groupID)
+	if err != nil {
+		return fmt.Errorf("RemoveGroupFromCollection: %w", err)
+	}
+	return nil
+}
+
+// ListCollections returns every collection ordered by position (then
+// name), each with its live group count and DEDUPED repo count.
+func (s *PostgresStore) ListCollections(ctx context.Context) ([]CollectionSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT c.collection_id, c.name, c.description, c.position, c.created_at,
+		       COUNT(DISTINCT cg.group_id)::int  AS groups,
+		       COUNT(DISTINCT ur.repo_id)::int   AS repos
+		FROM aveloxis_ops.collections c
+		LEFT JOIN aveloxis_ops.collection_groups cg USING (collection_id)
+		LEFT JOIN aveloxis_ops.user_repos ur ON ur.group_id = cg.group_id
+		GROUP BY c.collection_id
+		ORDER BY c.position, c.name`)
+	if err != nil {
+		return nil, fmt.Errorf("ListCollections: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]CollectionSummary, 0, 16)
+	for rows.Next() {
+		var cs CollectionSummary
+		if err := rows.Scan(&cs.CollectionID, &cs.Name, &cs.Description, &cs.Position, &cs.CreatedAt,
+			&cs.GroupCount, &cs.RepoCount); err != nil {
+			return nil, fmt.Errorf("ListCollections scan: %w", err)
+		}
+		out = append(out, cs)
+	}
+	return out, rows.Err()
+}
+
+// GetCollectionGroups returns the member groups of a collection in
+// link position order, each with its live repo count.
+func (s *PostgresStore) GetCollectionGroups(ctx context.Context, collectionID int64) ([]CollectionGroup, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT g.group_id, g.name, COUNT(ur.repo_id)::int AS repos
+		FROM aveloxis_ops.collection_groups cg
+		JOIN aveloxis_ops.user_groups g USING (group_id)
+		LEFT JOIN aveloxis_ops.user_repos ur ON ur.group_id = g.group_id
+		WHERE cg.collection_id = $1
+		GROUP BY g.group_id, g.name, cg.position
+		ORDER BY cg.position, g.name`, collectionID)
+	if err != nil {
+		return nil, fmt.Errorf("GetCollectionGroups: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]CollectionGroup, 0, 8)
+	for rows.Next() {
+		var g CollectionGroup
+		if err := rows.Scan(&g.GroupID, &g.Name, &g.RepoCount); err != nil {
+			return nil, fmt.Errorf("GetCollectionGroups scan: %w", err)
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+// GetCollectionRepos returns one page of the collection's DEDUPED
+// repo set (a repo in two member groups appears once), ordered by
+// owner/name with repo_id as the stable tiebreaker (the v0.18.7
+// pagination lesson), plus the total deduped count.
+func (s *PostgresStore) GetCollectionRepos(ctx context.Context, collectionID int64, page, pageSize int) ([]CollectionRepo, int, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 50
+	}
+
+	var total int
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT ur.repo_id)
+		FROM aveloxis_ops.collection_groups cg
+		JOIN aveloxis_ops.user_repos ur USING (group_id)
+		WHERE cg.collection_id = $1`, collectionID).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("GetCollectionRepos count: %w", err)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT r.repo_id, r.repo_owner, r.repo_name, r.repo_git
+		FROM aveloxis_ops.collection_groups cg
+		JOIN aveloxis_ops.user_repos ur USING (group_id)
+		JOIN aveloxis_data.repos r ON r.repo_id = ur.repo_id
+		WHERE cg.collection_id = $1
+		ORDER BY r.repo_owner, r.repo_name, r.repo_id
+		LIMIT $2 OFFSET $3`, collectionID, pageSize, (page-1)*pageSize)
+	if err != nil {
+		return nil, 0, fmt.Errorf("GetCollectionRepos: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]CollectionRepo, 0, pageSize)
+	for rows.Next() {
+		var cr CollectionRepo
+		if err := rows.Scan(&cr.RepoID, &cr.Owner, &cr.Name, &cr.GitURL); err != nil {
+			return nil, 0, fmt.Errorf("GetCollectionRepos scan: %w", err)
+		}
+		out = append(out, cr)
+	}
+	return out, total, rows.Err()
+}
+
+// CopyCollectionToGroup links every repo of the collection into
+// targetGroupID, which must be owned by userID. Returns the number of
+// NEW links (repos already in the group no-op via the user_repos PK).
+//
+// Deliberately a pure user_repos INSERT…SELECT: collection repos are
+// already tracked, so no queue rows and no add-requests are created —
+// approval gates NEW collection, never access to collected data
+// (v0.27.20 / v0.27.4 scope semantics).
+func (s *PostgresStore) CopyCollectionToGroup(ctx context.Context, collectionID int64, userID int, targetGroupID int64) (int64, error) {
+	if err := s.verifyGroupOwned(ctx, userID, targetGroupID); err != nil {
+		return 0, ErrNotGroupOwner
+	}
+	tag, err := s.pool.Exec(ctx, `
+		INSERT INTO aveloxis_ops.user_repos (group_id, repo_id)
+		SELECT DISTINCT $2::bigint, ur.repo_id
+		FROM aveloxis_ops.collection_groups cg
+		JOIN aveloxis_ops.user_repos ur USING (group_id)
+		WHERE cg.collection_id = $1
+		ON CONFLICT DO NOTHING`, collectionID, targetGroupID)
+	if err != nil {
+		return 0, fmt.Errorf("CopyCollectionToGroup: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/db/collections_store_test.go
+++ b/internal/db/collections_store_test.go
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// v0.27.63 — collections: admin-curated groups-of-groups. Source pins
+// on the three load-bearing decisions (groups-join model, admin-owned
+// link rule, copy-never-enqueues), then an integration test covering
+// the full lifecycle.
+
+func collectionsSQL(t *testing.T) string {
+	t.Helper()
+	return readSourceFile(t, "collections_store.go")
+}
+
+// Collections join to LIVE user_groups (not frozen repo lists):
+// admin org-groups auto-grow via org scans, so collections stay
+// fresh for free. A future refactor that snapshots repo ids into the
+// collection defeats the design.
+func TestCollectionsAreGroupJoins(t *testing.T) {
+	src := collectionsSQL(t)
+	if !strings.Contains(src, "aveloxis_ops.collection_groups") {
+		t.Error("collections must join through collection_groups to live user_groups")
+	}
+	if !strings.Contains(src, "aveloxis_ops.user_repos") {
+		t.Error("collection repos must resolve through user_repos at read time (live membership)")
+	}
+}
+
+// Link-time rule: only ADMIN-owned groups may join a collection.
+// Collections are a fleet-curation surface; linking an arbitrary
+// user's group would let its owner mutate what every user sees.
+func TestAddGroupToCollectionRequiresAdminOwner(t *testing.T) {
+	src := collectionsSQL(t)
+	if !strings.Contains(src, "u.admin") {
+		t.Error("AddGroupToCollection must verify the member group is admin-owned (users.admin)")
+	}
+}
+
+// THE copy invariant (v0.27.20 approval interplay): collections
+// contain only already-tracked repos, so copying into a user's group
+// is a direct user_repos INSERT…SELECT — it must NEVER touch the
+// collection queue or the add-request tables. Comment-stripped scan
+// so prose mentioning the words can't false-match.
+func TestCopyCollectionNeverEnqueues(t *testing.T) {
+	src := collectionsSQL(t)
+	var code []string
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		code = append(code, line)
+	}
+	joined := strings.Join(code, "\n")
+	for _, banned := range []string{"EnqueueRepo", "collection_queue", "collection_add_requests", "AddReposToGroup("} {
+		if strings.Contains(joined, banned) {
+			t.Errorf("collections_store.go must not reference %q — copy is a pure user_repos INSERT…SELECT (v0.27.20: approval gates NEW collection; collection repos are already tracked)", banned)
+		}
+	}
+	if !strings.Contains(joined, "ON CONFLICT DO NOTHING") {
+		t.Error("CopyCollectionToGroup must be idempotent (ON CONFLICT DO NOTHING on the user_repos PK)")
+	}
+}
+
+// ─── Integration (AVELOXIS_TEST_DB) ─────────────────────────────
+
+func TestCollectionsEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	clean := func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collections WHERE name LIKE '_avcoll%'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_repos WHERE group_id IN (SELECT group_id FROM aveloxis_ops.user_groups WHERE name LIKE '_avcoll%')`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_groups WHERE name LIKE '_avcoll%'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcoll'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.users WHERE login_name LIKE '_avcoll%'`)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	var adminID, plainID int
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ('_avcoll_admin', TRUE) RETURNING user_id`).Scan(&adminID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ('_avcoll_plain', FALSE) RETURNING user_id`).Scan(&plainID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two admin groups sharing one repo (dedup check) + a plain-user group.
+	mkGroup := func(userID int, name string) int64 {
+		var gid int64
+		if err := store.pool.QueryRow(ctx, `
+			INSERT INTO aveloxis_ops.user_groups (user_id, name) VALUES ($1, $2) RETURNING group_id`, userID, name).Scan(&gid); err != nil {
+			t.Fatal(err)
+		}
+		return gid
+	}
+	g1 := mkGroup(adminID, "_avcoll_g1")
+	g2 := mkGroup(adminID, "_avcoll_g2")
+	plainGroup := mkGroup(plainID, "_avcoll_target")
+	nonAdminGroup := mkGroup(plainID, "_avcoll_notadmin")
+
+	mkRepo := func(name string) int64 {
+		var rid int64
+		if err := store.pool.QueryRow(ctx, `
+			INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id)
+			VALUES ($1, '_avcoll', $2, 1) RETURNING repo_id`, "https://github.com/_avcoll/"+name, name).Scan(&rid); err != nil {
+			t.Fatal(err)
+		}
+		return rid
+	}
+	r1, r2, r3 := mkRepo("one"), mkRepo("two"), mkRepo("three")
+	link := func(gid, rid int64) {
+		if _, err := store.pool.Exec(ctx, `INSERT INTO aveloxis_ops.user_repos (group_id, repo_id) VALUES ($1, $2)`, gid, rid); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link(g1, r1)
+	link(g1, r2)
+	link(g2, r2) // shared with g1 — dedup proof
+	link(g2, r3)
+
+	// Create + link.
+	collID, err := store.CreateCollection(ctx, "_avcoll_main", "the test collection", 1, adminID)
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if err := store.AddGroupToCollection(ctx, collID, g1); err != nil {
+		t.Fatalf("AddGroupToCollection g1: %v", err)
+	}
+	if err := store.AddGroupToCollection(ctx, collID, g2); err != nil {
+		t.Fatalf("AddGroupToCollection g2: %v", err)
+	}
+	// Non-admin-owned group must be refused.
+	if err := store.AddGroupToCollection(ctx, collID, nonAdminGroup); err == nil {
+		t.Error("AddGroupToCollection must refuse a group owned by a non-admin")
+	}
+
+	// List: our collection shows 2 groups / 3 distinct repos.
+	sums, err := store.ListCollections(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, c := range sums {
+		if c.Name == "_avcoll_main" {
+			found = true
+			if c.GroupCount != 2 {
+				t.Errorf("group count = %d, want 2", c.GroupCount)
+			}
+			if c.RepoCount != 3 {
+				t.Errorf("repo count = %d, want 3 (deduped across groups)", c.RepoCount)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("collection not listed: %+v", sums)
+	}
+
+	// Detail repos: deduped, 3 rows.
+	repos, total, err := store.GetCollectionRepos(ctx, collID, 1, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(repos) != 3 {
+		t.Errorf("detail repos = %d rows / total %d, want 3/3", len(repos), total)
+	}
+
+	// Copy into the plain user's group: 3 links, no enqueue.
+	added, err := store.CopyCollectionToGroup(ctx, collID, plainID, plainGroup)
+	if err != nil {
+		t.Fatalf("CopyCollectionToGroup: %v", err)
+	}
+	if added != 3 {
+		t.Errorf("copy added = %d, want 3", added)
+	}
+	// Idempotent: second copy adds zero.
+	added, err = store.CopyCollectionToGroup(ctx, collID, plainID, plainGroup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added != 0 {
+		t.Errorf("second copy added = %d, want 0", added)
+	}
+	// Ownership: copying into someone ELSE's group must fail.
+	if _, err := store.CopyCollectionToGroup(ctx, collID, plainID, g1); err == nil {
+		t.Error("CopyCollectionToGroup must refuse a target group the caller does not own")
+	}
+	// The copy created ZERO queue rows for these repos.
+	var queued int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_ops.collection_queue WHERE repo_id IN ($1, $2, $3)`, r1, r2, r3).Scan(&queued); err != nil {
+		t.Fatal(err)
+	}
+	if queued != 0 {
+		t.Errorf("copy must never enqueue collection — found %d queue rows", queued)
+	}
+
+	// Remove a group: repo count shrinks to g2's set (r2, r3).
+	if err := store.RemoveGroupFromCollection(ctx, collID, g1); err != nil {
+		t.Fatal(err)
+	}
+	_, total, err = store.GetCollectionRepos(ctx, collID, 1, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Errorf("after removing g1, total = %d, want 2", total)
+	}
+
+	// Delete: join rows cascade.
+	if err := store.DeleteCollection(ctx, collID); err != nil {
+		t.Fatal(err)
+	}
+	var joins int
+	if err := store.pool.QueryRow(ctx, `SELECT COUNT(*) FROM aveloxis_ops.collection_groups WHERE collection_id = $1`, collID).Scan(&joins); err != nil {
+		t.Fatal(err)
+	}
+	if joins != 0 {
+		t.Errorf("collection_groups rows must cascade on delete, %d remain", joins)
+	}
+}

--- a/internal/db/collections_store_test.go
+++ b/internal/db/collections_store_test.go
@@ -48,6 +48,12 @@ func TestAddGroupToCollectionRequiresAdminOwner(t *testing.T) {
 // is a direct user_repos INSERT…SELECT — it must NEVER touch the
 // collection queue or the add-request tables. Comment-stripped scan
 // so prose mentioning the words can't false-match.
+//
+// 2026-08-02 scope correction: v0.27.74's GetCollectionRepos
+// legitimately READS collection_queue (the cached count columns), so
+// the bare "collection_queue" ban moved from file-wide to the
+// CopyCollectionToGroup body. Queue WRITES stay banned file-wide —
+// the invariant was always about mutation, not reads.
 func TestCopyCollectionNeverEnqueues(t *testing.T) {
 	src := collectionsSQL(t)
 	var code []string
@@ -62,12 +68,32 @@ func TestCopyCollectionNeverEnqueues(t *testing.T) {
 		code = append(code, line)
 	}
 	joined := strings.Join(code, "\n")
-	for _, banned := range []string{"EnqueueRepo", "collection_queue", "collection_add_requests", "AddReposToGroup("} {
+	// File-wide: no enqueue helpers, no add-request tables, no queue
+	// WRITES of any shape.
+	for _, banned := range []string{
+		"EnqueueRepo", "collection_add_requests", "AddReposToGroup(",
+		"INSERT INTO aveloxis_ops.collection_queue",
+		"UPDATE aveloxis_ops.collection_queue",
+		"DELETE FROM aveloxis_ops.collection_queue",
+	} {
 		if strings.Contains(joined, banned) {
 			t.Errorf("collections_store.go must not reference %q — copy is a pure user_repos INSERT…SELECT (v0.27.20: approval gates NEW collection; collection repos are already tracked)", banned)
 		}
 	}
-	if !strings.Contains(joined, "ON CONFLICT DO NOTHING") {
+	// Copy-path-scoped: the copy function itself may not touch the
+	// queue AT ALL, reads included.
+	start := strings.Index(joined, "func (s *PostgresStore) CopyCollectionToGroup")
+	if start < 0 {
+		t.Fatal("CopyCollectionToGroup not found in collections_store.go")
+	}
+	body := joined[start:]
+	if end := strings.Index(body[1:], "\nfunc "); end >= 0 {
+		body = body[:end+1]
+	}
+	if strings.Contains(body, "collection_queue") {
+		t.Error("CopyCollectionToGroup must not reference collection_queue in any form")
+	}
+	if !strings.Contains(body, "ON CONFLICT DO NOTHING") {
 		t.Error("CopyCollectionToGroup must be idempotent (ON CONFLICT DO NOTHING on the user_repos PK)")
 	}
 }
@@ -82,6 +108,14 @@ func TestCollectionsEndToEnd(t *testing.T) {
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collections WHERE name LIKE '_avcoll%'`)
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_repos WHERE group_id IN (SELECT group_id FROM aveloxis_ops.user_groups WHERE name LIKE '_avcoll%')`)
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_groups WHERE name LIKE '_avcoll%'`)
+		// Child rows FIRST (2026-08-02): user_repo_stars.repo_id and
+		// collection_queue.repo_id have no ON DELETE action, so a
+		// leftover child row silently kills the repos delete (errors
+		// here are discarded by design) and the stranded '_avcoll'
+		// repos collide with mkRepo on every subsequent run — the
+		// chicken-and-egg residue loop this pre-clean exists to break.
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_repo_stars WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avcoll')`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avcoll')`)
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcoll'`)
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.users WHERE login_name LIKE '_avcoll%'`)
 	}

--- a/internal/db/collections_store_test.go
+++ b/internal/db/collections_store_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -147,8 +148,9 @@ func TestCollectionsEndToEnd(t *testing.T) {
 		t.Error("AddGroupToCollection must refuse a group owned by a non-admin")
 	}
 
-	// List: our collection shows 2 groups / 3 distinct repos.
-	sums, err := store.ListCollections(ctx)
+	// List: our collection shows 2 groups / 3 distinct repos, and is
+	// unstarred for a caller who never starred it.
+	sums, err := store.ListCollections(ctx, plainID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,10 +164,74 @@ func TestCollectionsEndToEnd(t *testing.T) {
 			if c.RepoCount != 3 {
 				t.Errorf("repo count = %d, want 3 (deduped across groups)", c.RepoCount)
 			}
+			if c.Starred {
+				t.Error("collection must not be starred before StarCollection")
+			}
 		}
 	}
 	if !found {
 		t.Fatalf("collection not listed: %+v", sums)
+	}
+
+	// ─── v0.27.70: per-user stars ───────────────────────────────
+	// A second collection at a LATER position; starring it as plainID
+	// must sort it ahead of _avcoll_main for plainID ONLY.
+	coll2, err := store.CreateCollection(ctx, "_avcoll_second", "starred later", 9, adminID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StarCollection(ctx, plainID, coll2); err != nil {
+		t.Fatalf("StarCollection: %v", err)
+	}
+	// Idempotent re-star.
+	if err := store.StarCollection(ctx, plainID, coll2); err != nil {
+		t.Fatalf("second StarCollection: %v", err)
+	}
+	orderOf := func(userID int) (secondIdx, mainIdx int, secondStarred bool) {
+		secondIdx, mainIdx = -1, -1
+		list, lerr := store.ListCollections(ctx, userID)
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		for i, c := range list {
+			switch c.Name {
+			case "_avcoll_second":
+				secondIdx, secondStarred = i, c.Starred
+			case "_avcoll_main":
+				mainIdx = i
+			}
+		}
+		return secondIdx, mainIdx, secondStarred
+	}
+	secondIdx, mainIdx, secondStarred := orderOf(plainID)
+	if !secondStarred {
+		t.Error("starred collection must report starred=true for the starrer")
+	}
+	if secondIdx == -1 || mainIdx == -1 || secondIdx > mainIdx {
+		t.Errorf("starred collection must sort first for the starrer (second at %d, main at %d)", secondIdx, mainIdx)
+	}
+	// The star is PER-USER: the admin still sees position order.
+	secondIdx, mainIdx, secondStarred = orderOf(adminID)
+	if secondStarred {
+		t.Error("another user's star must not leak into the admin's listing")
+	}
+	if secondIdx == -1 || mainIdx == -1 || secondIdx < mainIdx {
+		t.Errorf("non-starrer must keep position order (second at %d, main at %d)", secondIdx, mainIdx)
+	}
+	// Unstar reverts the starrer's ordering.
+	if err := store.UnstarCollection(ctx, plainID, coll2); err != nil {
+		t.Fatalf("UnstarCollection: %v", err)
+	}
+	secondIdx, mainIdx, secondStarred = orderOf(plainID)
+	if secondStarred || secondIdx < mainIdx {
+		t.Errorf("after unstar, position order must return (second at %d starred=%v, main at %d)", secondIdx, secondStarred, mainIdx)
+	}
+	// Starring a nonexistent collection surfaces the typed sentinel.
+	if err := store.StarCollection(ctx, plainID, coll2+999999); !errors.Is(err, ErrCollectionNotFound) {
+		t.Errorf("starring a nonexistent collection: got %v, want ErrCollectionNotFound", err)
+	}
+	if err := store.DeleteCollection(ctx, coll2); err != nil {
+		t.Fatal(err)
 	}
 
 	// Detail repos: deduped, 3 rows.

--- a/internal/db/collections_store_test.go
+++ b/internal/db/collections_store_test.go
@@ -234,8 +234,8 @@ func TestCollectionsEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Detail repos: deduped, 3 rows.
-	repos, total, err := store.GetCollectionRepos(ctx, collID, 1, 50)
+	// Detail repos: deduped, 3 rows (default name-asc sort).
+	repos, total, err := store.GetCollectionRepos(ctx, collID, plainID, 1, 50, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,11 +273,55 @@ func TestCollectionsEndToEnd(t *testing.T) {
 		t.Errorf("copy must never enqueue collection — found %d queue rows", queued)
 	}
 
+	// ─── v0.27.74: counts + sort + starred on the detail rows ───
+	// (AFTER the zero-queue-rows assertion above — this block seeds
+	// queue rows deliberately, which would false-fail that check.)
+	for _, seed := range []struct {
+		rid                  int64
+		issues, prs, commits int64
+	}{{r1, 10, 5, 100}, {r2, 30, 2, 50}, {r3, 20, 9, 75}} {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_ops.collection_queue (repo_id, status, last_issues, last_prs, last_commits, last_collected)
+			VALUES ($1, 'queued', $2, $3, $4, NOW())
+			ON CONFLICT (repo_id) DO UPDATE SET last_issues = $2, last_prs = $3, last_commits = $4, last_collected = NOW()`,
+			seed.rid, seed.issues, seed.prs, seed.commits); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN ($1,$2,$3)`, r1, r2, r3)
+	})
+	if err := store.StarRepo(ctx, plainID, r3); err != nil {
+		t.Fatal(err)
+	}
+	sorted, _, err := store.GetCollectionRepos(ctx, collID, plainID, 1, 50, "issues", "desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 3 || sorted[0].RepoID != r2 || sorted[0].Issues != 30 {
+		t.Errorf("issues-desc sort: first row = %+v, want repo %d with 30 issues", sorted[0], r2)
+	}
+	if sorted[0].LastCollected == nil {
+		t.Error("last_collected must surface from the queue row")
+	}
+	for _, row := range sorted {
+		if row.RepoID == r3 && !row.Starred {
+			t.Error("r3 must carry the caller's starred flag")
+		}
+		if row.RepoID == r1 && row.Starred {
+			t.Error("unstarred repo must not be starred")
+		}
+	}
+	// An unknown sort key falls back safely (no SQL error, default order).
+	if _, _, err := store.GetCollectionRepos(ctx, collID, plainID, 1, 50, "evil; DROP TABLE x", "desc"); err != nil {
+		t.Errorf("unknown sort key must fall back to the default, got error: %v", err)
+	}
+
 	// Remove a group: repo count shrinks to g2's set (r2, r3).
 	if err := store.RemoveGroupFromCollection(ctx, collID, g1); err != nil {
 		t.Fatal(err)
 	}
-	_, total, err = store.GetCollectionRepos(ctx, collID, 1, 50)
+	_, total, err = store.GetCollectionRepos(ctx, collID, plainID, 1, 50, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/collections_store_test.go
+++ b/internal/db/collections_store_test.go
@@ -102,7 +102,7 @@ func TestCopyCollectionNeverEnqueues(t *testing.T) {
 
 func TestCollectionsEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	clean := func() {
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collections WHERE name LIKE '_avcoll%'`)

--- a/internal/db/columnfill_diff_integration_test.go
+++ b/internal/db/columnfill_diff_integration_test.go
@@ -34,7 +34,7 @@ func TestColumnFillDiffSelfComparison(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	store.SetMatviewSkip(true)
 	if err := RunMigrations(ctx, store, logger); err != nil {
 		t.Fatalf("RunMigrations: %v", err)
@@ -44,7 +44,7 @@ func TestColumnFillDiffSelfComparison(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 
 	// One REPEATABLE READ transaction serves as BOTH sides: a single
 	// MVCC snapshot makes the self-comparison deterministic even while

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -20,6 +20,16 @@ type RepoContributor struct {
 	Email          string `json:"email"`
 	ProfileCompany string `json:"profile_company"`
 	Location       string `json:"location"`
+	// v0.27.57 activity classification (GitHub contributionsCollection;
+	// empty class = never checked or GitLab-side contributor — GitLab
+	// has no restricted-contributions equivalent). Class vocabulary in
+	// model.Activity*; the "no-observable-activity" class must be
+	// rendered honestly (truly-inactive is indistinguishable from
+	// private-with-disclosure-off by GitHub's design).
+	ActivityClass      string `json:"activity_class"`
+	PublicContribsYear int    `json:"public_contribs_year"`
+	RestrictedContribs int    `json:"restricted_contribs_year"`
+	LastContributionYr int    `json:"last_contribution_year"`
 }
 
 // AffiliationCount is a single row in the affiliation breakdown returned
@@ -147,7 +157,11 @@ SELECT
     COALESCE(NULLIF(c.cntrb_full_name, ''), '')                        AS full_name,
     COALESCE(NULLIF(c.cntrb_email, ''), '')                            AS email,
     COALESCE(NULLIF(c.cntrb_company, ''), '')                          AS profile_company,
-    COALESCE(NULLIF(c.cntrb_location, ''), '')                         AS location
+    COALESCE(NULLIF(c.cntrb_location, ''), '')                         AS location,
+    COALESCE(c.gh_activity_class, '')                                  AS activity_class,
+    COALESCE(c.gh_public_contribs_year, 0)                             AS public_contribs_year,
+    COALESCE(c.gh_restricted_contribs_year, 0)                         AS restricted_contribs_year,
+    COALESCE(c.gh_last_contribution_year, 0)                           AS last_contribution_year
 FROM contributors_in_window ciw
 JOIN aveloxis_data.contributors c USING (cntrb_id)
 WHERE COALESCE(c.cntrb_deleted, 0) = 0
@@ -162,7 +176,8 @@ ORDER BY login NULLS LAST, full_name NULLS LAST`
 	out := make([]RepoContributor, 0, 128)
 	for rows.Next() {
 		var rc RepoContributor
-		if err := rows.Scan(&rc.CntrbID, &rc.Login, &rc.FullName, &rc.Email, &rc.ProfileCompany, &rc.Location); err != nil {
+		if err := rows.Scan(&rc.CntrbID, &rc.Login, &rc.FullName, &rc.Email, &rc.ProfileCompany, &rc.Location,
+			&rc.ActivityClass, &rc.PublicContribsYear, &rc.RestrictedContribs, &rc.LastContributionYr); err != nil {
 			return nil, fmt.Errorf("GetRepoContributors scan: %w", err)
 		}
 		out = append(out, rc)

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -361,6 +361,14 @@ func (s *PostgresStore) TopContributors(ctx context.Context, repoID int64, since
 	if limit <= 0 {
 		limit = 20
 	}
+	// Hard upper backstop AT THE STORE LAYER (CodeQL
+	// go/uncontrolled-allocation-size, 2026-07-31): the API handler
+	// caps limit at 100 too, but the store is the shared surface —
+	// a future caller that forgets its own cap must not reach the
+	// slice allocation (or the SQL LIMIT) with an unbounded value.
+	if limit > 100 {
+		limit = 100
+	}
 
 	sql := `
 WITH per_kind AS (

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -434,7 +434,14 @@ LIMIT $4`
 	}
 	defer rows.Close()
 
-	out := make([]TopContributor, 0, limit)
+	// CONSTANT capacity hint (CodeQL go/uncontrolled-allocation-size,
+	// round 2): the clamp above bounds `limit`, but the scanner's
+	// taint analysis doesn't credit clamp-and-continue reassignments
+	// as barriers — only guard-and-bail shapes. Capacity is just a
+	// pre-allocation hint (append grows past it), so decoupling the
+	// make() from the user-derived value entirely is free and kills
+	// the taint path for good. Do NOT change this back to `limit`.
+	out := make([]TopContributor, 0, 20)
 	for rows.Next() {
 		var tc TopContributor
 		if err := rows.Scan(&tc.CntrbID, &tc.Login, &tc.FullName, &tc.ActivityClass,

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -356,7 +356,19 @@ type TopContributor struct {
 // the two contributor surfaces can never disagree about who a
 // cntrb_id is. Commits with NULL cmt_ght_author_id (unresolved
 // authors) are excluded — there is no identity to rank.
-func (s *PostgresStore) TopContributors(ctx context.Context, repoID int64, since, until time.Time, limit int) ([]TopContributor, error) {
+//
+// excludeBots (v0.27.69, the "hide bots" checkbox): filters rows whose
+// identity is a bot by THREE markers — gh_type='Bot' (GitHub App
+// accounts: dependabot[bot]), the '[bot]' login suffix, and the
+// hyphenated -bot/-robot machine-account convention. The third marker
+// exists because the k8s fleet's dominant committers (k8s-ci-robot,
+// k8s-release-robot) are gh_type='User' machine accounts — verified
+// live 2026-08-01 — that the first two markers cannot see. The
+// separator requirement keeps human surnames (talbot, abbot) safe.
+// Deliberately BROADER than the contributor_retention metric's
+// exclusion (gh_type + [bot] only) — that one is pinned to 8Knot
+// parity; this one is a user-controlled display filter.
+func (s *PostgresStore) TopContributors(ctx context.Context, repoID int64, since, until time.Time, limit int, excludeBots bool) ([]TopContributor, error) {
 	lower, upper := resolveWindow(since, until)
 	if limit <= 0 {
 		limit = 20
@@ -424,7 +436,17 @@ SELECT
     (t.commits + t.issues + t.prs + t.reviews + t.comments)::int       AS total
 FROM totals t
 JOIN aveloxis_data.contributors c ON c.cntrb_id = t.cntrb_id
-WHERE COALESCE(c.cntrb_deleted, 0) = 0
+WHERE COALESCE(c.cntrb_deleted, 0) = 0`
+
+	if excludeBots {
+		sql += `
+  AND NOT (
+      COALESCE(c.gh_type, '') = 'Bot'
+      OR c.cntrb_login ILIKE '%[bot]%'
+      OR c.cntrb_login ~* '[-_](bot|robot)[0-9]*$'
+  )`
+	}
+	sql += `
 ORDER BY total DESC, login
 LIMIT $4`
 

--- a/internal/db/contributions.go
+++ b/internal/db/contributions.go
@@ -313,6 +313,134 @@ FROM enriched_state`
 	return out, nil
 }
 
+// TopContributor is one ranked row from TopContributors: a contributor
+// with their per-kind activity counts inside the requested window.
+type TopContributor struct {
+	CntrbID       string `json:"cntrb_id"`
+	Login         string `json:"login"`
+	FullName      string `json:"full_name"`
+	ActivityClass string `json:"activity_class"`
+	Commits       int    `json:"commits"`
+	Issues        int    `json:"issues"`
+	PRs           int    `json:"prs"`
+	Reviews       int    `json:"reviews"`
+	Comments      int    `json:"comments"`
+	Total         int    `json:"total"`
+}
+
+// TopContributors (v0.27.61) returns the top-N contributors to repoID
+// in [since, until), ranked by total activity, with the per-kind
+// breakdown that produced the rank.
+//
+// What counts, per kind (each arm windowed on its own event time):
+//   - commits:  DISTINCT commit hashes authored (the commits table is
+//     one row per FILE per commit — COUNT(*) would weight a 30-file
+//     commit 30×). Windowed on cmt_author_timestamp (TIMESTAMPTZ);
+//     cmt_author_date is TEXT and unsafe to range-filter.
+//   - issues:   issues OPENED (reporter_id / created_at).
+//   - prs:      pull requests OPENED (author_id / created_at).
+//   - reviews:  PR reviews SUBMITTED (cntrb_id / submitted_at) — the
+//     arm that makes maintainer review load visible; it is invisible
+//     in commit/PR counts alone.
+//   - comments: unified messages (issue comments + PR conversation +
+//     inline review comment bodies) by msg_timestamp.
+//
+// Issue/PR events (labels, assignments, closes) are deliberately NOT
+// counted — they are process noise for a "who does the work here"
+// ranking, though they DO count for cohort membership in
+// contributorsInWindowCTE. The two surfaces answer different
+// questions and the difference is documented in docs/guide/api.md.
+//
+// Identity resolution matches GetRepoContributors exactly: the shared
+// COALESCE login chain and the cntrb_deleted=0 soft-delete filter, so
+// the two contributor surfaces can never disagree about who a
+// cntrb_id is. Commits with NULL cmt_ght_author_id (unresolved
+// authors) are excluded — there is no identity to rank.
+func (s *PostgresStore) TopContributors(ctx context.Context, repoID int64, since, until time.Time, limit int) ([]TopContributor, error) {
+	lower, upper := resolveWindow(since, until)
+	if limit <= 0 {
+		limit = 20
+	}
+
+	sql := `
+WITH per_kind AS (
+    SELECT c.cmt_ght_author_id AS cntrb_id,
+           COUNT(DISTINCT c.cmt_commit_hash) AS commits,
+           0::bigint AS issues, 0::bigint AS prs, 0::bigint AS reviews, 0::bigint AS comments
+    FROM aveloxis_data.commits c
+    WHERE c.repo_id = $1 AND c.cmt_ght_author_id IS NOT NULL
+      AND c.cmt_author_timestamp >= $2 AND c.cmt_author_timestamp < $3
+    GROUP BY 1
+
+    UNION ALL
+    SELECT i.reporter_id, 0, COUNT(*), 0, 0, 0
+    FROM aveloxis_data.issues i
+    WHERE i.repo_id = $1 AND i.reporter_id IS NOT NULL
+      AND i.created_at >= $2 AND i.created_at < $3
+    GROUP BY 1
+
+    UNION ALL
+    SELECT pr.author_id, 0, 0, COUNT(*), 0, 0
+    FROM aveloxis_data.pull_requests pr
+    WHERE pr.repo_id = $1 AND pr.author_id IS NOT NULL
+      AND pr.created_at >= $2 AND pr.created_at < $3
+    GROUP BY 1
+
+    UNION ALL
+    SELECT prr.cntrb_id, 0, 0, 0, COUNT(*), 0
+    FROM aveloxis_data.pull_request_reviews prr
+    WHERE prr.repo_id = $1 AND prr.cntrb_id IS NOT NULL
+      AND prr.submitted_at >= $2 AND prr.submitted_at < $3
+    GROUP BY 1
+
+    UNION ALL
+    SELECT m.cntrb_id, 0, 0, 0, 0, COUNT(*)
+    FROM aveloxis_data.messages m
+    WHERE m.repo_id = $1 AND m.cntrb_id IS NOT NULL
+      AND m.msg_timestamp >= $2 AND m.msg_timestamp < $3
+    GROUP BY 1
+),
+totals AS (
+    SELECT cntrb_id,
+           SUM(commits) AS commits, SUM(issues) AS issues, SUM(prs) AS prs,
+           SUM(reviews) AS reviews, SUM(comments) AS comments
+    FROM per_kind
+    GROUP BY cntrb_id
+)
+SELECT
+    t.cntrb_id::text,
+    COALESCE(NULLIF(c.cntrb_login, ''), c.gh_login, c.gl_username, '') AS login,
+    COALESCE(NULLIF(c.cntrb_full_name, ''), '')                        AS full_name,
+    COALESCE(c.gh_activity_class, '')                                  AS activity_class,
+    t.commits::int, t.issues::int, t.prs::int, t.reviews::int, t.comments::int,
+    (t.commits + t.issues + t.prs + t.reviews + t.comments)::int       AS total
+FROM totals t
+JOIN aveloxis_data.contributors c ON c.cntrb_id = t.cntrb_id
+WHERE COALESCE(c.cntrb_deleted, 0) = 0
+ORDER BY total DESC, login
+LIMIT $4`
+
+	rows, err := s.pool.Query(ctx, sql, repoID, lower, upper, limit)
+	if err != nil {
+		return nil, fmt.Errorf("TopContributors query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]TopContributor, 0, limit)
+	for rows.Next() {
+		var tc TopContributor
+		if err := rows.Scan(&tc.CntrbID, &tc.Login, &tc.FullName, &tc.ActivityClass,
+			&tc.Commits, &tc.Issues, &tc.PRs, &tc.Reviews, &tc.Comments, &tc.Total); err != nil {
+			return nil, fmt.Errorf("TopContributors scan: %w", err)
+		}
+		out = append(out, tc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("TopContributors rows: %w", err)
+	}
+	return out, nil
+}
+
 // GetRepoAffiliationCounts returns the number of DISTINCT contributors
 // per affiliation in the same window as GetRepoContributors.
 //

--- a/internal/db/contributions_activity_fields_test.go
+++ b/internal/db/contributions_activity_fields_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// contributions_activity_fields_test.go — v0.27.57 pins: the
+// /contributions/identities endpoint rows carry the activity
+// classification so the operator's front-end page can render the four
+// classes without extra round trips.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRepoContributorCarriesActivityFields(t *testing.T) {
+	typ := reflect.TypeOf(RepoContributor{})
+	want := map[string]string{
+		"ActivityClass":      "activity_class",
+		"PublicContribsYear": "public_contribs_year",
+		"RestrictedContribs": "restricted_contribs_year",
+		"LastContributionYr": "last_contribution_year",
+	}
+	for field, tag := range want {
+		f, ok := typ.FieldByName(field)
+		if !ok {
+			t.Errorf("RepoContributor must carry %s (frontend activity page contract)", field)
+			continue
+		}
+		if got := f.Tag.Get("json"); got != tag {
+			t.Errorf("RepoContributor.%s json tag = %q, want %q — the GUI greps by these names", field, got, tag)
+		}
+	}
+}
+
+func TestGetRepoContributorsSelectsActivityColumns(t *testing.T) {
+	src := readSourceFile(t, "contributions.go")
+	idx := strings.Index(src, "func (s *PostgresStore) GetRepoContributors(")
+	if idx < 0 {
+		t.Fatal("cannot find GetRepoContributors")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	for _, col := range []string{"gh_activity_class", "gh_public_contribs_year", "gh_restricted_contribs_year", "gh_last_contribution_year"} {
+		if !strings.Contains(body, col) {
+			t.Errorf("GetRepoContributors must SELECT %s", col)
+		}
+	}
+}

--- a/internal/db/contributions_test.go
+++ b/internal/db/contributions_test.go
@@ -205,7 +205,7 @@ func insertContributor(ctx context.Context, t *testing.T, store *PostgresStore,
 // out-of-window contributors don't leak in.
 func TestGetRepoContributors_FiltersByWindow(t *testing.T) {
 	store, ctx := contributionsConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedContribRepo(ctx, t, store)
 	insider := insertContributor(ctx, t, store,
@@ -263,7 +263,7 @@ func TestGetRepoContributors_FiltersByWindow(t *testing.T) {
 // cntrb_company beats "(unknown)".
 func TestGetRepoAffiliationCounts_DerivationPriority(t *testing.T) {
 	store, ctx := contributionsConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedContribRepo(ctx, t, store)
 
@@ -337,7 +337,7 @@ func TestGetRepoAffiliationCounts_DerivationPriority(t *testing.T) {
 // predicate flipped" that the source-contract pin can't see.
 func TestGetRepoContributionsCoverage_ExerciseAllFields(t *testing.T) {
 	store, ctx := contributionsConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedContribRepo(ctx, t, store)
 
@@ -454,7 +454,7 @@ func TestGetRepoContributionsCoverage_ExerciseAllFields(t *testing.T) {
 // so the JSON omits the fields entirely rather than emitting zero-time.
 func TestGetRepoContributionsCoverage_EmptyCohort(t *testing.T) {
 	store, ctx := contributionsConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedContribRepo(ctx, t, store)
 

--- a/internal/db/contributor_activity_store.go
+++ b/internal/db/contributor_activity_store.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// contributor_activity_store.go — store layer for the v0.27.57
+// contributor activity classification (GitHub contributionsCollection).
+// The scheduler's activity ticker claims contributors here, fetches
+// their trailing-year contribution summary via the batched GraphQL
+// lookup, and writes the classification back. GITHUB-ONLY: the pool
+// filter is gh_login (GitLab has no restricted-contributions
+// equivalent — documented parity gap).
+
+// ActivityCheckContributor is one claimable contributor for the
+// activity-classification sweep.
+type ActivityCheckContributor struct {
+	ID    string // cntrb_id
+	Login string // gh_login
+}
+
+// ContributorActivityUpdate carries one contributor's classified
+// trailing-year activity for the batched write.
+type ContributorActivityUpdate struct {
+	CntrbID              string
+	PublicContribs       int
+	RestrictedContribs   int
+	LastContributionYear int
+	ActivityClass        string
+}
+
+// GetContributorsForActivityCheck returns contributors due for an
+// activity check, never-checked first, then oldest-checked — the same
+// claim contract as GetContributorsForBreadth, including the jittered
+// cooldown (BreadthCooldownJitterFrac): the sweep has the same
+// cohort-echo dynamics as breadth, and an unjittered cliff would
+// re-bunch check dates forever. Served by
+// idx_contributors_activity_checked (ASC NULLS FIRST — the v0.27.8
+// lesson: without the explicit ordering the claim full-sorts the 2.4M
+// contributor rows on every tick).
+func (s *PostgresStore) GetContributorsForActivityCheck(ctx context.Context, limit int, cooldown time.Duration) ([]ActivityCheckContributor, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if cooldown <= 0 {
+		cooldown = 7 * 24 * time.Hour
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT cntrb_id::text, gh_login
+		FROM aveloxis_data.contributors
+		WHERE gh_login IS NOT NULL
+		  AND gh_login != ''
+		  AND COALESCE(cntrb_deleted, 0) = 0
+		  AND (gh_activity_checked_at IS NULL
+		       OR gh_activity_checked_at < NOW() - ($2::interval * (1.0 - $3::float8 + random() * 2.0 * $3::float8)))
+		ORDER BY gh_activity_checked_at ASC NULLS FIRST
+		LIMIT $1`, limit, cooldown.String(), BreadthCooldownJitterFrac)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ActivityCheckContributor
+	for rows.Next() {
+		var c ActivityCheckContributor
+		if err := rows.Scan(&c.ID, &c.Login); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// UpdateContributorActivityBatch writes classified activity for a batch
+// of contributors in one transaction, stamping gh_activity_checked_at
+// alongside the data so a stored classification and its freshness can
+// never drift apart.
+func (s *PostgresStore) UpdateContributorActivityBatch(ctx context.Context, updates []ContributorActivityUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	b := &pgx.Batch{}
+	for _, u := range updates {
+		b.Queue(`
+			UPDATE aveloxis_data.contributors
+			SET gh_public_contribs_year = $2,
+			    gh_restricted_contribs_year = $3,
+			    gh_last_contribution_year = $4,
+			    gh_activity_class = $5,
+			    gh_activity_checked_at = NOW()
+			WHERE cntrb_id = $1::uuid`,
+			u.CntrbID, u.PublicContribs, u.RestrictedContribs, u.LastContributionYear, u.ActivityClass)
+	}
+	br := s.pool.SendBatch(ctx, b)
+	defer br.Close()
+	for range updates {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("update contributor activity batch: %w", err)
+		}
+	}
+	return nil
+}
+
+// MarkActivityCheckedBatch stamps gh_activity_checked_at for
+// contributors whose check yielded NO data (deleted/renamed accounts
+// absent from the GraphQL result). It deliberately touches ONLY the
+// stamp — clobbering a previously-stored class with empties on a later
+// dataless check would erase good data. Chunked ANY(uuid[]) per the
+// MarkBreadthAttemptedBatch pattern. Marking unconditionally is the
+// v0.20.17 lesson: unmarked dead-enders pin the NULLS-FIRST queue head
+// forever.
+func (s *PostgresStore) MarkActivityCheckedBatch(ctx context.Context, cntrbIDs []string) error {
+	const chunk = 500
+	for start := 0; start < len(cntrbIDs); start += chunk {
+		end := start + chunk
+		if end > len(cntrbIDs) {
+			end = len(cntrbIDs)
+		}
+		if _, err := s.pool.Exec(ctx, `
+			UPDATE aveloxis_data.contributors
+			SET gh_activity_checked_at = NOW()
+			WHERE cntrb_id = ANY($1::uuid[])`, cntrbIDs[start:end]); err != nil {
+			return fmt.Errorf("mark activity checked batch: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/db/contributor_activity_store_test.go
+++ b/internal/db/contributor_activity_store_test.go
@@ -139,7 +139,7 @@ func TestMarkActivityCheckedBatchContract(t *testing.T) {
 // pool.
 func TestContributorActivityStoreEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	cooldown := 240 * time.Hour
 
 	never := seedActivityContributor(t, store, "_avact_never", "")

--- a/internal/db/contributor_activity_store_test.go
+++ b/internal/db/contributor_activity_store_test.go
@@ -31,6 +31,38 @@ var activityColumns = []string{
 	"gh_activity_checked_at",
 }
 
+// TestSchemaGuardsNewIndexedColumnsForExistingFleets pins the fix for
+// the 2026-07-30 kate migrate failure: on an EXISTING database,
+// CREATE TABLE IF NOT EXISTS contributors no-ops, so columns that are
+// new in this release never materialize from the base DDL — and any
+// schema.sql CREATE INDEX referencing them fails with SQLSTATE 42703
+// BEFORE addColumnIfMissing gets a chance to run (base DDL executes
+// first). Every same-release (new column, schema.sql index) pair must
+// therefore carry an ALTER TABLE ... ADD COLUMN IF NOT EXISTS guard in
+// schema.sql, positioned BEFORE the index statement. (The local test
+// signal for this bug was "first migrate run fails, second passes" —
+// the failed run's addColumnIfMissing steps repair the DB for the next
+// attempt. Production migrate is fail-closed and runs once.)
+func TestSchemaGuardsNewIndexedColumnsForExistingFleets(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	flat := strings.Join(strings.Fields(schema), " ")
+	for _, g := range []struct{ column, index string }{
+		{"gh_activity_checked_at", "idx_contributors_activity_checked"},
+		{"gh_history_backfilled_at", "idx_contributors_history_backfilled"},
+	} {
+		guard := "ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS " + g.column
+		gpos := strings.Index(flat, guard)
+		ipos := strings.Index(flat, "CREATE INDEX IF NOT EXISTS "+g.index)
+		if gpos < 0 {
+			t.Errorf("schema.sql must carry %q so existing fleets (where CREATE TABLE no-ops) get the column before %s references it", guard, g.index)
+			continue
+		}
+		if ipos >= 0 && gpos > ipos {
+			t.Errorf("the %s guard must appear BEFORE %s — order is the whole point", g.column, g.index)
+		}
+	}
+}
+
 func TestSchemaDeclaresActivityColumns(t *testing.T) {
 	schema := readSourceFile(t, "schema.sql")
 	for _, col := range activityColumns {

--- a/internal/db/contributor_activity_store_test.go
+++ b/internal/db/contributor_activity_store_test.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// contributor_activity_store_test.go — TDD suite for the v0.27.57
+// contributor-activity store layer (GitHub contributionsCollection
+// classification). Contracts pinned:
+//   - the five gh_activity columns exist in schema.sql AND migrate.go
+//     (fresh installs + existing fleets);
+//   - the claim query mirrors the breadth claim: NULLS-first ordering,
+//     jittered cooldown (same BreadthCooldownJitterFrac — the same
+//     feast/famine echo dynamics apply), and a serving index declared
+//     ASC NULLS FIRST (the v0.27.8 lesson: without it the claim
+//     full-sorts 2.4M contributor rows every tick);
+//   - marking is decoupled from data: contributors ABSENT from the API
+//     result still get gh_activity_checked_at stamped (the v0.20.17
+//     lesson — unmarked dead-enders would pin the queue head forever).
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+var activityColumns = []string{
+	"gh_public_contribs_year",
+	"gh_restricted_contribs_year",
+	"gh_last_contribution_year",
+	"gh_activity_class",
+	"gh_activity_checked_at",
+}
+
+func TestSchemaDeclaresActivityColumns(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	for _, col := range activityColumns {
+		if !strings.Contains(schema, col) {
+			t.Errorf("schema.sql must declare contributors.%s", col)
+		}
+	}
+	flat := strings.Join(strings.Fields(schema), " ")
+	if !strings.Contains(flat, "idx_contributors_activity_checked ON aveloxis_data.contributors (gh_activity_checked_at ASC NULLS FIRST)") {
+		t.Error("schema.sql must declare idx_contributors_activity_checked with explicit ASC NULLS FIRST — the v0.27.8 breadth lesson: Postgres's ASC default is NULLS LAST and neither scan direction serves the claim's ORDER BY without it")
+	}
+}
+
+func TestMigrateAddsActivityColumns(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	for _, col := range activityColumns {
+		if !strings.Contains(src, `"`+col+`"`) {
+			t.Errorf("migrate.go must addColumnIfMissing %s for existing fleets", col)
+		}
+	}
+	if !strings.Contains(src, "idx_contributors_activity_checked") {
+		t.Error("migrate.go must build idx_contributors_activity_checked (CONCURRENTLY) for existing fleets")
+	}
+}
+
+func TestActivityClaimQueryContract(t *testing.T) {
+	src := readSourceFile(t, "contributor_activity_store.go")
+	idx := strings.Index(src, "func (s *PostgresStore) GetContributorsForActivityCheck(")
+	if idx < 0 {
+		t.Fatal("cannot find GetContributorsForActivityCheck")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	flat := strings.Join(strings.Fields(body), " ")
+	for _, needle := range []string{
+		"gh_activity_checked_at IS NULL",
+		"ORDER BY gh_activity_checked_at ASC NULLS FIRST",
+		"BreadthCooldownJitterFrac",
+		`gh_login != ''`,
+		"COALESCE(cntrb_deleted, 0) = 0",
+	} {
+		if !strings.Contains(flat, needle) {
+			t.Errorf("activity claim query must contain %q (mirrors the breadth claim contract)", needle)
+		}
+	}
+}
+
+// MarkActivityCheckedBatch must stamp checked_at WITHOUT touching the
+// activity fields — it's the "attempted, no data returned" path for
+// deleted/renamed users, and clobbering a previously-stored class with
+// empties would erase good data on a later failed check.
+func TestMarkActivityCheckedBatchContract(t *testing.T) {
+	src := readSourceFile(t, "contributor_activity_store.go")
+	idx := strings.Index(src, "func (s *PostgresStore) MarkActivityCheckedBatch(")
+	if idx < 0 {
+		t.Fatal("cannot find MarkActivityCheckedBatch")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	if !strings.Contains(body, "ANY($1::uuid[])") {
+		t.Error("mark must be a chunked ANY(uuid[]) update (the MarkBreadthAttemptedBatch pattern), not per-row round trips")
+	}
+	if strings.Contains(body, "gh_activity_class") {
+		t.Error("MarkActivityCheckedBatch must NOT touch gh_activity_class — a mark-only pass may not clobber previously-stored classification")
+	}
+}
+
+// End-to-end against the scratch DB: claim honors cooldown + NULLS
+// first; the update writes all fields; marked rows leave the claim
+// pool.
+func TestContributorActivityStoreEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+	cooldown := 240 * time.Hour
+
+	never := seedActivityContributor(t, store, "_avact_never", "")
+	recent := seedActivityContributor(t, store, "_avact_recent", "NOW()")
+	old := seedActivityContributor(t, store, "_avact_old", "NOW() - '480:00:00'::interval")
+
+	var poolN int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_data.contributors
+		WHERE gh_login IS NOT NULL AND gh_login != '' AND COALESCE(cntrb_deleted, 0) = 0`).Scan(&poolN); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := store.GetContributorsForActivityCheck(ctx, poolN+10, cooldown)
+	if err != nil {
+		t.Fatalf("GetContributorsForActivityCheck: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, c := range claimed {
+		ids[c.ID] = true
+	}
+	if !ids[never] || !ids[old] {
+		t.Fatal("never-checked and past-cooldown contributors must be claimable")
+	}
+	if ids[recent] {
+		t.Fatal("recently-checked contributor must be excluded by the cooldown")
+	}
+
+	// Store activity for one; mark-only for another.
+	if err := store.UpdateContributorActivityBatch(ctx, []ContributorActivityUpdate{
+		{CntrbID: never, PublicContribs: 1742, RestrictedContribs: 1895, LastContributionYear: 2026, ActivityClass: "public-active"},
+	}); err != nil {
+		t.Fatalf("UpdateContributorActivityBatch: %v", err)
+	}
+	if err := store.MarkActivityCheckedBatch(ctx, []string{old}); err != nil {
+		t.Fatalf("MarkActivityCheckedBatch: %v", err)
+	}
+
+	var pub, restr, lastYr int
+	var class string
+	if err := store.pool.QueryRow(ctx, `
+		SELECT gh_public_contribs_year, gh_restricted_contribs_year, gh_last_contribution_year, gh_activity_class
+		FROM aveloxis_data.contributors WHERE cntrb_id = $1::uuid`, never).Scan(&pub, &restr, &lastYr, &class); err != nil {
+		t.Fatal(err)
+	}
+	if pub != 1742 || restr != 1895 || lastYr != 2026 || class != "public-active" {
+		t.Errorf("stored activity wrong: pub=%d restr=%d yr=%d class=%q", pub, restr, lastYr, class)
+	}
+
+	// Both leave the claim pool.
+	claimed, err = store.GetContributorsForActivityCheck(ctx, poolN+10, cooldown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range claimed {
+		if c.ID == never || c.ID == old {
+			t.Errorf("contributor %s still claimable after update/mark", c.ID)
+		}
+	}
+}
+
+// seedActivityContributor mirrors seedJitterContributor for the
+// gh_activity_checked_at column. checkedAtSQL "" means NULL.
+func seedActivityContributor(t *testing.T, store *PostgresStore, login, checkedAtSQL string) string {
+	t.Helper()
+	ctx := t.Context()
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	stamp := "NULL"
+	if checkedAtSQL != "" {
+		stamp = checkedAtSQL
+	}
+	var id string
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.contributors
+			(cntrb_id, cntrb_login, gh_login, gh_activity_checked_at, data_collection_date)
+		VALUES (gen_random_uuid(), $1, $1, `+stamp+`, NOW())
+		RETURNING cntrb_id::text`, login).Scan(&id); err != nil {
+		t.Fatalf("seed %s: %v", login, err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	})
+	return id
+}

--- a/internal/db/contributor_elsewhere_store.go
+++ b/internal/db/contributor_elsewhere_store.go
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// v0.27.64 — the read surface over the v0.27.58 contributor daily
+// history (contributor_activity_days / _day_totals, fed by GitHub's
+// contributionsCollection):
+//
+//   - ContributorsElsewhere: "where else are this repo's top
+//     contributors active?" — the repo page's cross-repo matrix.
+//   - ContributorActivity: one person's monthly per-repo view + the
+//     disclosed-total day series.
+//
+// THE HONESTY RULE (v0.27.58): every contributor entry carries
+// contributors.gh_history_backfilled_at. An un-backfilled contributor
+// has NO history rows, and rendering that absence as "active nowhere
+// else" would be a lie — the frontend shows "history pending" when
+// the stamp is nil.
+
+// ElsewhereRepo is one other-repo aggregate for a contributor.
+// RepoID is non-nil only when the repo is tracked on THIS instance
+// (GitHub side — the history source is GitHub-only, so the link join
+// is restricted to platform_id = 1).
+type ElsewhereRepo struct {
+	RepoFullName string `json:"repo_full_name"`
+	RepoID       *int64 `json:"repo_id,omitempty"`
+	ActiveDays   int    `json:"active_days"`
+	Commits      int    `json:"commits"`
+	Issues       int    `json:"issues"`
+	PRs          int    `json:"prs"`
+	Reviews      int    `json:"reviews"`
+}
+
+// ElsewhereContributor is one top contributor with their other-repo
+// activity.
+type ElsewhereContributor struct {
+	CntrbID      string          `json:"cntrb_id"`
+	Login        string          `json:"login"`
+	BackfilledAt *time.Time      `json:"backfilled_at"`
+	Elsewhere    []ElsewhereRepo `json:"elsewhere"`
+}
+
+// ContributorsElsewhere returns the repo's top-N contributors (by the
+// same ranking as TopContributors) with each one's top other repos
+// from the daily-history tables, aggregated over [since, now).
+//
+// The CURRENT repo is excluded case-insensitively: repo_full_name is
+// GitHub-canonical TEXT and our stored owner/name casing can drift
+// from it (the v0.25.32 case lesson).
+func (s *PostgresStore) ContributorsElsewhere(ctx context.Context, repoID int64, since time.Time, topN, reposPer int) ([]ElsewhereContributor, error) {
+	if topN <= 0 {
+		topN = 10
+	}
+	if reposPer <= 0 {
+		reposPer = 10
+	}
+
+	top, err := s.TopContributors(ctx, repoID, since, time.Time{}, topN)
+	if err != nil {
+		return nil, err
+	}
+	if len(top) == 0 {
+		return []ElsewhereContributor{}, nil
+	}
+
+	ids := make([]string, len(top))
+	out := make([]ElsewhereContributor, len(top))
+	index := make(map[string]int, len(top))
+	for i, tc := range top {
+		ids[i] = tc.CntrbID
+		out[i] = ElsewhereContributor{CntrbID: tc.CntrbID, Login: tc.Login, Elsewhere: []ElsewhereRepo{}}
+		index[tc.CntrbID] = i
+	}
+
+	// Backfill stamps for the whole cohort (nil = history pending).
+	stampRows, err := s.pool.Query(ctx, `
+		SELECT cntrb_id::text, gh_history_backfilled_at
+		FROM aveloxis_data.contributors
+		WHERE cntrb_id = ANY($1::uuid[])`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("ContributorsElsewhere stamps: %w", err)
+	}
+	for stampRows.Next() {
+		var id string
+		var at *time.Time
+		if err := stampRows.Scan(&id, &at); err != nil {
+			stampRows.Close()
+			return nil, fmt.Errorf("ContributorsElsewhere stamp scan: %w", err)
+		}
+		if i, ok := index[id]; ok {
+			out[i].BackfilledAt = at
+		}
+	}
+	stampRows.Close()
+	if err := stampRows.Err(); err != nil {
+		return nil, fmt.Errorf("ContributorsElsewhere stamps rows: %w", err)
+	}
+
+	// Per-contributor other-repo aggregates, ranked by active days.
+	// The repo_id link joins platform 1 only — the history source is
+	// GitHub's contributionsCollection, and the platform filter keeps
+	// the join at most 1:1 under uq_repos_repo_git_ci.
+	rows, err := s.pool.Query(ctx, `
+		WITH agg AS (
+		    SELECT ad.cntrb_id, ad.repo_full_name,
+		           COUNT(*)::int              AS active_days,
+		           SUM(ad.commit_count)::int  AS commits,
+		           SUM(ad.issue_count)::int   AS issues,
+		           SUM(ad.pr_count)::int      AS prs,
+		           SUM(ad.review_count)::int  AS reviews
+		    FROM aveloxis_data.contributor_activity_days ad
+		    WHERE ad.cntrb_id = ANY($1::uuid[])
+		      AND ad.day >= $2::date
+		      AND LOWER(ad.repo_full_name) <> LOWER(
+		            (SELECT r.repo_owner || '/' || r.repo_name
+		             FROM aveloxis_data.repos r WHERE r.repo_id = $3))
+		    GROUP BY ad.cntrb_id, ad.repo_full_name
+		),
+		ranked AS (
+		    SELECT agg.*,
+		           ROW_NUMBER() OVER (
+		               PARTITION BY agg.cntrb_id
+		               ORDER BY agg.active_days DESC,
+		                        (agg.commits + agg.issues + agg.prs + agg.reviews) DESC,
+		                        agg.repo_full_name) AS rn
+		    FROM agg
+		)
+		SELECT rk.cntrb_id::text, rk.repo_full_name, tr.repo_id,
+		       rk.active_days, rk.commits, rk.issues, rk.prs, rk.reviews
+		FROM ranked rk
+		LEFT JOIN aveloxis_data.repos tr
+		    ON LOWER(tr.repo_owner || '/' || tr.repo_name) = LOWER(rk.repo_full_name)
+		    AND tr.platform_id = 1
+		WHERE rk.rn <= $4
+		ORDER BY rk.cntrb_id, rk.rn`, ids, since, repoID, reposPer)
+	if err != nil {
+		return nil, fmt.Errorf("ContributorsElsewhere query: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		var er ElsewhereRepo
+		if err := rows.Scan(&id, &er.RepoFullName, &er.RepoID,
+			&er.ActiveDays, &er.Commits, &er.Issues, &er.PRs, &er.Reviews); err != nil {
+			return nil, fmt.Errorf("ContributorsElsewhere scan: %w", err)
+		}
+		if i, ok := index[id]; ok {
+			out[i].Elsewhere = append(out[i].Elsewhere, er)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ContributorsElsewhere rows: %w", err)
+	}
+	return out, nil
+}
+
+// ActivityMonth is one month bucket of one repo's activity.
+type ActivityMonth struct {
+	Month      string `json:"month"` // YYYY-MM
+	ActiveDays int    `json:"active_days"`
+	Commits    int    `json:"commits"`
+	Issues     int    `json:"issues"`
+	PRs        int    `json:"prs"`
+	Reviews    int    `json:"reviews"`
+}
+
+// ActivityRepo is one repo in a contributor's monthly view.
+type ActivityRepo struct {
+	RepoFullName string          `json:"repo_full_name"`
+	RepoID       *int64          `json:"repo_id,omitempty"`
+	Months       []ActivityMonth `json:"months"`
+}
+
+// DayTotal is one day of the contribution calendar's disclosed total
+// (includes private contributions when the user enabled disclosure).
+type DayTotal struct {
+	Day   string `json:"day"` // YYYY-MM-DD
+	Total int    `json:"total"`
+}
+
+// ContributorActivityView is the person-level cross-repo response.
+type ContributorActivityView struct {
+	CntrbID      string         `json:"cntrb_id"`
+	Login        string         `json:"login"`
+	BackfilledAt *time.Time     `json:"backfilled_at"`
+	Months       int            `json:"months"`
+	Repos        []ActivityRepo `json:"repos"`
+	DayTotals    []DayTotal     `json:"day_totals"`
+}
+
+// ContributorActivity returns one contributor's monthly per-repo
+// activity (top 10 repos by total activity in the window) plus the
+// disclosed-total day series, over the trailing `months` months.
+func (s *PostgresStore) ContributorActivity(ctx context.Context, cntrbID string, months int) (*ContributorActivityView, error) {
+	if months <= 0 {
+		months = 24
+	}
+	since := time.Now().AddDate(0, -months, 0)
+
+	view := &ContributorActivityView{
+		CntrbID: cntrbID,
+		Months:  months,
+		Repos:   []ActivityRepo{},
+	}
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(NULLIF(cntrb_login, ''), gh_login, gl_username, ''), gh_history_backfilled_at
+		FROM aveloxis_data.contributors
+		WHERE cntrb_id = $1::uuid AND COALESCE(cntrb_deleted, 0) = 0`,
+		cntrbID).Scan(&view.Login, &view.BackfilledAt); err != nil {
+		return nil, fmt.Errorf("ContributorActivity contributor lookup: %w", err)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		WITH windowed AS (
+		    SELECT ad.repo_full_name,
+		           to_char(date_trunc('month', ad.day), 'YYYY-MM') AS month,
+		           COUNT(*)::int             AS active_days,
+		           SUM(ad.commit_count)::int AS commits,
+		           SUM(ad.issue_count)::int  AS issues,
+		           SUM(ad.pr_count)::int     AS prs,
+		           SUM(ad.review_count)::int AS reviews
+		    FROM aveloxis_data.contributor_activity_days ad
+		    WHERE ad.cntrb_id = $1::uuid AND ad.day >= $2::date
+		    GROUP BY ad.repo_full_name, date_trunc('month', ad.day)
+		),
+		repo_rank AS (
+		    SELECT repo_full_name,
+		           SUM(commits + issues + prs + reviews) AS total
+		    FROM windowed
+		    GROUP BY repo_full_name
+		    ORDER BY total DESC, repo_full_name
+		    LIMIT 10
+		)
+		SELECT w.repo_full_name, tr.repo_id, w.month,
+		       w.active_days, w.commits, w.issues, w.prs, w.reviews
+		FROM windowed w
+		JOIN repo_rank rr USING (repo_full_name)
+		LEFT JOIN aveloxis_data.repos tr
+		    ON LOWER(tr.repo_owner || '/' || tr.repo_name) = LOWER(w.repo_full_name)
+		    AND tr.platform_id = 1
+		ORDER BY rr.total DESC, w.repo_full_name, w.month`, cntrbID, since)
+	if err != nil {
+		return nil, fmt.Errorf("ContributorActivity months query: %w", err)
+	}
+	defer rows.Close()
+
+	byRepo := map[string]int{}
+	for rows.Next() {
+		var name, month string
+		var repoLink *int64
+		var m ActivityMonth
+		if err := rows.Scan(&name, &repoLink, &month, &m.ActiveDays, &m.Commits, &m.Issues, &m.PRs, &m.Reviews); err != nil {
+			return nil, fmt.Errorf("ContributorActivity months scan: %w", err)
+		}
+		m.Month = month
+		i, ok := byRepo[name]
+		if !ok {
+			view.Repos = append(view.Repos, ActivityRepo{RepoFullName: name, RepoID: repoLink, Months: []ActivityMonth{}})
+			i = len(view.Repos) - 1
+			byRepo[name] = i
+		}
+		view.Repos[i].Months = append(view.Repos[i].Months, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ContributorActivity months rows: %w", err)
+	}
+
+	dtRows, err := s.pool.Query(ctx, `
+		SELECT to_char(day, 'YYYY-MM-DD'), total_contributions
+		FROM aveloxis_data.contributor_activity_day_totals
+		WHERE cntrb_id = $1::uuid AND day >= $2::date
+		ORDER BY day`, cntrbID, since)
+	if err != nil {
+		return nil, fmt.Errorf("ContributorActivity day totals: %w", err)
+	}
+	defer dtRows.Close()
+
+	view.DayTotals = []DayTotal{}
+	for dtRows.Next() {
+		var dt DayTotal
+		if err := dtRows.Scan(&dt.Day, &dt.Total); err != nil {
+			return nil, fmt.Errorf("ContributorActivity day-total scan: %w", err)
+		}
+		view.DayTotals = append(view.DayTotals, dt)
+	}
+	return view, dtRows.Err()
+}

--- a/internal/db/contributor_elsewhere_store.go
+++ b/internal/db/contributor_elsewhere_store.go
@@ -54,7 +54,7 @@ type ElsewhereContributor struct {
 // The CURRENT repo is excluded case-insensitively: repo_full_name is
 // GitHub-canonical TEXT and our stored owner/name casing can drift
 // from it (the v0.25.32 case lesson).
-func (s *PostgresStore) ContributorsElsewhere(ctx context.Context, repoID int64, since time.Time, topN, reposPer int) ([]ElsewhereContributor, error) {
+func (s *PostgresStore) ContributorsElsewhere(ctx context.Context, repoID int64, since time.Time, topN, reposPer int, excludeBots bool) ([]ElsewhereContributor, error) {
 	if topN <= 0 {
 		topN = 10
 	}
@@ -62,7 +62,7 @@ func (s *PostgresStore) ContributorsElsewhere(ctx context.Context, repoID int64,
 		reposPer = 10
 	}
 
-	top, err := s.TopContributors(ctx, repoID, since, time.Time{}, topN)
+	top, err := s.TopContributors(ctx, repoID, since, time.Time{}, topN, excludeBots)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/contributor_elsewhere_test.go
+++ b/internal/db/contributor_elsewhere_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// v0.27.64 — the read surface over the v0.27.58 daily-history tables:
+// ContributorsElsewhere ("where else are this repo's top contributors
+// active?") and ContributorActivity (one person's cross-repo monthly
+// view). Source pins on the honesty-critical decisions, then an
+// integration test.
+
+func elsewhereSQL(t *testing.T) string {
+	t.Helper()
+	return readSourceFile(t, "contributor_elsewhere_store.go")
+}
+
+// Every contributor entry must carry gh_history_backfilled_at: an
+// un-backfilled contributor has NO history rows, and without the
+// stamp the frontend would render that absence as "active nowhere
+// else" — a lie. "History pending" and "zero elsewhere activity" must
+// be distinguishable (the v0.27.58 honesty rule).
+func TestElsewhereCarriesBackfilledAt(t *testing.T) {
+	src := elsewhereSQL(t)
+	if !strings.Contains(src, "gh_history_backfilled_at") {
+		t.Error("elsewhere/activity responses must carry contributors.gh_history_backfilled_at")
+	}
+}
+
+// The current repo is excluded from "elsewhere" case-insensitively:
+// repo_full_name is GitHub-canonical TEXT and our stored owner/name
+// casing can drift from it (the v0.25.32 case lesson).
+func TestElsewhereExcludesCurrentRepoCaseInsensitively(t *testing.T) {
+	src := elsewhereSQL(t)
+	if !strings.Contains(src, "LOWER(ad.repo_full_name)") {
+		t.Error("current-repo exclusion must compare LOWER(repo_full_name) — GitHub canonical casing can differ from ours")
+	}
+}
+
+// The repo-link annotation join is restricted to platform 1: the
+// history data comes from GitHub's contributionsCollection, so a
+// same-path GitLab repo must not be linked (and the platform filter
+// is what keeps the join at most 1:1 under uq_repos_repo_git_ci).
+func TestElsewhereRepoLinkIsGitHubOnly(t *testing.T) {
+	src := elsewhereSQL(t)
+	if !strings.Contains(src, "platform_id = 1") {
+		t.Error("repo_id link annotation must join repos with platform_id = 1 only")
+	}
+}
+
+// ─── Integration (AVELOXIS_TEST_DB) ─────────────────────────────
+
+func TestContributorElsewhereEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	clean := func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_days WHERE cntrb_id IN (SELECT cntrb_id FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avelse%')`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_day_totals WHERE cntrb_id IN (SELECT cntrb_id FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avelse%')`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.commits WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avelse')`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avelse'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avelse%'`)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	var repoID int64
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id)
+		VALUES ('https://github.com/_avelse/home', '_avelse', 'home', 1) RETURNING repo_id`).Scan(&repoID); err != nil {
+		t.Fatal(err)
+	}
+	// A tracked repo the contributor is ALSO active in — proves the
+	// repo_id link annotation.
+	var otherID int64
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id)
+		VALUES ('https://github.com/_avelse/other', '_avelse', 'other', 1) RETURNING repo_id`).Scan(&otherID); err != nil {
+		t.Fatal(err)
+	}
+
+	cid := "0100beef-0000-0000-0000-00000000e15e"
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributors (cntrb_id, cntrb_login, gh_history_backfilled_at)
+		VALUES ($1::uuid, '_avelse_carol', NOW())
+		ON CONFLICT (cntrb_login) WHERE cntrb_login != '' DO NOTHING`, cid); err != nil {
+		t.Fatal(err)
+	}
+	// Make carol the repo's top contributor: one commit in-window.
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename, cmt_author_name, cmt_author_email, cmt_author_date, cmt_author_timestamp, cmt_ght_author_id)
+		VALUES ($1, 'e15e111', 'a.go', 'c', 'c@x', '2026-07-01', NOW() - interval '5 days', $2::uuid)`, repoID, cid); err != nil {
+		t.Fatal(err)
+	}
+
+	day := func(offset int, repoFullName string, commits int) {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.contributor_activity_days (cntrb_id, day, repo_full_name, commit_count)
+			VALUES ($1::uuid, CURRENT_DATE - $2::int, $3, $4)`, cid, offset, repoFullName, commits); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// History: the home repo under GITHUB'S canonical casing (case
+	// differs from ours — must still be excluded), a tracked other
+	// repo, and an untracked one.
+	day(3, "_AVelse/Home", 2)
+	day(3, "_avelse/other", 5)
+	day(4, "_avelse/other", 1)
+	day(5, "torvalds/linux", 7)
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.contributor_activity_day_totals (cntrb_id, day, total_contributions)
+		VALUES ($1::uuid, CURRENT_DATE - 3, 15)`, cid); err != nil {
+		t.Fatal(err)
+	}
+
+	since := time.Now().AddDate(0, 0, -180)
+	rows, err := store.ContributorsElsewhere(ctx, repoID, since, 10, 10)
+	if err != nil {
+		t.Fatalf("ContributorsElsewhere: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 contributor, got %d: %+v", len(rows), rows)
+	}
+	c := rows[0]
+	if c.Login != "_avelse_carol" {
+		t.Fatalf("unexpected contributor: %+v", c)
+	}
+	if c.BackfilledAt == nil {
+		t.Error("backfilled_at must be carried on every contributor entry")
+	}
+	names := map[string]ElsewhereRepo{}
+	for _, er := range c.Elsewhere {
+		names[er.RepoFullName] = er
+	}
+	if _, ok := names["_AVelse/Home"]; ok {
+		t.Error("the current repo must be excluded from elsewhere (case-insensitively)")
+	}
+	other, ok := names["_avelse/other"]
+	if !ok {
+		t.Fatalf("tracked other repo missing from elsewhere: %+v", c.Elsewhere)
+	}
+	if other.RepoID == nil || *other.RepoID != otherID {
+		t.Errorf("tracked repo must carry its repo_id link, got %+v", other)
+	}
+	if other.ActiveDays != 2 || other.Commits != 6 {
+		t.Errorf("other repo aggregation wrong (want 2 active days, 6 commits): %+v", other)
+	}
+	linux, ok := names["torvalds/linux"]
+	if !ok {
+		t.Fatalf("untracked repo missing from elsewhere: %+v", c.Elsewhere)
+	}
+	if linux.RepoID != nil {
+		t.Error("untracked repo must carry a nil repo_id")
+	}
+
+	// The person-level view: monthly buckets + day totals.
+	act, err := store.ContributorActivity(ctx, cid, 24)
+	if err != nil {
+		t.Fatalf("ContributorActivity: %v", err)
+	}
+	if act.BackfilledAt == nil {
+		t.Error("activity view must carry backfilled_at")
+	}
+	if len(act.DayTotals) != 1 || act.DayTotals[0].Total != 15 {
+		t.Errorf("day_totals wrong: %+v", act.DayTotals)
+	}
+	var sawLinux bool
+	for _, r := range act.Repos {
+		if r.RepoFullName == "torvalds/linux" && len(r.Months) == 1 && r.Months[0].Commits == 7 {
+			sawLinux = true
+		}
+	}
+	if !sawLinux {
+		t.Errorf("monthly per-repo buckets missing torvalds/linux: %+v", act.Repos)
+	}
+}

--- a/internal/db/contributor_elsewhere_test.go
+++ b/internal/db/contributor_elsewhere_test.go
@@ -119,7 +119,7 @@ func TestContributorElsewhereEndToEnd(t *testing.T) {
 	}
 
 	since := time.Now().AddDate(0, 0, -180)
-	rows, err := store.ContributorsElsewhere(ctx, repoID, since, 10, 10)
+	rows, err := store.ContributorsElsewhere(ctx, repoID, since, 10, 10, false)
 	if err != nil {
 		t.Fatalf("ContributorsElsewhere: %v", err)
 	}

--- a/internal/db/contributor_elsewhere_test.go
+++ b/internal/db/contributor_elsewhere_test.go
@@ -57,7 +57,7 @@ func TestElsewhereRepoLinkIsGitHubOnly(t *testing.T) {
 
 func TestContributorElsewhereEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	clean := func() {
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_days WHERE cntrb_id IN (SELECT cntrb_id FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avelse%')`)

--- a/internal/db/contributor_email_lookup_indexes_test.go
+++ b/internal/db/contributor_email_lookup_indexes_test.go
@@ -99,7 +99,7 @@ func TestEmailLookupIndexNamesNotDropTargets(t *testing.T) {
 // exist on contributors and are valid.
 func TestContributorEmailLookupIndexesEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	for _, idx := range emailLookupIndexes {
 		var valid bool
 		err := store.pool.QueryRow(ctx, `

--- a/internal/db/contributor_email_lookup_indexes_test.go
+++ b/internal/db/contributor_email_lookup_indexes_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// contributor_email_lookup_indexes_test.go — TDD suite for the v0.27.54
+// email/canonical lookup indexes on contributors.
+//
+// Motivating incident (2026-07-29, aveloxis_large): the hourly
+// mailing-list sender-resolve candidates query
+// (GetMailingListSenderResolveCandidates) ran 30-50 minutes occupying 5
+// backends. EXPLAIN showed its NOT EXISTS against contributors planned as
+// a nested-loop anti-join whose inner side was a full parallel seq scan
+// of the 9.4 GB contributors heap ONCE PER OUTER ROW — the OR-equality
+// (cntrb_email = X OR cntrb_canonical = X) cannot hash-anti-join and
+// neither column had an index. History: cntrb_email never had one;
+// cntrb_canonical's was dropped in v0.25.6 as "no reader" — correct that
+// day, then v0.25.7+ shipped the mailing-list machinery with new readers
+// of exactly these columns (this query, ResolveContributorIDByEmail's
+// join, CreateEmailOnlyContributor's probe).
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// emailLookupIndexes is the local fixture (deliberately NOT shared with
+// production code, per the anti-rename-drift test pattern): a refactor
+// that renames the production index still fails here by name.
+var emailLookupIndexes = []struct {
+	name   string
+	column string
+}{
+	{"idx_contributors_email_lookup", "cntrb_email"},
+	{"idx_contributors_canonical_lookup", "cntrb_canonical"},
+}
+
+// Both indexes must be declared in schema.sql for fresh installs, and
+// must be NON-partial: the hot probes compare against a JOIN column
+// (em.sender_email), and the planner cannot prove a partial predicate
+// like "cntrb_email != ”" from a join variable at plan time — a partial
+// index would be silently ignored for exactly the anti-join this fix
+// targets. (The v0.19.9 partial gh_login index is fine because those
+// probes are plan-time-known parameters; this one is not.)
+func TestSchemaDeclaresContributorEmailLookupIndexes(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	flat := strings.Join(strings.Fields(schema), " ")
+	for _, idx := range emailLookupIndexes {
+		decl := regexp.MustCompile(
+			`CREATE INDEX IF NOT EXISTS ` + idx.name +
+				` ON aveloxis_data\.contributors \(` + idx.column + `\)([^;]*);`)
+		m := decl.FindStringSubmatch(flat)
+		if m == nil {
+			t.Errorf("schema.sql must declare CREATE INDEX IF NOT EXISTS %s ON aveloxis_data.contributors (%s)", idx.name, idx.column)
+			continue
+		}
+		if strings.Contains(strings.ToUpper(m[1]), "WHERE") {
+			t.Errorf("%s must be NON-partial: a WHERE predicate cannot be proven from the join-variable probes (em.sender_email) and the planner would ignore the index for the sender-resolve anti-join — the exact query this index exists to fix", idx.name)
+		}
+	}
+}
+
+// Existing fleets get the indexes via a CONCURRENTLY build in migrate.go
+// (the schema.sql plain form only covers fresh installs — base DDL runs
+// inside a transaction where CONCURRENTLY is not allowed).
+func TestMigrationCreatesEmailLookupIndexesConcurrently(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	for _, idx := range emailLookupIndexes {
+		pos := strings.Index(src, `"`+idx.name+`"`)
+		if pos < 0 {
+			t.Errorf("migrate.go must build %s (pass the name to execCreateIndexConcurrently so the INVALID-index self-heal can find it)", idx.name)
+			continue
+		}
+		window := src[max(0, pos-300):pos]
+		if !strings.Contains(window, "execCreateIndexConcurrently") {
+			t.Errorf("%s must be created via execCreateIndexConcurrently (non-blocking on live fleets, self-healing on interrupted builds), not a plain CREATE INDEX", idx.name)
+		}
+	}
+}
+
+// The v0.25.6 index-drop steps still run on every migrate (idempotent
+// history). The new indexes must not collide with ANY DROP INDEX target
+// in migrate.go — a name collision would drop-and-rebuild a ~2.5M-row
+// index on every single migrate run.
+func TestEmailLookupIndexNamesNotDropTargets(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	dropStmt := regexp.MustCompile(`(?i)DROP INDEX[^;` + "`" + `"]*`)
+	for _, stmt := range dropStmt.FindAllString(src, -1) {
+		for _, idx := range emailLookupIndexes {
+			if strings.Contains(stmt, idx.name) {
+				t.Errorf("%s appears in a DROP INDEX statement (%q) — historical drop steps run on every migrate, so this would rebuild the index each run; use a different name", idx.name, stmt)
+			}
+		}
+	}
+}
+
+// End-to-end (gated on AVELOXIS_TEST_DB): after Migrate, both indexes
+// exist on contributors and are valid.
+func TestContributorEmailLookupIndexesEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+	for _, idx := range emailLookupIndexes {
+		var valid bool
+		err := store.pool.QueryRow(ctx, `
+			SELECT x.indisvalid
+			FROM pg_index x
+			JOIN pg_class i ON i.oid = x.indexrelid
+			JOIN pg_class c ON c.oid = x.indrelid
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = 'aveloxis_data' AND c.relname = 'contributors' AND i.relname = $1`,
+			idx.name).Scan(&valid)
+		if err != nil {
+			t.Fatalf("%s missing after Migrate: %v", idx.name, err)
+		}
+		if !valid {
+			t.Errorf("%s exists but is INVALID — interrupted CONCURRENTLY build not self-healed", idx.name)
+		}
+	}
+}

--- a/internal/db/contributor_history_store.go
+++ b/internal/db/contributor_history_store.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/jackc/pgx/v5"
+)
+
+// contributor_history_store.go — store layer for the v0.27.58 daily
+// contributor activity history. One claim mechanism drives both the
+// bootstrap (gh_history_backfilled_at IS NULL — newly discovered
+// contributors are born NULL and stage themselves) and the quarterly
+// re-audit (stamp older than the cooldown; heals disclosure-toggle
+// flips and other retroactive changes).
+
+// GetContributorsForHistoryBackfill claims contributors for the daily
+// history sweep: never-backfilled first, then oldest — with
+// contributors whose trailing-year class shows activity
+// ('public-active' / 'private-active') prioritized ahead of the quiet
+// pool, because they're the rows the frontend renders. Same jittered
+// cooldown as breadth (the quarterly re-audit has the same cohort-echo
+// dynamics). Served by idx_contributors_history_backfilled.
+func (s *PostgresStore) GetContributorsForHistoryBackfill(ctx context.Context, limit int, cooldown time.Duration) ([]ActivityCheckContributor, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if cooldown <= 0 {
+		cooldown = 90 * 24 * time.Hour
+	}
+	claim := func(classFilter string, n int) ([]ActivityCheckContributor, error) {
+		rows, err := s.pool.Query(ctx, `
+			SELECT cntrb_id::text, gh_login
+			FROM aveloxis_data.contributors
+			WHERE gh_login IS NOT NULL
+			  AND gh_login != ''
+			  AND COALESCE(cntrb_deleted, 0) = 0
+			  `+classFilter+`
+			  AND (gh_history_backfilled_at IS NULL
+			       OR gh_history_backfilled_at < NOW() - ($2::interval * (1.0 - $3::float8 + random() * 2.0 * $3::float8)))
+			ORDER BY gh_history_backfilled_at ASC NULLS FIRST
+			LIMIT $1`, n, cooldown.String(), BreadthCooldownJitterFrac)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		var out []ActivityCheckContributor
+		for rows.Next() {
+			var c ActivityCheckContributor
+			if err := rows.Scan(&c.ID, &c.Login); err != nil {
+				return nil, err
+			}
+			out = append(out, c)
+		}
+		return out, rows.Err()
+	}
+	// Priority pass: active-classified contributors first.
+	out, err := claim(`AND gh_activity_class IN ('public-active', 'private-active')`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("history backfill claim (priority): %w", err)
+	}
+	if len(out) < limit {
+		seen := make(map[string]bool, len(out))
+		for _, c := range out {
+			seen[c.ID] = true
+		}
+		rest, err := claim(`AND gh_activity_class NOT IN ('public-active', 'private-active')`, limit-len(out))
+		if err != nil {
+			return nil, fmt.Errorf("history backfill claim (fallback): %w", err)
+		}
+		for _, c := range rest {
+			if !seen[c.ID] {
+				out = append(out, c)
+			}
+		}
+	}
+	return out, nil
+}
+
+// StoreContributorActivityHistory upserts a contributor's daily
+// history rows and calendar totals AND stamps gh_history_backfilled_at
+// in ONE transaction — data and its freshness stamp can never drift.
+// Upserts overwrite on the natural keys so the quarterly re-audit
+// heals in place. Rows for days that disappeared upstream (deleted
+// repos, disclosure changes) are left as historical record.
+func (s *PostgresStore) StoreContributorActivityHistory(ctx context.Context, cntrbID string, days []model.ContributorDayActivity, totals []model.ContributorDayTotal) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store activity history begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	b := &pgx.Batch{}
+	for _, d := range days {
+		b.Queue(`
+			INSERT INTO aveloxis_data.contributor_activity_days
+				(cntrb_id, day, repo_full_name, commit_count, issue_count, pr_count, review_count, fetched_at)
+			VALUES ($1::uuid, $2::date, $3, $4, $5, $6, $7, NOW())
+			ON CONFLICT (cntrb_id, day, repo_full_name) DO UPDATE SET
+				commit_count = EXCLUDED.commit_count,
+				issue_count  = EXCLUDED.issue_count,
+				pr_count     = EXCLUDED.pr_count,
+				review_count = EXCLUDED.review_count,
+				fetched_at   = NOW()`,
+			cntrbID, d.Day, d.RepoFullName, d.Commits, d.Issues, d.PRs, d.Reviews)
+	}
+	for _, dt := range totals {
+		b.Queue(`
+			INSERT INTO aveloxis_data.contributor_activity_day_totals
+				(cntrb_id, day, total_contributions, fetched_at)
+			VALUES ($1::uuid, $2::date, $3, NOW())
+			ON CONFLICT (cntrb_id, day) DO UPDATE SET
+				total_contributions = EXCLUDED.total_contributions,
+				fetched_at          = NOW()`,
+			cntrbID, dt.Day, dt.Total)
+	}
+	b.Queue(`UPDATE aveloxis_data.contributors SET gh_history_backfilled_at = NOW() WHERE cntrb_id = $1::uuid`, cntrbID)
+
+	br := tx.SendBatch(ctx, b)
+	for i := 0; i < len(days)+len(totals)+1; i++ {
+		if _, err := br.Exec(); err != nil {
+			_ = br.Close()
+			return fmt.Errorf("store activity history exec: %w", err)
+		}
+	}
+	if err := br.Close(); err != nil {
+		return fmt.Errorf("store activity history close: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// MarkHistoryBackfilled stamps the claim column WITHOUT writing data —
+// the path for contributors whose meta/history fetch found no account
+// (deleted/renamed). Marking unconditionally keeps dead-enders off the
+// NULLS-FIRST claim head (the v0.20.17 lesson).
+func (s *PostgresStore) MarkHistoryBackfilled(ctx context.Context, cntrbID string) error {
+	if _, err := s.pool.Exec(ctx, `
+		UPDATE aveloxis_data.contributors SET gh_history_backfilled_at = NOW() WHERE cntrb_id = $1::uuid`, cntrbID); err != nil {
+		return fmt.Errorf("mark history backfilled: %w", err)
+	}
+	return nil
+}

--- a/internal/db/contributor_history_store_test.go
+++ b/internal/db/contributor_history_store_test.go
@@ -86,7 +86,7 @@ func TestHistoryClaimContract(t *testing.T) {
 
 func TestActivityHistoryEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	cooldown := 90 * 24 * time.Hour
 
 	id := seedHistoryContributor(t, store, "_avhist_active", "public-active", "")

--- a/internal/db/contributor_history_store_test.go
+++ b/internal/db/contributor_history_store_test.go
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// contributor_history_store_test.go — TDD suite for the v0.27.58 daily
+// contributor-history store. Contracts:
+//   - two new tables (contributor_activity_days keyed (cntrb, day,
+//     repo_full_name); contributor_activity_day_totals keyed (cntrb,
+//     day)) with the house cntrb_id FK clause — repo_full_name is
+//     deliberately TEXT, not a repos FK: these are mostly repositories
+//     Aveloxis does not track;
+//   - claim: never-backfilled first, active-classified contributors
+//     prioritized, jittered quarterly cooldown;
+//   - StoreContributorActivityHistory writes rows AND the
+//     gh_history_backfilled_at stamp in ONE transaction (data and
+//     freshness can't drift); MarkHistoryBackfilled is the dataless
+//     path (deleted/renamed users).
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+func TestSchemaDeclaresActivityHistoryTables(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	flat := strings.Join(strings.Fields(schema), " ")
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_days",
+		"CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_day_totals",
+		"UNIQUE (cntrb_id, day, repo_full_name)",
+		"UNIQUE (cntrb_id, day)",
+	} {
+		if !strings.Contains(flat, needle) {
+			t.Errorf("schema.sql must contain %q", needle)
+		}
+	}
+	if !strings.Contains(flat, "idx_contributors_history_backfilled ON aveloxis_data.contributors (gh_history_backfilled_at ASC NULLS FIRST)") {
+		t.Error("the history claim needs idx_contributors_history_backfilled declared ASC NULLS FIRST (v0.27.8 lesson)")
+	}
+}
+
+func TestMigrateAddsActivityHistoryPieces(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	for _, needle := range []string{
+		"contributor_activity_days",
+		"contributor_activity_day_totals",
+		`"gh_history_backfilled_at"`,
+		"idx_contributors_history_backfilled",
+	} {
+		if !strings.Contains(src, needle) {
+			t.Errorf("migrate.go must handle %q for existing fleets", needle)
+		}
+	}
+}
+
+func TestHistoryClaimContract(t *testing.T) {
+	src := readSourceFile(t, "contributor_history_store.go")
+	idx := strings.Index(src, "func (s *PostgresStore) GetContributorsForHistoryBackfill(")
+	if idx < 0 {
+		t.Fatal("cannot find GetContributorsForHistoryBackfill")
+	}
+	body := src[idx:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	flat := strings.Join(strings.Fields(body), " ")
+	for _, needle := range []string{
+		"gh_history_backfilled_at IS NULL",
+		"ORDER BY gh_history_backfilled_at ASC NULLS FIRST",
+		"BreadthCooldownJitterFrac",
+		// Active-first bootstrap: contributors whose trailing-year class
+		// shows activity get their history first — they're the rows the
+		// frontend renders.
+		"'public-active'",
+		"'private-active'",
+	} {
+		if !strings.Contains(flat, needle) {
+			t.Errorf("history claim must contain %q", needle)
+		}
+	}
+}
+
+func TestActivityHistoryEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+	cooldown := 90 * 24 * time.Hour
+
+	id := seedHistoryContributor(t, store, "_avhist_active", "public-active", "")
+	quiet := seedHistoryContributor(t, store, "_avhist_quiet", "", "")
+	done := seedHistoryContributor(t, store, "_avhist_done", "public-active", "NOW()")
+
+	var poolN int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_data.contributors
+		WHERE gh_login IS NOT NULL AND gh_login != '' AND COALESCE(cntrb_deleted, 0) = 0`).Scan(&poolN); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := store.GetContributorsForHistoryBackfill(ctx, poolN+10, cooldown)
+	if err != nil {
+		t.Fatalf("GetContributorsForHistoryBackfill: %v", err)
+	}
+	pos := map[string]int{}
+	for i, c := range claimed {
+		pos[c.ID] = i + 1 // 1-based; 0 = absent
+	}
+	if pos[id] == 0 || pos[quiet] == 0 {
+		t.Fatal("never-backfilled contributors must be claimable")
+	}
+	if pos[done] != 0 {
+		t.Fatal("recently-backfilled contributor must be excluded by the cooldown")
+	}
+	if pos[id] > pos[quiet] {
+		t.Errorf("active-classified contributor must be claimed before unclassified quiet one (active pos %d, quiet pos %d)", pos[id], pos[quiet])
+	}
+
+	// Store history: rows + stamp in one call.
+	days := []model.ContributorDayActivity{
+		{Day: "2026-03-05", RepoFullName: "aveloxis/aveloxis", Commits: 4, Issues: 1},
+		{Day: "2026-03-06", RepoFullName: "chaoss/augur", PRs: 2, Reviews: 1},
+	}
+	totals := []model.ContributorDayTotal{{Day: "2026-03-05", Total: 9}, {Day: "2026-03-06", Total: 3}}
+	if err := store.StoreContributorActivityHistory(ctx, id, days, totals); err != nil {
+		t.Fatalf("StoreContributorActivityHistory: %v", err)
+	}
+	var commits, issues int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT commit_count, issue_count FROM aveloxis_data.contributor_activity_days
+		WHERE cntrb_id = $1::uuid AND day = '2026-03-05' AND repo_full_name = 'aveloxis/aveloxis'`,
+		id).Scan(&commits, &issues); err != nil {
+		t.Fatal(err)
+	}
+	if commits != 4 || issues != 1 {
+		t.Errorf("day row wrong: commits=%d issues=%d", commits, issues)
+	}
+	var total int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT total_contributions FROM aveloxis_data.contributor_activity_day_totals
+		WHERE cntrb_id = $1::uuid AND day = '2026-03-06'`, id).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("day total wrong: %d", total)
+	}
+
+	// Idempotent re-store (the quarterly re-audit path): same keys, new
+	// values overwrite, no duplicate-key error.
+	days[0].Commits = 7
+	if err := store.StoreContributorActivityHistory(ctx, id, days, totals); err != nil {
+		t.Fatalf("re-store must upsert cleanly: %v", err)
+	}
+	if err := store.pool.QueryRow(ctx, `
+		SELECT commit_count FROM aveloxis_data.contributor_activity_days
+		WHERE cntrb_id = $1::uuid AND day = '2026-03-05' AND repo_full_name = 'aveloxis/aveloxis'`,
+		id).Scan(&commits); err != nil {
+		t.Fatal(err)
+	}
+	if commits != 7 {
+		t.Errorf("re-store must overwrite: commits=%d want 7", commits)
+	}
+
+	// Dataless path + both leave the claim pool.
+	if err := store.MarkHistoryBackfilled(ctx, quiet); err != nil {
+		t.Fatalf("MarkHistoryBackfilled: %v", err)
+	}
+	claimed, err = store.GetContributorsForHistoryBackfill(ctx, poolN+10, cooldown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range claimed {
+		if c.ID == id || c.ID == quiet {
+			t.Errorf("contributor %s still claimable after store/mark", c.ID)
+		}
+	}
+}
+
+func seedHistoryContributor(t *testing.T, store *PostgresStore, login, class, backfilledSQL string) string {
+	t.Helper()
+	ctx := t.Context()
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_days WHERE cntrb_id IN (SELECT cntrb_id FROM aveloxis_data.contributors WHERE cntrb_login = $1)`, login)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_day_totals WHERE cntrb_id IN (SELECT cntrb_id FROM aveloxis_data.contributors WHERE cntrb_login = $1)`, login)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login = $1`, login)
+	stamp := "NULL"
+	if backfilledSQL != "" {
+		stamp = backfilledSQL
+	}
+	var id string
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.contributors
+			(cntrb_id, cntrb_login, gh_login, gh_activity_class, gh_history_backfilled_at, data_collection_date)
+		VALUES (gen_random_uuid(), $1, $1, $2, `+stamp+`, NOW())
+		RETURNING cntrb_id::text`, login, class).Scan(&id); err != nil {
+		t.Fatalf("seed %s: %v", login, err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_days WHERE cntrb_id = $1::uuid`, id)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributor_activity_day_totals WHERE cntrb_id = $1::uuid`, id)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_id = $1::uuid`, id)
+	})
+	return id
+}

--- a/internal/db/db_health_test.go
+++ b/internal/db/db_health_test.go
@@ -8,7 +8,7 @@ import "testing"
 // TestPingHealthyDB confirms Ping succeeds against a reachable database.
 func TestPingHealthyDB(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	if err := store.Ping(ctx); err != nil {
 		t.Fatalf("Ping on a healthy DB must succeed; got %v", err)
 	}

--- a/internal/db/email_message_store_test.go
+++ b/internal/db/email_message_store_test.go
@@ -70,7 +70,7 @@ func emConnect(t *testing.T) (*PostgresStore, context.Context) {
 
 func TestUpsertEmailMessageIsIdempotent(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const mid = "emtest-idem-<aaa@dev.kafka.apache.org>"
 	em := &model.EmailMessage{
@@ -106,7 +106,7 @@ func TestUpsertEmailMessageIsIdempotent(t *testing.T) {
 
 func TestResolveSignaledRepoForURL(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const url = "https://github.com/emtest-owner/emtest-resolve-repo"
 	const mid = "emtest-resolve-<bbb@github.arrow.apache.org>"
@@ -152,7 +152,7 @@ func TestResolveSignaledRepoForURL(t *testing.T) {
 
 func TestInsertEmailMessageRefIdempotent(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID, err := store.UpsertRepo(ctx, &model.Repo{
 		Platform: model.PlatformGitHub, GitURL: "https://github.com/emtest-owner/emtest-ref-repo",

--- a/internal/db/fk_extra_test.go
+++ b/internal/db/fk_extra_test.go
@@ -280,12 +280,14 @@ func TestSchemaDeclaresDeferredOnCntrbIDFKs(t *testing.T) {
 	code := string(src)
 	refTarget := "REFERENCES aveloxis_data.contributors(cntrb_id)"
 	occurrences := strings.Count(code, refTarget)
-	// v0.22.1 baseline: 16. v0.23.0 added contributor_login_history,
-	// bringing the total to 17. If you add another cntrb_id child
-	// table, bump this count AND add the entry to cntrbIDChildFKs in
-	// cntrb_id_cascade.go so the migration helper covers it.
-	if occurrences != 17 {
-		t.Fatalf("expected 17 cntrb_id FK occurrences in schema.sql, got %d — "+
+	// v0.22.1 baseline: 16. v0.23.0 added contributor_login_history
+	// (17). v0.27.58 added contributor_activity_days and
+	// contributor_activity_day_totals (19). If you add another
+	// cntrb_id child table, bump this count AND add the entry to
+	// cntrbIDChildFKs in cntrb_id_cascade.go so the migration helper
+	// covers it.
+	if occurrences != 19 {
+		t.Fatalf("expected 19 cntrb_id FK occurrences in schema.sql, got %d — "+
 			"if this changed, update both this test and the cntrb_id_cascade.go fixture", occurrences)
 	}
 	idx := 0

--- a/internal/db/home_store.go
+++ b/internal/db/home_store.go
@@ -170,6 +170,14 @@ func (s *PostgresStore) findOrCreateNamedGroup(ctx context.Context, userID int, 
 	return s.CreateUserGroup(ctx, userID, name)
 }
 
+// FindOrCreateUserGroupByName is the exported find-or-create for a
+// user's group by name (v0.27.63 — the collections copy flow lets the
+// caller name a fresh destination group). Same v0.19.0 status rules
+// as every other creation path.
+func (s *PostgresStore) FindOrCreateUserGroupByName(ctx context.Context, userID int, name string) (int64, error) {
+	return s.findOrCreateNamedGroup(ctx, userID, name)
+}
+
 // FindOrCreateStarredGroup returns the user's Starred group id,
 // creating the group on first use.
 func (s *PostgresStore) FindOrCreateStarredGroup(ctx context.Context, userID int) (int64, error) {

--- a/internal/db/mailinglist_mirror_test.go
+++ b/internal/db/mailinglist_mirror_test.go
@@ -29,7 +29,7 @@ func TestMirrorAndExternalKeyMethodsExist(t *testing.T) {
 
 func TestResolveMirrorLinkAndExternalKeyBackfill(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID, err := store.UpsertRepo(ctx, &model.Repo{
 		Platform: model.PlatformGitHub, GitURL: "https://github.com/apache/mirrortest",

--- a/internal/db/mailinglist_pr_equivalents_test.go
+++ b/internal/db/mailinglist_pr_equivalents_test.go
@@ -32,7 +32,7 @@ func TestMailingListPREquivalentsDeclaredNotRefreshed(t *testing.T) {
 // mail (discuss/issue_event) produces ZERO rows (the forge-less filter).
 func TestMailingListPREquivalents(t *testing.T) {
 	store, ctx := emConnect(t) // runs Migrate → creates the view
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const repoGit = "https://github.com/_av_pre/repo"
 	const list = "linux-pci@_av_pre.kernel.org"

--- a/internal/db/mailinglist_projection_backfill_test.go
+++ b/internal/db/mailinglist_projection_backfill_test.go
@@ -15,7 +15,7 @@ import (
 // lone discuss is marked mailing_list_only — and a re-run is a no-op.
 func TestBackfillMailingListProjection(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const (
 		repoGit = "https://github.com/_av_bf/repo"
@@ -126,7 +126,7 @@ func TestMlBackfillTitle(t *testing.T) {
 // (idempotent) and the two indexes exist afterward.
 func TestEnsureMailingListProjectionIndexes(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	lg := slog.New(slog.NewTextHandler(io.Discard, nil))
 	if err := store.EnsureMailingListProjectionIndexes(ctx, lg); err != nil {
 		t.Fatalf("ensure indexes: %v", err)

--- a/internal/db/mailinglist_projection_store_test.go
+++ b/internal/db/mailinglist_projection_store_test.go
@@ -57,7 +57,7 @@ func TestIssueNumberFromKey(t *testing.T) {
 // link-existing, plus the comment bridge + comment_count recompute, live.
 func TestLinkOrCreateIssueFromEmail(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const repoGit = "https://github.com/_av_proj/repo"
 	clean := func() {
@@ -159,7 +159,7 @@ func TestEmailMessageModelHasProjectionFields(t *testing.T) {
 // issue is reported; one without a native twin is not.
 func TestMailingListProjectionDuplicates(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const repoGit = "https://github.com/_av_dup/repo"
 	clean := func() {
@@ -218,7 +218,7 @@ func TestMailingListProjectionDuplicates(t *testing.T) {
 // issue carries only in its title — it skips the shadowed native issue instead.
 func TestBackfillExternalKeysConflictSafe(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const repoGit = "https://github.com/_av_bxk/repo"
 	clean := func() {
@@ -256,7 +256,7 @@ func TestBackfillExternalKeysConflictSafe(t *testing.T) {
 // winner-per-(repo,key) fix must key exactly one and not error.
 func TestBackfillExternalKeysSameStatementDup(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const repoGit = "https://github.com/_av_ssd/repo"
 	clean := func() {

--- a/internal/db/mailinglist_sender_resolve_store_test.go
+++ b/internal/db/mailinglist_sender_resolve_store_test.go
@@ -30,7 +30,7 @@ func TestSchemaDeclaresSenderResolveTable(t *testing.T) {
 // sender never appears; a DB-resolvable sender never appears.
 func TestSenderResolveCandidatesAndStamp(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const (
 		hot      = "_av_srhot@example.org"   // 6 messages, unresolvable → candidate
@@ -105,7 +105,7 @@ func TestSenderResolveCandidatesAndStamp(t *testing.T) {
 // and records the sender email as an alias.
 func TestLinkMailingListSenderCreatesContributorAndAlias(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const (
 		email = "_av_srlink@example.org"
@@ -143,7 +143,7 @@ func TestLinkMailingListSenderCreatesContributorAndAlias(t *testing.T) {
 // convergence ticker), idempotent on re-call, and gets an alias row.
 func TestCreateEmailOnlyContributor(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const email = "_av_eoc_human@example.org"
 	clean := func() {

--- a/internal/db/mailinglist_staging_store_test.go
+++ b/internal/db/mailinglist_staging_store_test.go
@@ -34,7 +34,7 @@ func mlsPtr(v int64) *int64 { return &v }
 // processed, plus idempotency of re-staging the same message.
 func TestMailingListStagingRoundTrip(t *testing.T) {
 	store, ctx := emConnect(t) // runs Migrate → creates mailing_list_staging
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const rgls = int64(999000111)
 	clean := func() {
@@ -111,7 +111,7 @@ func containsInt64(xs []int64, v int64) bool {
 // whose group HAS a repo is not (it can drain). summary/12 §11.
 func TestStuckMailingLists(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const (
 		stuckList  = "dev@_av_stuck.apache.org"

--- a/internal/db/mailinglist_state_store_test.go
+++ b/internal/db/mailinglist_state_store_test.go
@@ -59,7 +59,7 @@ func seedList(t *testing.T, store *PostgresStore, ctx context.Context, system, e
 
 func TestClaimNextListLifecycle(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const system = "mltest_lifecycle"
 	email := "dev@mltest-lifecycle.example.org"
@@ -115,7 +115,7 @@ func TestClaimNextListLifecycle(t *testing.T) {
 
 func TestRecoverStaleListLocks(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	rglsID := seedList(t, store, ctx, "mltest_stale", "dev@mltest-stale.example.org")
 	defer store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repo_groups_list_serve WHERE rgls_id=$1`, rglsID)
@@ -145,7 +145,7 @@ func TestRecoverStaleListLocks(t *testing.T) {
 
 func TestMailingListStatsSmoke(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	if _, err := store.MailingListStats(ctx); err != nil {
 		t.Errorf("MailingListStats should not error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestMailingListStatsSmoke(t *testing.T) {
 
 func TestRecordListFailureBacksOff(t *testing.T) {
 	store, ctx := emConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const system = "mltest_failure"
 	email := "dev@mltest-failure.example.org"

--- a/internal/db/message_heal_index_test.go
+++ b/internal/db/message_heal_index_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// v0.27.67 — the heal-messages "SELECT runs forever" fix (live
+// diagnosis 2026-08-01 on aveloxis_large): GetMessageHealBatch's
+// review-side LATERAL probes pull_request_review_message_ref by
+// msg_id, but the table's only msg_id-bearing index is
+// uq_pr_review_msg_ref (pr_review_id, msg_id) — pr_review_id leads,
+// so the probe walked all ~30.5M index entries as a FILTER. Measured:
+// 1.67s per probe × 546,081 pending worklist rows ≈ 10.5 DAYS for
+// one batch SELECT. Same class as v0.27.54's email-lookup indexes.
+
+// The index must exist in schema.sql (fresh installs) …
+func TestSchemaDeclaresReviewMsgRefMsgIDIndex(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	needle := "idx_pull_request_review_message_ref_msg_id"
+	if !strings.Contains(schema, needle) {
+		t.Fatalf("schema.sql must declare %s — without it GetMessageHealBatch's review-side probe filter-scans a 30.5M-entry index per worklist row", needle)
+	}
+	// NON-partial on purpose (the v0.27.54 lesson): the probe value
+	// is a JOIN variable (w.msg_id), and the planner cannot prove a
+	// partial predicate for join-variable probes at plan time — a
+	// partial variant would be ignored and the seq/filter scan would
+	// return. Pin the declaration shape.
+	idx := strings.Index(schema, needle)
+	decl := schema[idx:min(idx+220, len(schema))]
+	if strings.Contains(decl, "WHERE") {
+		t.Error("idx_pull_request_review_message_ref_msg_id must be NON-partial — join-variable probes can't use partial indexes (v0.27.54)")
+	}
+}
+
+// … and be built CONCURRENTLY by the migration for live fleets (a
+// blocking build on the 41 GB production table would stall writes).
+func TestMigrationBuildsReviewMsgRefMsgIDIndexConcurrently(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	idx := strings.Index(src, "idx_pull_request_review_message_ref_msg_id")
+	if idx < 0 {
+		t.Fatal("migrate.go must build idx_pull_request_review_message_ref_msg_id (execCreateIndexConcurrently) — schema.sql's plain form alone would build BLOCKING on existing fleets")
+	}
+	window := src[max(0, idx-400):min(idx+400, len(src))]
+	if !strings.Contains(window, "execCreateIndexConcurrently") {
+		t.Error("the index must be built via execCreateIndexConcurrently (self-healing INVALID cleanup + non-blocking)")
+	}
+	if !strings.Contains(window, "CONCURRENTLY") {
+		t.Error("the migration CREATE INDEX must use CONCURRENTLY")
+	}
+}
+
+// The name must never appear in a DROP INDEX step (the v0.27.54
+// name-collision tripwire: reusing a dropped name would rebuild the
+// index on every migrate).
+func TestReviewMsgRefMsgIDIndexNotADropTarget(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	for _, line := range strings.Split(src, "\n") {
+		if strings.Contains(line, "DROP INDEX") && strings.Contains(line, "idx_pull_request_review_message_ref_msg_id") {
+			t.Fatalf("idx_pull_request_review_message_ref_msg_id appears in a DROP INDEX step — pick a different name or the index rebuilds every migrate: %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1709,6 +1709,27 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		 SET dependency_scope = 'runtime'
 		 WHERE COALESCE(dependency_scope, '') = ''
 		   AND COALESCE(dependency_kind, '') <> 'self'`)
+
+	// v0.27.54: email/canonical lookup indexes for the mailing-list
+	// identity chain (sender-resolve candidates NOT EXISTS,
+	// ResolveContributorIDByEmail join, CreateEmailOnlyContributor
+	// probe). Without them the OR-equality anti-join seq-scanned the
+	// 9.4 GB contributors heap per outer row — 30-50 min hourly on 5
+	// backends (2026-07-29). The v0.25.6 "no reader" rationale for
+	// dropping the canonical index was obsoleted by v0.25.7+'s
+	// mailing-list readers — do not re-drop these in a future index
+	// audit. NEW names because the v0.25.6 DROP steps above still run
+	// on every migrate; reusing the dropped names would rebuild each
+	// run. NON-partial because the probes are join variables, which
+	// cannot prove a partial predicate at plan time.
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_contributors_email_lookup",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_email_lookup
+		 ON aveloxis_data.contributors (cntrb_email)`)
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_contributors_canonical_lookup",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_canonical_lookup
+		 ON aveloxis_data.contributors (cntrb_canonical)`)
 }
 
 // MigrateAdvisoryLockID is the postgres advisory-lock id used by

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1730,6 +1730,23 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		"aveloxis_data", "idx_contributors_canonical_lookup",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_canonical_lookup
 		 ON aveloxis_data.contributors (cntrb_canonical)`)
+
+	// v0.27.57: GitHub contribution-activity classification columns
+	// (GraphQL contributionsCollection — distinguishes publicly-active
+	// / privately-active-disclosed / dormant / no-observable-activity
+	// for contributors whose REST events feed is empty). GITHUB-ONLY;
+	// GitLab has no restrictedContributionsCount equivalent. The
+	// claim index is declared ASC NULLS FIRST per the v0.27.8 breadth
+	// lesson.
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_public_contribs_year", "INTEGER")
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_restricted_contribs_year", "INTEGER")
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_last_contribution_year", "INTEGER")
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_activity_class", "TEXT DEFAULT ''")
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_activity_checked_at", "TIMESTAMPTZ")
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_contributors_activity_checked",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_activity_checked
+		 ON aveloxis_data.contributors (gh_activity_checked_at ASC NULLS FIRST)`)
 }
 
 // MigrateAdvisoryLockID is the postgres advisory-lock id used by

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1804,6 +1804,19 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_added_at
 		 ON aveloxis_data.repos (added_at DESC)`)
 
+	// v0.27.67: msg_id probe index for heal-messages (live diagnosis
+	// 2026-08-01: GetMessageHealBatch's review-side LATERAL filter-
+	// scanned the 30.5M-entry uq_pr_review_msg_ref per worklist row —
+	// 1.67s/probe × 546K pending ≈ 10.5 days for one batch SELECT).
+	// CONCURRENTLY: the production table is 41 GB and a blocking
+	// build would stall the message writers. Operators can pre-create
+	// by hand via scripts/create_message_heal_index.sql — this step
+	// then no-ops via IF NOT EXISTS (the v0.27.54 pattern).
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_pull_request_review_message_ref_msg_id",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pull_request_review_message_ref_msg_id
+		 ON aveloxis_data.pull_request_review_message_ref (msg_id)`)
+
 	// v0.27.63: collections (admin-curated groups-of-groups) — same
 	// DDL as schema.sql so existing fleets pick the tables up on
 	// migrate. Both idempotent via IF NOT EXISTS.

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1838,6 +1838,16 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		    position      INT NOT NULL DEFAULT 0,
 		    PRIMARY KEY (collection_id, group_id)
 		)`)
+
+	// v0.27.70: per-user collection stars.
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.70 create aveloxis_ops.user_collection_stars",
+		`CREATE TABLE IF NOT EXISTS aveloxis_ops.user_collection_stars (
+		    user_id       INT NOT NULL REFERENCES aveloxis_ops.users(user_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+		    collection_id BIGINT NOT NULL REFERENCES aveloxis_ops.collections(collection_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+		    starred_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		    PRIMARY KEY (user_id, collection_id)
+		)`)
 }
 
 // MigrateAdvisoryLockID is the postgres advisory-lock id used by

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1747,6 +1747,38 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		"aveloxis_data", "idx_contributors_activity_checked",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_activity_checked
 		 ON aveloxis_data.contributors (gh_activity_checked_at ASC NULLS FIRST)`)
+
+	// v0.27.58: daily contributor activity history (see schema.sql for
+	// the design rationale — TEXT repo names on purpose, no repos FK).
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.contributors", "gh_history_backfilled_at", "TIMESTAMPTZ")
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.58 create contributor_activity_days",
+		`CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_days (
+			activity_day_id BIGSERIAL PRIMARY KEY,
+			cntrb_id        UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+			day             DATE NOT NULL,
+			repo_full_name  TEXT NOT NULL,
+			commit_count    INTEGER NOT NULL DEFAULT 0,
+			issue_count     INTEGER NOT NULL DEFAULT 0,
+			pr_count        INTEGER NOT NULL DEFAULT 0,
+			review_count    INTEGER NOT NULL DEFAULT 0,
+			fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (cntrb_id, day, repo_full_name)
+		)`)
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.58 create contributor_activity_day_totals",
+		`CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_day_totals (
+			activity_total_id   BIGSERIAL PRIMARY KEY,
+			cntrb_id            UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+			day                 DATE NOT NULL,
+			total_contributions INTEGER NOT NULL DEFAULT 0,
+			fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (cntrb_id, day)
+		)`)
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_contributors_history_backfilled",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_history_backfilled
+		 ON aveloxis_data.contributors (gh_history_backfilled_at ASC NULLS FIRST)`)
 }
 
 // MigrateAdvisoryLockID is the postgres advisory-lock id used by

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1779,6 +1779,52 @@ func migrateStage10RecentReleases(ctx context.Context, pg *PostgresStore, logger
 		"aveloxis_data", "idx_contributors_history_backfilled",
 		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_history_backfilled
 		 ON aveloxis_data.contributors (gh_history_backfilled_at ASC NULLS FIRST)`)
+
+	// v0.27.60: stable fleet-entry timestamp for the new-repositories
+	// feeds. ORDER IS LOAD-BEARING: (1) bare column add — a STABLE
+	// DEFAULT at add-time would stamp every legacy row with the
+	// migration timestamp via attmissingval; (2) backfill legacy rows
+	// from data_collection_date (an HONEST last-touch approximation —
+	// collection_queue has no created-at to do better; feeds are noisy
+	// for one window post-deploy, which is why this ships ahead of the
+	// endpoint); (3) only then the NOW() default for future inserts.
+	// added_at is deliberately absent from UpsertRepo's DO UPDATE SET
+	// (insert-only contract, pinned).
+	addColumnIfMissing(ctx, pg, logger, errs, "aveloxis_data.repos", "added_at", "TIMESTAMPTZ")
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.60 backfill repos.added_at from data_collection_date (last-touch approximation)",
+		`UPDATE aveloxis_data.repos
+		 SET added_at = COALESCE(data_collection_date, created_at, NOW())
+		 WHERE added_at IS NULL`)
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.60 default repos.added_at to NOW() for future inserts",
+		`ALTER TABLE aveloxis_data.repos ALTER COLUMN added_at SET DEFAULT NOW()`)
+	execCreateIndexConcurrently(ctx, pg, logger, errs,
+		"aveloxis_data", "idx_repos_added_at",
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repos_added_at
+		 ON aveloxis_data.repos (added_at DESC)`)
+
+	// v0.27.63: collections (admin-curated groups-of-groups) — same
+	// DDL as schema.sql so existing fleets pick the tables up on
+	// migrate. Both idempotent via IF NOT EXISTS.
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.63 create aveloxis_ops.collections",
+		`CREATE TABLE IF NOT EXISTS aveloxis_ops.collections (
+		    collection_id BIGSERIAL PRIMARY KEY,
+		    name          TEXT NOT NULL UNIQUE,
+		    description   TEXT NOT NULL DEFAULT '',
+		    position      INT NOT NULL DEFAULT 0,
+		    created_by    INT REFERENCES aveloxis_ops.users(user_id) DEFERRABLE INITIALLY DEFERRED,
+		    created_at    TIMESTAMPTZ DEFAULT NOW()
+		)`)
+	execMigrationStep(ctx, pg, logger, errs,
+		"v0.27.63 create aveloxis_ops.collection_groups",
+		`CREATE TABLE IF NOT EXISTS aveloxis_ops.collection_groups (
+		    collection_id BIGINT NOT NULL REFERENCES aveloxis_ops.collections(collection_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+		    group_id      BIGINT NOT NULL REFERENCES aveloxis_ops.user_groups(group_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+		    position      INT NOT NULL DEFAULT 0,
+		    PRIMARY KEY (collection_id, group_id)
+		)`)
 }
 
 // MigrateAdvisoryLockID is the postgres advisory-lock id used by

--- a/internal/db/migrate_integration_test.go
+++ b/internal/db/migrate_integration_test.go
@@ -90,7 +90,7 @@ func TestRunMigrationsOnFreshDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPostgresStore: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	// Run migrations. Any non-nil return means at least one
 	// schema-changing step failed. The error message includes
@@ -148,7 +148,7 @@ func TestRunMigrationsIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPostgresStore: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	if err := RunMigrations(ctx, store, logger); err != nil {
 		t.Fatalf("first RunMigrations: %v", err)

--- a/internal/db/new_repos_store.go
+++ b/internal/db/new_repos_store.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// NewRepo is one row in the home page's "New Repositories" feed
+// (v0.27.62): a repo that entered the fleet since the window start.
+type NewRepo struct {
+	RepoID  int64     `json:"repo_id"`
+	Owner   string    `json:"owner"`
+	Name    string    `json:"name"`
+	Org     string    `json:"org"`
+	AddedAt time.Time `json:"added_at"`
+}
+
+// newReposArmSQL builds one feed arm. The org set differs per arm —
+// fleet = orgs registered by ADMIN users (the "curated fleet" signal:
+// on the production deployment that is the operator's org tracking,
+// generalized to every admin); mine = orgs the CALLER registered —
+// but both share every other gate:
+//
+//   - the org's owning group is not 'rejected' (v0.27.20: RejectGroup
+//     is the abuse lever; a rejected group's orgs surface nowhere),
+//   - repos.added_at >= window start (the v0.27.60 fleet-entry stamp;
+//     pre-v0.27.60 rows carry a last-touch approximation — the feed
+//     is honest-noisy for one window after that deploy, by design),
+//   - archived repos excluded,
+//   - owner ↔ org matching is case-insensitive (GitHub logins are
+//     case-preserving but case-insensitive; org_url casing is
+//     whatever the registrant typed). KNOWN v1 EDGE: GitLab nested
+//     group paths ("group/subgroup") won't equal repo_owner and fall
+//     out of the feed silently — accepted in the plan.
+//
+// org_url is "https://host/org", so SPLIT_PART(…, '/', 4) is the org
+// login.
+const newReposArmSQL = `
+WITH org_set AS (
+    SELECT DISTINCT LOWER(SPLIT_PART(uor.org_url, '/', 4)) AS org_login
+    FROM aveloxis_ops.user_org_requests uor
+    JOIN aveloxis_ops.users u ON u.user_id = uor.user_id
+    JOIN aveloxis_ops.user_groups g ON g.group_id = uor.group_id
+    WHERE COALESCE(g.status, 'approved') <> 'rejected'
+      AND %s
+)
+SELECT r.repo_id, r.repo_owner, r.repo_name, os.org_login, r.added_at
+FROM aveloxis_data.repos r
+JOIN org_set os ON LOWER(r.repo_owner) = os.org_login
+WHERE r.added_at >= $1
+  AND NOT COALESCE(r.repo_archived, FALSE)
+ORDER BY r.added_at DESC, r.repo_id DESC
+LIMIT $2`
+
+// GetNewRepos returns the two "New Repositories" feed arms for userID:
+// fleet (admin-registered orgs) and mine (the caller's own orgs), each
+// newest-first and capped at limit rows. A repo under an org that is
+// both admin-registered AND the caller's own appears in both arms —
+// the frontend labels, it doesn't dedupe.
+func (s *PostgresStore) GetNewRepos(ctx context.Context, userID int, since time.Time, limit int) (fleet, mine []NewRepo, err error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	run := func(predicate string, args ...any) ([]NewRepo, error) {
+		sql := fmt.Sprintf(newReposArmSQL, predicate)
+		rows, err := s.pool.Query(ctx, sql, args...)
+		if err != nil {
+			return nil, fmt.Errorf("GetNewRepos query: %w", err)
+		}
+		defer rows.Close()
+		out := make([]NewRepo, 0, 32)
+		for rows.Next() {
+			var nr NewRepo
+			if err := rows.Scan(&nr.RepoID, &nr.Owner, &nr.Name, &nr.Org, &nr.AddedAt); err != nil {
+				return nil, fmt.Errorf("GetNewRepos scan: %w", err)
+			}
+			out = append(out, nr)
+		}
+		return out, rows.Err()
+	}
+
+	// Fleet arm: orgs registered by any admin user.
+	fleet, err = run("u.admin", since, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Mine arm: orgs THIS user registered (admin or not).
+	mine, err = run("uor.user_id = $3", since, limit, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return fleet, mine, nil
+}

--- a/internal/db/new_repos_store_test.go
+++ b/internal/db/new_repos_store_test.go
@@ -59,7 +59,7 @@ func TestGetNewReposOwnerMatchCaseInsensitive(t *testing.T) {
 
 func TestGetNewReposEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	clean := func() {
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_org_requests WHERE org_url LIKE 'https://github.com/_avnewr%'`)

--- a/internal/db/new_repos_store_test.go
+++ b/internal/db/new_repos_store_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// v0.27.62 — GetNewRepos: the "New Repositories" home feed. Fleet arm
+// = repos added since the window start whose owner matches an org
+// registered by an ADMIN user (the "main user" generalized) with a
+// non-rejected owning group; mine arm = same, filtered to orgs the
+// CALLER registered. Source pins on the two gating decisions, then an
+// integration test that seeds both arms.
+
+func newReposSQL(t *testing.T) string {
+	t.Helper()
+	src := readSourceFile(t, "new_repos_store.go")
+	if !strings.Contains(src, "func (s *PostgresStore) GetNewRepos(") {
+		t.Fatal("GetNewRepos missing from new_repos_store.go")
+	}
+	return src
+}
+
+// The fleet arm is gated on ADMIN-registered orgs (u.admin) whose
+// owning group is not rejected — the same rejected-group refusal the
+// org-scan paths honor (v0.27.20: RejectGroup is the abuse lever, so
+// a rejected group's orgs must not surface anywhere).
+func TestGetNewReposFleetArmGating(t *testing.T) {
+	src := newReposSQL(t)
+	if !strings.Contains(src, "u.admin") {
+		t.Error("fleet arm must gate on users.admin (admin-registered orgs only)")
+	}
+	if !strings.Contains(src, "<> 'rejected'") {
+		t.Error("org set must exclude orgs whose owning group is rejected")
+	}
+	if !strings.Contains(src, "added_at") {
+		t.Error("feed must window on repos.added_at (v0.27.60)")
+	}
+	if !strings.Contains(src, "repo_archived") {
+		t.Error("archived repos don't belong in a new-repos feed")
+	}
+}
+
+// Owner matching is case-insensitive: GitHub org logins are
+// case-preserving but case-insensitive, and org_url casing is
+// whatever the registrant typed.
+func TestGetNewReposOwnerMatchCaseInsensitive(t *testing.T) {
+	src := newReposSQL(t)
+	if !strings.Contains(src, "LOWER(r.repo_owner)") {
+		t.Error("owner ↔ org matching must be case-insensitive (LOWER on both sides)")
+	}
+}
+
+// ─── Integration (AVELOXIS_TEST_DB) ─────────────────────────────
+
+func TestGetNewReposEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	clean := func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_org_requests WHERE org_url LIKE 'https://github.com/_avnewr%'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_groups WHERE name LIKE '_avnewr%'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner ILIKE '_avnewr%'`)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.users WHERE login_name LIKE '_avnewr%'`)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	var adminID, plainID int
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ('_avnewr_admin', TRUE) RETURNING user_id`).Scan(&adminID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, admin) VALUES ('_avnewr_plain', FALSE) RETURNING user_id`).Scan(&plainID); err != nil {
+		t.Fatal(err)
+	}
+
+	mkGroup := func(userID int, name, status string) int64 {
+		var gid int64
+		if err := store.pool.QueryRow(ctx, `
+			INSERT INTO aveloxis_ops.user_groups (user_id, name, status)
+			VALUES ($1, $2, $3) RETURNING group_id`, userID, name, status).Scan(&gid); err != nil {
+			t.Fatal(err)
+		}
+		return gid
+	}
+	adminGroup := mkGroup(adminID, "_avnewr_admingrp", "approved")
+	plainGroup := mkGroup(plainID, "_avnewr_plaingrp", "approved")
+	rejGroup := mkGroup(adminID, "_avnewr_rejgrp", "rejected")
+
+	mkOrg := func(userID int, gid int64, org string) {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_ops.user_org_requests (user_id, group_id, org_url, org_name)
+			VALUES ($1, $2, $3, $4)`, userID, gid, "https://github.com/"+org, org); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkOrg(adminID, adminGroup, "_avnewr_fleetorg")
+	mkOrg(plainID, plainGroup, "_avnewr_mineorg")
+	mkOrg(adminID, rejGroup, "_avnewr_rejorg")
+
+	mkRepo := func(owner, name string, age time.Duration) {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id, added_at)
+			VALUES ($1, $2, $3, 1, NOW() - $4::interval)`,
+			"https://github.com/"+owner+"/"+name, owner, name, age.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Case-variant owner spelling proves the LOWER match.
+	mkRepo("_AVNEWR_fleetorg", "fresh", 24*time.Hour)
+	mkRepo("_avnewr_fleetorg", "stale", 200*24*time.Hour) // outside any window
+	mkRepo("_avnewr_mineorg", "mine1", 24*time.Hour)
+	mkRepo("_avnewr_rejorg", "hidden", 24*time.Hour) // rejected group → never surfaces
+
+	since := time.Now().AddDate(0, 0, -30)
+
+	// Plain user: fleet = admin-org repos (fresh only), mine = their own
+	// org's repo. The rejected-group org must appear in NEITHER.
+	fleet, mine, err := store.GetNewRepos(ctx, plainID, since, 100)
+	if err != nil {
+		t.Fatalf("GetNewRepos: %v", err)
+	}
+	find := func(rows []NewRepo, name string) bool {
+		for _, r := range rows {
+			if r.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !find(fleet, "fresh") {
+		t.Errorf("fleet arm must include the fresh admin-org repo (case-variant owner): %+v", fleet)
+	}
+	if find(fleet, "stale") {
+		t.Error("fleet arm must window on added_at — 200-day-old repo leaked in")
+	}
+	if find(fleet, "hidden") || find(mine, "hidden") {
+		t.Error("rejected-group org repos must never surface")
+	}
+	if find(fleet, "mine1") {
+		t.Error("fleet arm is admin-registered orgs only — plain user's org leaked in")
+	}
+	if !find(mine, "mine1") {
+		t.Errorf("mine arm must include the caller's own org repos: %+v", mine)
+	}
+	if find(mine, "fresh") {
+		t.Error("mine arm is the CALLER's orgs only")
+	}
+}

--- a/internal/db/org_demand_probe_test.go
+++ b/internal/db/org_demand_probe_test.go
@@ -56,7 +56,7 @@ func TestHasNeverScannedOrgsBehavior(t *testing.T) {
 		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
 	}
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	const slug = "_avdemandprobe"
 	cleanup := func() {

--- a/internal/db/portal_store.go
+++ b/internal/db/portal_store.go
@@ -4,41 +4,49 @@
 package db
 
 // v0.27.3 — small store helpers for the portal JSON endpoints.
-// v0.27.14 — the group listing paginates (limit/offset + total) so
-// fleet-scale groups don't ship thousands of rows per render. The
-// per-row count columns (annotated by the API layer from
-// GetRepoStatsBatch) are ALL-TIME totals from the latest repo_info
-// snapshot — deliberately NOT a 90-day activity query, which is the
-// v0.27.4 nginx-timeout class at fleet scale.
+// v0.27.14 — the group listing paginates (page/page_size + total) so
+// fleet-scale groups don't ship thousands of rows per render.
+// v0.27.75 — the group listing adopts the COLLECTIONS table grammar
+// (operator request 2026-08-02, "same columns as the Collections
+// listing"): per-row cached issue/PR/commit counts from the queue's
+// cumulative totals (v0.19.11/v0.21.2 — never per-request
+// aggregation, the v0.27.4 nginx-timeout class), last_collected, the
+// forge-reported last_activity via the repo_info LATERAL, and the
+// caller's starred flag, with server-side sort through the SAME
+// collectionRepoSorts allowlist GetCollectionRepos uses — the two
+// tables can never disagree on what a sort key means.
 
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 )
 
 // PortalGroupRepo is one repo inside a user group, for the group page.
-// The *_all_time counts and Starred are filled by the API layer per
-// PAGE (GetRepoStatsBatch + GetUserStarredRepoIDs), never here — the
-// store returns the bare listing slice.
+// Same row shape as CollectionRepo (v0.27.74) so the two GUI tables
+// render identically.
 type PortalGroupRepo struct {
 	RepoID int64  `json:"repo_id"`
 	Owner  string `json:"owner"`
 	Name   string `json:"name"`
 	GitURL string `json:"git_url"`
-	// All-time totals from the latest repo_info snapshot (the forge's
-	// own reported counts) — labeled all_time so the GUI says so.
-	CommitsAllTime int  `json:"commits_all_time"`
-	IssuesAllTime  int  `json:"issues_all_time"`
-	PRsAllTime     int  `json:"prs_all_time"`
-	Starred        bool `json:"starred"`
+	// Cached cumulative gathered counts from collection_queue — the
+	// values the monitor renders, refreshed by CompleteJob.
+	Issues        int64      `json:"issues"`
+	PRs           int64      `json:"prs"`
+	Commits       int64      `json:"commits"`
+	LastCollected *time.Time `json:"last_collected,omitempty"`
+	LastActivity  *time.Time `json:"last_activity,omitempty"`
+	Starred       bool       `json:"starred"`
 }
 
 // GetPortalGroupReposForUser lists one page of a group's repos plus
 // the group's TOTAL repo count (for the pager), enforcing ownership:
-// non-admin callers may only read their own groups. limit/offset
-// slice the (repo_owner, repo_name)-ordered listing; limit <= 0 means
-// no limit (offset still applies).
-func (s *PostgresStore) GetPortalGroupReposForUser(ctx context.Context, userID int, groupID int64, isAdmin bool, limit, offset int) ([]PortalGroupRepo, int, error) {
+// non-admin callers may only read their own groups. sortKey/sortDir
+// resolve through the collectionRepoSorts ALLOWLIST before any
+// interpolation — unknown values fall back to name asc.
+func (s *PostgresStore) GetPortalGroupReposForUser(ctx context.Context, userID int, groupID int64, isAdmin bool, page, pageSize int, sortKey, sortDir string) ([]PortalGroupRepo, int, error) {
 	if !isAdmin {
 		var owner int
 		err := s.pool.QueryRow(ctx,
@@ -47,29 +55,63 @@ func (s *PostgresStore) GetPortalGroupReposForUser(ctx context.Context, userID i
 			return nil, 0, fmt.Errorf("group %d is not yours", groupID)
 		}
 	}
+	if page < 1 {
+		page = 1
+	}
+	// Two bare single-comparison clamps, NOT one compound condition —
+	// the CodeQL go/uncontrolled-allocation-size barrier shape
+	// (v0.27.65 lesson).
+	if pageSize < 1 {
+		pageSize = 50
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
 	var total int
 	if err := s.pool.QueryRow(ctx,
 		`SELECT COUNT(*) FROM aveloxis_ops.user_repos WHERE group_id = $1`, groupID).Scan(&total); err != nil {
 		return nil, 0, err
 	}
-	if offset < 0 {
-		offset = 0
+	sortExpr, ok := collectionRepoSorts[sortKey]
+	if !ok {
+		sortExpr = collectionRepoSorts["name"]
 	}
+	dir := "ASC"
+	if sortDir == "desc" {
+		dir = "DESC"
+	}
+	orderBy := strings.ReplaceAll(sortExpr, "%s", dir) + ", r.repo_id"
+
 	rows, err := s.pool.Query(ctx, `
-		SELECT r.repo_id, r.repo_owner, r.repo_name, r.repo_git
+		SELECT r.repo_id, r.repo_owner, r.repo_name, r.repo_git,
+		       COALESCE(q.last_issues, 0), COALESCE(q.last_prs, 0), COALESCE(q.last_commits, 0),
+		       q.last_collected, ri.last_updated,
+		       (ucs.user_id IS NOT NULL) AS starred
 		FROM aveloxis_ops.user_repos ur
-		JOIN aveloxis_data.repos r USING (repo_id)
+		JOIN aveloxis_data.repos r ON r.repo_id = ur.repo_id
+		LEFT JOIN aveloxis_ops.collection_queue q ON q.repo_id = r.repo_id
+		LEFT JOIN LATERAL (
+			SELECT last_updated FROM aveloxis_data.repo_info
+			WHERE repo_id = r.repo_id
+			ORDER BY data_collection_date DESC LIMIT 1
+		) ri ON TRUE
+		LEFT JOIN aveloxis_ops.user_repo_stars ucs
+			ON ucs.repo_id = r.repo_id AND ucs.user_id = $2
 		WHERE ur.group_id = $1
-		ORDER BY r.repo_owner, r.repo_name, r.repo_id
-		LIMIT NULLIF($2, 0) OFFSET $3`, groupID, max(limit, 0), offset)
+		ORDER BY `+orderBy+`
+		LIMIT $3 OFFSET $4`, groupID, userID, pageSize, (page-1)*pageSize)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer rows.Close()
-	var out []PortalGroupRepo
+	// CONSTANT capacity hint — never `pageSize` (the CodeQL
+	// go/uncontrolled-allocation-size rule doesn't credit clamps as
+	// barriers; v0.27.66).
+	out := make([]PortalGroupRepo, 0, 50)
 	for rows.Next() {
 		var g PortalGroupRepo
-		if err := rows.Scan(&g.RepoID, &g.Owner, &g.Name, &g.GitURL); err != nil {
+		if err := rows.Scan(&g.RepoID, &g.Owner, &g.Name, &g.GitURL,
+			&g.Issues, &g.PRs, &g.Commits, &g.LastCollected, &g.LastActivity, &g.Starred); err != nil {
 			return nil, 0, err
 		}
 		out = append(out, g)

--- a/internal/db/portal_store_integration_test.go
+++ b/internal/db/portal_store_integration_test.go
@@ -60,15 +60,15 @@ func TestGetPortalGroupReposForUserOwnership(t *testing.T) {
 	})
 
 	// Owner reads own (empty) group fine.
-	if _, _, err := store.GetPortalGroupReposForUser(ctx, ownerID, groupID, false, 50, 0); err != nil {
+	if _, _, err := store.GetPortalGroupReposForUser(ctx, ownerID, groupID, false, 1, 50, "", ""); err != nil {
 		t.Errorf("owner must be able to read own group: %v", err)
 	}
 	// Stranger is refused.
-	if _, _, err := store.GetPortalGroupReposForUser(ctx, strangerID, groupID, false, 50, 0); err == nil {
+	if _, _, err := store.GetPortalGroupReposForUser(ctx, strangerID, groupID, false, 1, 50, "", ""); err == nil {
 		t.Error("non-owner non-admin must NOT be able to read another user's group")
 	}
 	// Admin bypasses ownership.
-	if _, _, err := store.GetPortalGroupReposForUser(ctx, strangerID, groupID, true, 50, 0); err != nil {
+	if _, _, err := store.GetPortalGroupReposForUser(ctx, strangerID, groupID, true, 1, 50, "", ""); err != nil {
 		t.Errorf("admin must be able to read any group: %v", err)
 	}
 
@@ -152,14 +152,14 @@ func TestGetPortalGroupReposPagination(t *testing.T) {
 		}
 	})
 
-	page1, total, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 2, 0)
+	page1, total, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 1, 2, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(page1) != 2 || total != 3 {
 		t.Errorf("page 1: want 2 repos of total 3, got %d of %d", len(page1), total)
 	}
-	page2, total, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 2, 2)
+	page2, total, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 2, 2, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,5 +170,73 @@ func TestGetPortalGroupReposPagination(t *testing.T) {
 	if len(page1) == 2 && len(page2) == 1 &&
 		(page1[0].RepoID == page2[0].RepoID || page1[1].RepoID == page2[0].RepoID) {
 		t.Error("pages must be disjoint slices of the ordered listing")
+	}
+
+	// ─── v0.27.75: the collections table grammar on the group page ───
+	// Cached queue counts + last_collected surface per row; sort keys
+	// resolve through the shared allowlist; the caller's stars ride
+	// along; hostile sort keys fall back instead of erroring.
+	for i, seed := range []struct {
+		issues, prs, commits int64
+	}{{10, 5, 100}, {30, 2, 50}, {20, 9, 75}} {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_ops.collection_queue (repo_id, status, last_issues, last_prs, last_commits, last_collected)
+			VALUES ($1, 'queued', $2, $3, $4, NOW())
+			ON CONFLICT (repo_id) DO UPDATE SET last_issues = $2, last_prs = $3, last_commits = $4, last_collected = NOW()`,
+			repoIDs[i], seed.issues, seed.prs, seed.commits); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN ($1,$2,$3)`, repoIDs[0], repoIDs[1], repoIDs[2])
+	})
+	if err := store.StarRepo(ctx, userID, repoIDs[2]); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.user_repo_stars WHERE user_id = $1`, userID)
+	})
+	sorted, _, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 1, 50, "issues", "desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sorted) != 3 || sorted[0].RepoID != repoIDs[1] || sorted[0].Issues != 30 {
+		t.Errorf("issues-desc sort: first row = %+v, want repo %d with 30 issues", sorted[0], repoIDs[1])
+	}
+	if sorted[0].LastCollected == nil {
+		t.Error("last_collected must surface from the queue row")
+	}
+	for _, row := range sorted {
+		if row.RepoID == repoIDs[2] && !row.Starred {
+			t.Error("starred repo must carry the caller's starred flag")
+		}
+		if row.RepoID == repoIDs[0] && row.Starred {
+			t.Error("unstarred repo must not be starred")
+		}
+	}
+	// A DIFFERENT caller (admin read) sees their own star state, not
+	// the owner's.
+	var adminID int
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_ops.users (login_name, oauth_provider, email, admin)
+		VALUES ($1, 'github', '', TRUE) RETURNING user_id`,
+		fmt.Sprintf("_avpage_admin_%d", suffix)).Scan(&adminID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.users WHERE user_id = $1`, adminID)
+	})
+	adminView, _, err := store.GetPortalGroupReposForUser(ctx, adminID, groupID, true, 1, 50, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range adminView {
+		if row.Starred {
+			t.Error("stars are per-caller — the admin never starred anything here")
+		}
+	}
+	// A hostile sort key falls back to the default order, no SQL error.
+	if _, _, err := store.GetPortalGroupReposForUser(ctx, userID, groupID, false, 1, 50, "evil; DROP TABLE x", "desc"); err != nil {
+		t.Errorf("unknown sort key must fall back to the default, got error: %v", err)
 	}
 }

--- a/internal/db/public_stats_store.go
+++ b/internal/db/public_stats_store.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import "context"
+
+// CountActiveRepos returns the number of non-archived repositories in
+// the catalog — the landing page's "N repositories under analysis"
+// number (v0.27.59). Exact COUNT(*) on purpose: repos is ~100K rows
+// (tens of milliseconds), and pg_class estimates cannot filter the
+// archived cohort. Callers cache (60s, stale-on-error in the api
+// layer), so this runs at most once a minute regardless of traffic.
+func (s *PostgresStore) CountActiveRepos(ctx context.Context) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM aveloxis_data.repos WHERE NOT COALESCE(repo_archived, FALSE)`).Scan(&n)
+	return n, err
+}

--- a/internal/db/public_stats_store.go
+++ b/internal/db/public_stats_store.go
@@ -5,15 +5,22 @@ package db
 
 import "context"
 
-// CountActiveRepos returns the number of non-archived repositories in
-// the catalog — the landing page's "N repositories under analysis"
-// number (v0.27.59). Exact COUNT(*) on purpose: repos is ~100K rows
-// (tens of milliseconds), and pg_class estimates cannot filter the
-// archived cohort. Callers cache (60s, stale-on-error in the api
+// CountActiveRepos returns the TOTAL number of repositories in the
+// catalog — the landing page's "N repositories under analysis" number.
+//
+// v0.27.68 (operator decision 2026-08-01): archived repos COUNT.
+// v0.27.59 excluded them ("read-only isn't under analysis"), but that
+// made the landing number (74,317) visibly disagree with the monitor
+// (~94K queue rows) — a definition mismatch that reads as a bug to
+// anyone who sees both. Archived repos carry full collected history,
+// SBOMs, and vulnerability data; "under analysis" includes them.
+//
+// Exact COUNT(*) on purpose: repos is ~100K rows (tens of
+// milliseconds). Callers cache (60s, stale-on-error in the api
 // layer), so this runs at most once a minute regardless of traffic.
 func (s *PostgresStore) CountActiveRepos(ctx context.Context) (int, error) {
 	var n int
 	err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM aveloxis_data.repos WHERE NOT COALESCE(repo_archived, FALSE)`).Scan(&n)
+		`SELECT COUNT(*) FROM aveloxis_data.repos`).Scan(&n)
 	return n, err
 }

--- a/internal/db/public_stats_store_test.go
+++ b/internal/db/public_stats_store_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCountActiveReposPredicate (v0.27.59): the landing-page count must
+// exclude archived repositories. Deterministic under parallel test
+// packages (a global before/after count-delta races concurrent
+// inserts into the shared scratch DB — the original form of this test
+// flaked exactly that way): pin the method's predicate at the source
+// level, then prove that predicate's behavior on seeded rows with a
+// scoped query.
+func TestCountActiveReposPredicate(t *testing.T) {
+	src := readSourceFile(t, "public_stats_store.go")
+	if !strings.Contains(src, "NOT COALESCE(repo_archived, FALSE)") {
+		t.Fatal("CountActiveRepos must filter NOT COALESCE(repo_archived, FALSE) — archived repos are read-only and don't belong in 'repositories under analysis'")
+	}
+}
+
+func TestCountActiveReposExcludesArchived(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcount'`)
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id, repo_archived) VALUES
+		('https://github.com/_avcount/active',   '_avcount', 'active',   1, FALSE),
+		('https://github.com/_avcount/archived', '_avcount', 'archived', 1, TRUE)`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcount'`)
+	})
+
+	// The exact predicate the method is pinned to, scoped to the seeded
+	// cohort: exactly the active row survives.
+	var n int
+	if err := store.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM aveloxis_data.repos
+		WHERE NOT COALESCE(repo_archived, FALSE) AND repo_owner = '_avcount'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("predicate must keep the active row and exclude the archived one: got %d of 2 seeded", n)
+	}
+
+	// And the method itself executes cleanly against the live schema.
+	if _, err := store.CountActiveRepos(ctx); err != nil {
+		t.Fatalf("CountActiveRepos: %v", err)
+	}
+}

--- a/internal/db/public_stats_store_test.go
+++ b/internal/db/public_stats_store_test.go
@@ -8,21 +8,25 @@ import (
 	"testing"
 )
 
-// TestCountActiveReposPredicate (v0.27.59): the landing-page count must
-// exclude archived repositories. Deterministic under parallel test
-// packages (a global before/after count-delta races concurrent
-// inserts into the shared scratch DB — the original form of this test
-// flaked exactly that way): pin the method's predicate at the source
-// level, then prove that predicate's behavior on seeded rows with a
-// scoped query.
-func TestCountActiveReposPredicate(t *testing.T) {
+// TestCountActiveReposCountsEverything (v0.27.68, reversing the
+// v0.27.59 archived-exclusion): the landing count is the TOTAL repo
+// catalog. The v0.27.59 non-archived filter made the landing number
+// visibly disagree with the monitor's ~94K queue view — a definition
+// mismatch the operator resolved in favor of "count everything"
+// (archived repos carry full collected history and analysis).
+// Deterministic under parallel test packages: source-level predicate
+// pin + a scoped seeded-row check.
+func TestCountActiveReposCountsEverything(t *testing.T) {
 	src := readSourceFile(t, "public_stats_store.go")
-	if !strings.Contains(src, "NOT COALESCE(repo_archived, FALSE)") {
-		t.Fatal("CountActiveRepos must filter NOT COALESCE(repo_archived, FALSE) — archived repos are read-only and don't belong in 'repositories under analysis'")
+	if strings.Contains(src, "NOT COALESCE(repo_archived, FALSE)") {
+		t.Fatal("CountActiveRepos must NOT filter archived repos (v0.27.68 operator decision — the landing number must agree with the monitor's total)")
+	}
+	if !strings.Contains(src, "SELECT COUNT(*) FROM aveloxis_data.repos") {
+		t.Fatal("CountActiveRepos must count the whole repos catalog")
 	}
 }
 
-func TestCountActiveReposExcludesArchived(t *testing.T) {
+func TestCountActiveReposIncludesArchived(t *testing.T) {
 	store, ctx := v0251Connect(t)
 	defer store.Close()
 
@@ -37,16 +41,15 @@ func TestCountActiveReposExcludesArchived(t *testing.T) {
 		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcount'`)
 	})
 
-	// The exact predicate the method is pinned to, scoped to the seeded
-	// cohort: exactly the active row survives.
+	// Both seeded rows count — archived included (scoped check so
+	// parallel packages can't race the assertion).
 	var n int
 	if err := store.pool.QueryRow(ctx, `
-		SELECT COUNT(*) FROM aveloxis_data.repos
-		WHERE NOT COALESCE(repo_archived, FALSE) AND repo_owner = '_avcount'`).Scan(&n); err != nil {
+		SELECT COUNT(*) FROM aveloxis_data.repos WHERE repo_owner = '_avcount'`).Scan(&n); err != nil {
 		t.Fatal(err)
 	}
-	if n != 1 {
-		t.Errorf("predicate must keep the active row and exclude the archived one: got %d of 2 seeded", n)
+	if n != 2 {
+		t.Errorf("both rows (active + archived) must count: got %d of 2 seeded", n)
 	}
 
 	// And the method itself executes cleanly against the live schema.

--- a/internal/db/public_stats_store_test.go
+++ b/internal/db/public_stats_store_test.go
@@ -28,7 +28,7 @@ func TestCountActiveReposCountsEverything(t *testing.T) {
 
 func TestCountActiveReposIncludesArchived(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avcount'`)
 	if _, err := store.pool.Exec(ctx, `

--- a/internal/db/queue_realign_integration_test.go
+++ b/internal/db/queue_realign_integration_test.go
@@ -136,7 +136,7 @@ func approxEqual(a, b time.Time, tolerance time.Duration) bool {
 // was not restarted" or a rendering-layer issue (not a store issue).
 func TestRealignDueDates_ShiftsDueAtOnConfigChange(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "shift")
 
@@ -175,7 +175,7 @@ func TestRealignDueDates_ShiftsDueAtOnConfigChange(t *testing.T) {
 // would churn the updated_at column across the whole fleet.
 func TestRealignDueDates_Idempotent(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "idem")
 	lastCollected := time.Now().Add(-2 * time.Hour).UTC()
@@ -211,7 +211,7 @@ func TestRealignDueDates_Idempotent(t *testing.T) {
 // the worker claimed it.
 func TestRealignDueDates_SkipsCollecting(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "collecting")
 	lastCollected := time.Now().Add(-48 * time.Hour).UTC()
@@ -244,7 +244,7 @@ func TestRealignDueDates_SkipsCollecting(t *testing.T) {
 // explicit.
 func TestRealignDueDates_SkipsNullLastCollected(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "nevercoll")
 	// last_collected = NULL, due_at = now (typical state for a newly-added
@@ -274,7 +274,7 @@ func TestRealignDueDates_SkipsNullLastCollected(t *testing.T) {
 // production.
 func TestRealignDueDates_VariousDurations(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	cases := []struct {
 		name     string
@@ -332,7 +332,7 @@ func TestRealignDueDates_VariousDurations(t *testing.T) {
 // call and the post-read).
 func TestCompleteJob_BakesDueAtFromRecollectAfter(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "complete")
 	// Start in 'collecting' to match real life — CompleteJob is called
@@ -376,7 +376,7 @@ func TestCompleteJob_BakesDueAtFromRecollectAfter(t *testing.T) {
 // will still reflect the 1-day interval, and this test will fail loudly.
 func TestCompleteJob_ThenRealign_FullConfigChangeScenario(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "scenario")
 	seedQueueRow(ctx, t, store, repoID, "collecting", nil, time.Now().UTC())
@@ -444,7 +444,7 @@ func TestCompleteJob_ThenRealign_FullConfigChangeScenario(t *testing.T) {
 // explicitly claims.
 func TestRealignDueDates_OverdueRowGetsNewWindow(t *testing.T) {
 	store, ctx := realignConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	repoID := seedRealignRepo(ctx, t, store, "overdue")
 	// Row completed 10 days ago, old 1d setting baked due_at = 9 days ago.

--- a/internal/db/repo_labor_history_test.go
+++ b/internal/db/repo_labor_history_test.go
@@ -372,7 +372,7 @@ func rlCount(t *testing.T, ctx context.Context, s *PostgresStore, table string, 
 // untouched, all-NULL untouched, and a re-run moves nothing.
 func TestRepoLaborSnapshotMigrationEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	rlCleanup(t, ctx, store, rlRepoMulti, rlRepoSingle, rlRepoAllNull)
 	rlSeedRepo(t, ctx, store, rlRepoMulti)
@@ -480,7 +480,7 @@ func TestRepoLaborSnapshotMigrationEndToEnd(t *testing.T) {
 // zero source files) leaves an empty current snapshot.
 func TestReplaceRepoLaborSnapshotEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	rlCleanup(t, ctx, store, rlRepoReplace)
 	rlSeedRepo(t, ctx, store, rlRepoReplace)
@@ -540,7 +540,7 @@ func TestReplaceRepoLaborSnapshotEndToEnd(t *testing.T) {
 // installs until its inherited copy is dropped next to the CREATE.
 func TestRepoLaborHistoryHasNoNaturalKeyUniques(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	var hasPK bool
 	if err := store.pool.QueryRow(ctx, `
@@ -590,7 +590,7 @@ func TestRepoLaborHistoryHasNoNaturalKeyUniques(t *testing.T) {
 // cleared, history accumulates across rotations.
 func TestRotateScorecardToHistoryBehaviorPreserved(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	rlCleanup(t, ctx, store, rlRepoScorecard)
 	rlSeedRepo(t, ctx, store, rlRepoScorecard)

--- a/internal/db/repos_added_at_test.go
+++ b/internal/db/repos_added_at_test.go
@@ -83,7 +83,7 @@ func TestUpsertRepoNeverTouchesAddedAt(t *testing.T) {
 
 func TestAddedAtEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	// Fresh insert gets a NOW()-ish stamp via the default.
 	login := "_avaddedat/probe"

--- a/internal/db/repos_added_at_test.go
+++ b/internal/db/repos_added_at_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+// repos_added_at_test.go — TDD suite for v0.27.60: a STABLE
+// "when did this repo enter the fleet" timestamp, feeding the
+// new-repositories feeds (v0.27.62). Contracts:
+//   - migration ORDER pins the NOW()-default trap: ADD COLUMN with a
+//     STABLE default would stamp every legacy row with the migration
+//     timestamp via attmissingval, destroying the backfill's
+//     distinction — so: (1) add bare column, (2) backfill from
+//     COALESCE(data_collection_date, created_at, NOW()) — an honest
+//     last-touch APPROXIMATION for legacy rows (no queue created-at
+//     exists), (3) only then SET DEFAULT NOW();
+//   - added_at is INSERT-ONLY: absent from UpsertRepo's DO UPDATE SET,
+//     so re-collections never move it;
+//   - schema.sql carries the v0.27.58-lesson ALTER guard before its
+//     index (existing fleets no-op the CREATE TABLE).
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+func TestAddedAtMigrationOrderPinsDefaultTrap(t *testing.T) {
+	src := readSourceFile(t, "migrate.go")
+	addPos := strings.Index(src, `"added_at", "TIMESTAMPTZ"`)
+	if addPos < 0 {
+		t.Fatal(`migrate.go must addColumnIfMissing("added_at", "TIMESTAMPTZ") — BARE type, no DEFAULT: a STABLE default at add-time stamps every legacy row with the migration timestamp`)
+	}
+	backfillPos := strings.Index(src, "SET added_at = COALESCE(data_collection_date, created_at, NOW())")
+	if backfillPos < 0 {
+		t.Fatal("migrate.go must backfill added_at from COALESCE(data_collection_date, created_at, NOW()) WHERE added_at IS NULL")
+	}
+	defaultPos := strings.Index(src, "ALTER COLUMN added_at SET DEFAULT NOW()")
+	if defaultPos < 0 {
+		t.Fatal("migrate.go must SET DEFAULT NOW() on added_at AFTER the backfill")
+	}
+	if !(addPos < backfillPos && backfillPos < defaultPos) {
+		t.Errorf("order must be add(%d) < backfill(%d) < set-default(%d) — reordering reintroduces the attmissingval trap", addPos, backfillPos, defaultPos)
+	}
+	if !strings.Contains(src, "WHERE added_at IS NULL") {
+		t.Error("the backfill must be idempotent by predicate (WHERE added_at IS NULL)")
+	}
+}
+
+func TestAddedAtSchemaDeclarations(t *testing.T) {
+	schema := readSourceFile(t, "schema.sql")
+	flat := strings.Join(strings.Fields(schema), " ")
+	if !strings.Contains(flat, "added_at TIMESTAMPTZ DEFAULT NOW()") {
+		t.Error("schema.sql repos CREATE TABLE must declare added_at TIMESTAMPTZ DEFAULT NOW() (fresh installs)")
+	}
+	// The v0.27.58 existing-fleet lesson: an index on a same-release
+	// new column needs an ALTER guard ahead of it in schema.sql.
+	guard := strings.Index(flat, "ALTER TABLE aveloxis_data.repos ADD COLUMN IF NOT EXISTS added_at")
+	idx := strings.Index(flat, "CREATE INDEX IF NOT EXISTS idx_repos_added_at")
+	if guard < 0 {
+		t.Fatal("schema.sql must guard added_at with ALTER TABLE ... ADD COLUMN IF NOT EXISTS before its index (existing fleets no-op the CREATE TABLE)")
+	}
+	if idx >= 0 && guard > idx {
+		t.Error("the added_at guard must precede idx_repos_added_at")
+	}
+}
+
+func TestUpsertRepoNeverTouchesAddedAt(t *testing.T) {
+	src := readSourceFile(t, "postgres.go")
+	i := strings.Index(src, "func (s *PostgresStore) UpsertRepo(")
+	if i < 0 {
+		t.Fatal("cannot find UpsertRepo")
+	}
+	body := src[i:]
+	if end := strings.Index(body[1:], "\nfunc "); end > 0 {
+		body = body[:1+end]
+	}
+	if strings.Contains(body, "added_at") {
+		t.Error("UpsertRepo must not reference added_at at all — the DEFAULT stamps it at INSERT and the DO UPDATE must never move it (insert-only contract)")
+	}
+}
+
+func TestAddedAtEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	// Fresh insert gets a NOW()-ish stamp via the default.
+	login := "_avaddedat/probe"
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_git = $1`, "https://github.com/"+login)
+	var id int64
+	var first time.Time
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id)
+		VALUES ($1, '_avaddedat', 'probe', 1) RETURNING repo_id, added_at`,
+		"https://github.com/"+login).Scan(&id, &first); err != nil {
+		t.Fatalf("insert with default: %v", err)
+	}
+	t.Cleanup(func() { _, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, id) })
+	if time.Since(first) > time.Minute {
+		t.Errorf("fresh insert must stamp added_at ≈ now, got %s", first)
+	}
+
+	// A second UpsertRepo touch must NOT move added_at.
+	if _, err := store.UpsertRepo(ctx, &model.Repo{
+		GitURL: "https://github.com/" + login, Owner: "_avaddedat", Name: "probe",
+		Platform: model.PlatformGitHub,
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	var second time.Time
+	if err := store.pool.QueryRow(ctx, `SELECT added_at FROM aveloxis_data.repos WHERE repo_id = $1`, id).Scan(&second); err != nil {
+		t.Fatal(err)
+	}
+	if !second.Equal(first) {
+		t.Errorf("added_at moved on re-upsert: %s → %s (must be insert-only)", first, second)
+	}
+
+	// Backfill semantics: NULL the stamp, run the migration statement's
+	// exact predicate path via Migrate, assert it heals from
+	// data_collection_date.
+	if _, err := store.pool.Exec(ctx, `UPDATE aveloxis_data.repos SET added_at = NULL, data_collection_date = '2026-01-15T00:00:00Z' WHERE repo_id = $1`, id); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	var healed time.Time
+	if err := store.pool.QueryRow(ctx, `SELECT added_at FROM aveloxis_data.repos WHERE repo_id = $1`, id).Scan(&healed); err != nil {
+		t.Fatal(err)
+	}
+	if healed.UTC().Format("2006-01-02") != "2026-01-15" {
+		t.Errorf("backfill must use data_collection_date (2026-01-15), got %s", healed)
+	}
+}

--- a/internal/db/retention_store_test.go
+++ b/internal/db/retention_store_test.go
@@ -243,7 +243,7 @@ func monthValue(points []WeeklyPoint, year int, month time.Month) float64 {
 
 func TestContributorRetentionSeriesEndToEnd(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 	uniq := time.Now().UnixNano()
 

--- a/internal/db/scancode_v0276_integration_test.go
+++ b/internal/db/scancode_v0276_integration_test.go
@@ -35,7 +35,7 @@ func v0276Connect(t *testing.T) (*PostgresStore, context.Context) {
 	// t.Cleanup runs LIFO and AFTER the test's deferred calls would —
 	// registering the pool close here (before any per-row cleanup is
 	// registered) guarantees the row deletes still have a live pool.
-	// An explicit `defer store.pool.Close()` in the test body would
+	// An explicit `t.Cleanup(store.pool.Close)` in the test body would
 	// close the pool BEFORE t.Cleanup's deletes, silently leaking
 	// seed rows into the shared scratch DB (observed on the first
 	// suite re-run as 23505 on repos_repo_git_key).

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2643,6 +2643,16 @@ CREATE INDEX IF NOT EXISTS idx_pull_request_message_ref_msg_id ON aveloxis_data.
 CREATE INDEX IF NOT EXISTS idx_review_comments_msg_id ON aveloxis_data.review_comments (msg_id);
 -- pull_request_reviews(pr_review_id) ← 2 children
 CREATE INDEX IF NOT EXISTS idx_pull_request_review_message_ref_pr_review_id ON aveloxis_data.pull_request_review_message_ref (pr_review_id);
+-- v0.27.67: msg_id probe for GetMessageHealBatch's review-side
+-- LATERAL (and any future msg→review resolution). uq_pr_review_msg_ref
+-- leads with pr_review_id, so it cannot serve a bare msg_id seek —
+-- without this index the heal-messages batch SELECT filter-scanned
+-- 30.5M index entries PER worklist row (measured 1.67s/probe ≈ 10.5
+-- days for the 546K-row worklist on aveloxis_large, 2026-08-01).
+-- NON-partial on purpose: the probe value is a join variable
+-- (v0.27.54 lesson — partial predicates can't be proven at plan time
+-- for join-variable probes).
+CREATE INDEX IF NOT EXISTS idx_pull_request_review_message_ref_msg_id ON aveloxis_data.pull_request_review_message_ref (msg_id);
 CREATE INDEX IF NOT EXISTS idx_review_comments_pr_review_id ON aveloxis_data.review_comments (pr_review_id);
 -- repos(repo_id) ← 30 children (includes issue_assignees.repo_id)
 CREATE INDEX IF NOT EXISTS idx_commit_comment_ref_repo_id ON aveloxis_data.commit_comment_ref (repo_id);

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -2324,6 +2324,16 @@ CREATE TABLE IF NOT EXISTS aveloxis_ops.collection_groups (
     PRIMARY KEY (collection_id, group_id)
 );
 
+-- v0.27.70: per-user collection stars (the user_repo_stars pattern).
+-- Collections are public; a star only affects the STARRER's sort
+-- order (starred collections list first for them).
+CREATE TABLE IF NOT EXISTS aveloxis_ops.user_collection_stars (
+    user_id       INT NOT NULL REFERENCES aveloxis_ops.users(user_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    collection_id BIGINT NOT NULL REFERENCES aveloxis_ops.collections(collection_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    starred_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, collection_id)
+);
+
 CREATE TABLE IF NOT EXISTS aveloxis_ops.client_applications (
     id             TEXT PRIMARY KEY,
     api_key        TEXT NOT NULL DEFAULT '',

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -220,6 +220,13 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.contributors (
     cntrb_created_at TIMESTAMPTZ,
     cntrb_last_enriched_at TIMESTAMPTZ,
     cntrb_last_breadth_at  TIMESTAMPTZ,
+    -- v0.27.57 GitHub contribution-activity classification (see the
+    -- idx_contributors_activity_checked comment below).
+    gh_public_contribs_year     INTEGER,
+    gh_restricted_contribs_year INTEGER,
+    gh_last_contribution_year   INTEGER,
+    gh_activity_class           TEXT DEFAULT '',
+    gh_activity_checked_at      TIMESTAMPTZ,
     tool_source    TEXT DEFAULT 'aveloxis',
     tool_version   TEXT DEFAULT '',
     data_source    TEXT DEFAULT '',
@@ -274,6 +281,23 @@ CREATE INDEX IF NOT EXISTS idx_contributors_email_lookup
 
 CREATE INDEX IF NOT EXISTS idx_contributors_canonical_lookup
     ON aveloxis_data.contributors (cntrb_canonical);
+
+-- v0.27.57 — GitHub contribution-activity classification (GraphQL
+-- contributionsCollection). Distinguishes publicly-active /
+-- privately-active-disclosed / dormant / no-observable-activity for
+-- the ~1.4M contributors whose REST events feed is empty. GITHUB-ONLY
+-- (gh_ prefix): GitLab has no restrictedContributionsCount
+-- equivalent — private profiles are simply invisible (documented
+-- parity gap). Empty gh_activity_class = never checked, or the user
+-- was absent from the API response (deleted/renamed).
+-- The index serves GetContributorsForActivityCheck's
+-- `ORDER BY gh_activity_checked_at ASC NULLS FIRST` claim — explicit
+-- ASC NULLS FIRST per the v0.27.8 breadth lesson (Postgres's ASC
+-- default is NULLS LAST; neither scan direction serves the ORDER BY
+-- without it). Existing fleets get the CONCURRENTLY build from
+-- migrate.go; this plain form covers fresh installs.
+CREATE INDEX IF NOT EXISTS idx_contributors_activity_checked
+    ON aveloxis_data.contributors (gh_activity_checked_at ASC NULLS FIRST);
 
 CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_identities (
     identity_id    BIGSERIAL PRIMARY KEY,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -283,6 +283,21 @@ CREATE INDEX IF NOT EXISTS idx_contributors_email_lookup
 CREATE INDEX IF NOT EXISTS idx_contributors_canonical_lookup
     ON aveloxis_data.contributors (cntrb_canonical);
 
+-- v0.27.57/58 EXISTING-FLEET GUARDS (the 2026-07-30 kate migrate
+-- failure): on a database where contributors already exists, the
+-- CREATE TABLE above no-ops and its new columns never materialize —
+-- and the CREATE INDEX statements below would then fail with 42703
+-- BEFORE migrate.go's addColumnIfMissing steps run (base DDL executes
+-- first). Any same-release (new column, schema.sql index) pair MUST
+-- carry one of these guards ahead of its index. Fresh installs no-op
+-- here (the CREATE TABLE already declared the columns).
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_public_contribs_year INTEGER;
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_restricted_contribs_year INTEGER;
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_last_contribution_year INTEGER;
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_activity_class TEXT DEFAULT '';
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_activity_checked_at TIMESTAMPTZ;
+ALTER TABLE aveloxis_data.contributors ADD COLUMN IF NOT EXISTS gh_history_backfilled_at TIMESTAMPTZ;
+
 -- v0.27.57 — GitHub contribution-activity classification (GraphQL
 -- contributionsCollection). Distinguishes publicly-active /
 -- privately-active-disclosed / dormant / no-observable-activity for

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -227,6 +227,7 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.contributors (
     gh_last_contribution_year   INTEGER,
     gh_activity_class           TEXT DEFAULT '',
     gh_activity_checked_at      TIMESTAMPTZ,
+    gh_history_backfilled_at    TIMESTAMPTZ,
     tool_source    TEXT DEFAULT 'aveloxis',
     tool_version   TEXT DEFAULT '',
     data_source    TEXT DEFAULT '',
@@ -298,6 +299,45 @@ CREATE INDEX IF NOT EXISTS idx_contributors_canonical_lookup
 -- migrate.go; this plain form covers fresh installs.
 CREATE INDEX IF NOT EXISTS idx_contributors_activity_checked
     ON aveloxis_data.contributors (gh_activity_checked_at ASC NULLS FIRST);
+
+-- v0.27.58 — daily contributor activity history (GitHub GraphQL
+-- contributionsCollection, operator decision 2026-07-30: store by
+-- day). contributor_activity_days holds per-(contributor, day,
+-- repository) PUBLIC activity binned from the four by-repository
+-- connections; repo_full_name is deliberately TEXT with NO repos FK —
+-- these are mostly repositories Aveloxis does not track (the
+-- ecosystem outside the fleet is the point of the data).
+-- contributor_activity_day_totals holds the contribution calendar's
+-- per-day TOTAL, which INCLUDES disclosed private contributions — the
+-- only daily private signal (untyped and repo-less by GitHub's
+-- design). Both upsert on their natural keys (the quarterly re-audit
+-- overwrites in place); the claim column
+-- contributors.gh_history_backfilled_at drives bootstrap (NULL-first)
+-- and the quarterly healing in one mechanism.
+CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_days (
+    activity_day_id BIGSERIAL PRIMARY KEY,
+    cntrb_id        UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    day             DATE NOT NULL,
+    repo_full_name  TEXT NOT NULL,
+    commit_count    INTEGER NOT NULL DEFAULT 0,
+    issue_count     INTEGER NOT NULL DEFAULT 0,
+    pr_count        INTEGER NOT NULL DEFAULT 0,
+    review_count    INTEGER NOT NULL DEFAULT 0,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (cntrb_id, day, repo_full_name)
+);
+
+CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_activity_day_totals (
+    activity_total_id   BIGSERIAL PRIMARY KEY,
+    cntrb_id            UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    day                 DATE NOT NULL,
+    total_contributions INTEGER NOT NULL DEFAULT 0,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (cntrb_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contributors_history_backfilled
+    ON aveloxis_data.contributors (gh_history_backfilled_at ASC NULLS FIRST);
 
 CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_identities (
     identity_id    BIGSERIAL PRIMARY KEY,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -55,6 +55,11 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     platform_repo_id TEXT DEFAULT '',
     created_at       TIMESTAMPTZ,
     updated_at       TIMESTAMPTZ,
+    -- v0.27.60: STABLE fleet-entry timestamp (insert-only — NOT in
+    -- UpsertRepo's DO UPDATE SET). Feeds the new-repositories feeds.
+    -- Legacy rows are backfilled from data_collection_date (an honest
+    -- last-touch approximation) by the migrate step.
+    added_at         TIMESTAMPTZ DEFAULT NOW(),
     tool_source      TEXT DEFAULT 'aveloxis',
     tool_version     TEXT DEFAULT '',
     data_source      TEXT DEFAULT '',
@@ -138,6 +143,18 @@ CREATE TABLE IF NOT EXISTS aveloxis_data.repos (
     -- incomplete.
     distribution_scan_complete   BOOLEAN DEFAULT TRUE
 );
+
+-- v0.27.60 EXISTING-FLEET GUARD (the v0.27.58 lesson): on a database
+-- where repos already exists the CREATE TABLE above no-ops, so
+-- added_at must be guarded here before its index references it. Bare
+-- type on purpose — the migrate step backfills legacy rows from
+-- data_collection_date and only then sets the NOW() default (the
+-- STABLE-default-at-add trap would stamp every legacy row with the
+-- migration timestamp).
+ALTER TABLE aveloxis_data.repos ADD COLUMN IF NOT EXISTS added_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_repos_added_at
+    ON aveloxis_data.repos (added_at DESC);
 
 -- ============================================================
 -- Repo groups list serve (mailing lists)
@@ -2284,6 +2301,27 @@ CREATE TABLE IF NOT EXISTS aveloxis_ops.user_org_requests (
     last_scanned   TIMESTAMPTZ,
     created_at     TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE (group_id, org_url)
+);
+
+-- v0.27.63: collections — admin-curated groups-of-groups for the GUI
+-- home page ("Collections" box). Collections join to LIVE user_groups
+-- (not frozen repo lists): admin org-groups auto-grow via org scans,
+-- so collections stay fresh for free. Placed after users +
+-- user_groups per the create-before-reference rule (v0.27.9).
+CREATE TABLE IF NOT EXISTS aveloxis_ops.collections (
+    collection_id BIGSERIAL PRIMARY KEY,
+    name          TEXT NOT NULL UNIQUE,
+    description   TEXT NOT NULL DEFAULT '',
+    position      INT NOT NULL DEFAULT 0,
+    created_by    INT REFERENCES aveloxis_ops.users(user_id) DEFERRABLE INITIALLY DEFERRED,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS aveloxis_ops.collection_groups (
+    collection_id BIGINT NOT NULL REFERENCES aveloxis_ops.collections(collection_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    group_id      BIGINT NOT NULL REFERENCES aveloxis_ops.user_groups(group_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    position      INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (collection_id, group_id)
 );
 
 CREATE TABLE IF NOT EXISTS aveloxis_ops.client_applications (

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -253,6 +253,28 @@ CREATE INDEX IF NOT EXISTS idx_contributors_last_breadth
 CREATE INDEX IF NOT EXISTS idx_contributors_gh_login_lower
     ON aveloxis_data.contributors (LOWER(gh_login)) WHERE gh_login != '';
 
+-- v0.27.54 — serve the mailing-list identity chain's email-equality
+-- probes: GetMailingListSenderResolveCandidates' NOT EXISTS,
+-- ResolveContributorIDByEmail's join, CreateEmailOnlyContributor's
+-- lookup. Without these the OR-equality anti-join planned as a full
+-- contributors seq scan (9.4 GB on aveloxis_large) PER OUTER ROW —
+-- observed 30-50 min hourly on 5 backends (2026-07-29). History:
+-- cntrb_email never had an index; cntrb_canonical's was dropped in
+-- v0.25.6 as "no reader", then v0.25.7+ shipped these readers. NEW
+-- names on purpose: the v0.25.6 DROP steps still run every migrate,
+-- so reusing the old names would rebuild the index each run.
+-- Deliberately NON-partial: the hot probes compare against a JOIN
+-- column (em.sender_email), and a partial predicate cannot be proven
+-- from a join variable at plan time — a partial index would be
+-- ignored for exactly the anti-join this fixes. Existing fleets get
+-- the CONCURRENTLY build from migrate.go; this plain form covers
+-- fresh installs.
+CREATE INDEX IF NOT EXISTS idx_contributors_email_lookup
+    ON aveloxis_data.contributors (cntrb_email);
+
+CREATE INDEX IF NOT EXISTS idx_contributors_canonical_lookup
+    ON aveloxis_data.contributors (cntrb_canonical);
+
 CREATE TABLE IF NOT EXISTS aveloxis_data.contributor_identities (
     identity_id    BIGSERIAL PRIMARY KEY,
     cntrb_id       UUID NOT NULL REFERENCES aveloxis_data.contributors(cntrb_id) ON UPDATE CASCADE ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,

--- a/internal/db/scorecard_mode_test.go
+++ b/internal/db/scorecard_mode_test.go
@@ -114,7 +114,7 @@ func scorecardModeConnect(t *testing.T) (*PostgresStore, context.Context) {
 // ever diverge on scorecard_mode.
 func TestScorecardModePersistsAndRotates(t *testing.T) {
 	store, ctx := scorecardModeConnect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	var repoID int64
 	err := store.pool.QueryRow(ctx, `
@@ -196,7 +196,7 @@ func TestScorecardModePersistsAndRotates(t *testing.T) {
 // first, older-than filter, limit, and the last_collected gate.
 func TestListScorecardBacklogOrdering(t *testing.T) {
 	store, ctx := scorecardModeConnect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	mk := func(name string, collected bool) int64 {
 		var id int64

--- a/internal/db/store_methods_behavioral_test.go
+++ b/internal/db/store_methods_behavioral_test.go
@@ -37,7 +37,7 @@ func (s *retentionSeed) enqueueCollected() {
 
 func TestClaimNextScancodeRepoClaimsEligibleRow(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 	seed.enqueueCollected()
 
@@ -87,7 +87,7 @@ func TestClaimNextScancodeRepoClaimsEligibleRow(t *testing.T) {
 
 func TestRecordScancodeFailureBackoffAndSideline(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 
 	readState := func() (attempts int, lastFailed, lastRun, lockedAt *time.Time) {
@@ -153,7 +153,7 @@ func TestRecordScancodeFailureBackoffAndSideline(t *testing.T) {
 
 func TestClearStaleNullPidLocksHealsOnlyStaleRows(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	stale := newRetentionSeed(ctx, t, store)
 	fresh := newRetentionSeed(ctx, t, store)
 
@@ -196,7 +196,7 @@ func TestClearStaleNullPidLocksHealsOnlyStaleRows(t *testing.T) {
 
 func TestGetRepoTransitivePackagesFoldsScopeAndExcludesDirect(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 
 	insert := func(name, version, lockfile string, direct bool, scope string) {
@@ -233,7 +233,7 @@ func TestGetRepoTransitivePackagesFoldsScopeAndExcludesDirect(t *testing.T) {
 
 func TestBackfillGitLabCommitCountPatchesOnlyZeroLatestRow(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 	seed := newRetentionSeed(ctx, t, store)
 	carol := seed.contributor("_avgt-backfill", "User", 0)
 
@@ -310,7 +310,7 @@ func TestBackfillGitLabCommitCountPatchesOnlyZeroLatestRow(t *testing.T) {
 // ground-truth rule.
 func TestCollectedRepoIDsCohort(t *testing.T) {
 	store, ctx := retentionConnect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	collected := newRetentionSeed(ctx, t, store)
 	collected.enqueueCollected()

--- a/internal/db/top_contributors_test.go
+++ b/internal/db/top_contributors_test.go
@@ -160,7 +160,7 @@ func TestTopContributorsEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rows, err := store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 20)
+	rows, err := store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 20, false)
 	if err != nil {
 		t.Fatalf("TopContributors: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestTopContributorsEndToEnd(t *testing.T) {
 	// Windowed: the 3-year-old commit falls out — alice commits = 1
 	// (deduped from two file rows), total 5.
 	since := time.Now().AddDate(0, -2, 0)
-	rows, err = store.TopContributors(ctx, repoID, since, time.Time{}, 20)
+	rows, err = store.TopContributors(ctx, repoID, since, time.Time{}, 20, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,11 +204,64 @@ func TestTopContributorsEndToEnd(t *testing.T) {
 	}
 
 	// Limit applies AFTER ranking: limit 1 returns only alice.
-	rows, err = store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 1)
+	rows, err = store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rows) != 1 || rows[0].Login != "_avtopc_alice" {
 		t.Errorf("limit 1 must return exactly the top-ranked row, got %+v", rows)
+	}
+
+	// v0.27.69 — the bot filter. Three marker classes, seeded to
+	// mirror the live k8s finding (k8s-ci-robot is gh_type='User' —
+	// only the -robot suffix catches it).
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avtopc_x%'`)
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login LIKE '_avtopc_x%'`)
+	})
+	seedBot := func(login, id, ghType string) {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.contributors (cntrb_id, cntrb_login, gh_type)
+			VALUES ($1::uuid, $2, $3)
+			ON CONFLICT (cntrb_login) WHERE cntrb_login != '' DO NOTHING`, id, login, ghType); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename, cmt_author_name, cmt_author_email, cmt_author_date, cmt_author_timestamp, cmt_ght_author_id)
+			VALUES ($1, $2, 'z.go', 'x', 'x@x', '2026-07-01', $3, $4::uuid)`,
+			repoID, "h"+id[len(id)-6:], in, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedBot("_avtopc_x[bot]", "0100abcd-0000-0000-0000-0000000000b1", "Bot")      // App bot
+	seedBot("_avtopc_x-ci-robot", "0100abcd-0000-0000-0000-0000000000b2", "User") // k8s-class machine user
+	seedBot("_avtopc_x-bot", "0100abcd-0000-0000-0000-0000000000b3", "User")      // hyphen-bot machine user
+	seedBot("_avtopc_xtalbot", "0100abcd-0000-0000-0000-0000000000b4", "User")    // HUMAN surname — must survive
+
+	all, err := store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 20, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filtered, err := store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 20, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != len(filtered)+3 {
+		t.Errorf("excludeBots must drop exactly the 3 bot rows: all=%d filtered=%d", len(all), len(filtered))
+	}
+	for _, r := range filtered {
+		switch r.Login {
+		case "_avtopc_x[bot]", "_avtopc_x-ci-robot", "_avtopc_x-bot":
+			t.Errorf("bot %q survived the filter", r.Login)
+		}
+	}
+	var talbotSurvives bool
+	for _, r := range filtered {
+		if r.Login == "_avtopc_xtalbot" {
+			talbotSurvives = true
+		}
+	}
+	if !talbotSurvives {
+		t.Error("human login ending in 'bot' without a separator (talbot) must NOT be filtered")
 	}
 }

--- a/internal/db/top_contributors_test.go
+++ b/internal/db/top_contributors_test.go
@@ -74,7 +74,7 @@ func TestTopContributorsIdentityJoin(t *testing.T) {
 
 func TestTopContributorsEndToEnd(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.Close()
+	t.Cleanup(store.Close)
 
 	// Scoped fixture: everything under repo_owner '_avtopc' so
 	// parallel test packages can't interfere.

--- a/internal/db/top_contributors_test.go
+++ b/internal/db/top_contributors_test.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// v0.27.61 — TopContributors: the ranked per-contributor activity
+// breakdown behind GET /repos/{id}/contributors/top. Source-contract
+// pins first (the load-bearing SQL decisions), then an
+// AVELOXIS_TEST_DB integration test that seeds one of every activity
+// kind and checks the per-kind counts, ranking, window filter, and
+// limit behave.
+
+func topContributorsSQL(t *testing.T) string {
+	t.Helper()
+	src := readSourceFile(t, "contributions.go")
+	if !strings.Contains(src, "func (s *PostgresStore) TopContributors(") {
+		t.Fatal("TopContributors method missing from contributions.go")
+	}
+	return src
+}
+
+// The commits arm must range-filter on cmt_author_timestamp
+// (TIMESTAMPTZ) — cmt_author_date is TEXT and the ::DATE cast pattern
+// was one of the v0.27.5 dead-endpoint bugs. And commits are stored
+// one row per FILE per commit, so the count must collapse on
+// DISTINCT cmt_commit_hash or a 30-file commit counts 30×.
+func TestTopContributorsCommitArmIsSafe(t *testing.T) {
+	src := topContributorsSQL(t)
+	if !strings.Contains(src, "COUNT(DISTINCT c.cmt_commit_hash)") &&
+		!strings.Contains(src, "COUNT(DISTINCT cmt_commit_hash)") {
+		t.Error("commits arm must COUNT(DISTINCT cmt_commit_hash) — the table is one row per file per commit")
+	}
+	if strings.Contains(src, "cmt_author_date::DATE") {
+		t.Error("cmt_author_date is TEXT — range-filter on cmt_author_timestamp (TIMESTAMPTZ) instead")
+	}
+}
+
+// Reviews are a first-class arm (the plan's explicit ask — review
+// load is invisible in commit/PR counts alone), windowed on
+// submitted_at like the contributorsInWindowCTE reviews arm.
+func TestTopContributorsHasReviewsArm(t *testing.T) {
+	src := topContributorsSQL(t)
+	if !strings.Contains(src, "pull_request_reviews") {
+		t.Error("TopContributors must count pull_request_reviews (reviews arm)")
+	}
+	if !strings.Contains(src, "submitted_at") {
+		t.Error("reviews arm must window on submitted_at")
+	}
+}
+
+// Identity join contract: same COALESCE login chain + soft-delete
+// filter as GetRepoContributors, so the two contributor surfaces can
+// never disagree about who a cntrb_id is.
+func TestTopContributorsIdentityJoin(t *testing.T) {
+	src := topContributorsSQL(t)
+	if !strings.Contains(src, "COALESCE(NULLIF(c.cntrb_login, ''), c.gh_login, c.gl_username, '')") {
+		t.Error("TopContributors must use the shared COALESCE login chain")
+	}
+	if !strings.Contains(src, "COALESCE(c.cntrb_deleted, 0) = 0") {
+		t.Error("TopContributors must exclude soft-deleted (merge-tombstone) contributors")
+	}
+	if !strings.Contains(src, "gh_activity_class") {
+		t.Error("TopContributors rows must carry the v0.27.57 activity_class")
+	}
+}
+
+// ─── Integration (AVELOXIS_TEST_DB) ─────────────────────────────
+
+func TestTopContributorsEndToEnd(t *testing.T) {
+	store, ctx := v0251Connect(t)
+	defer store.Close()
+
+	// Scoped fixture: everything under repo_owner '_avtopc' so
+	// parallel test packages can't interfere.
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_ops.collection_queue WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.commits WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.messages WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.pull_request_reviews WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.pull_requests WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.issues WHERE repo_id IN (SELECT repo_id FROM aveloxis_data.repos WHERE repo_owner = '_avtopc')`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_owner = '_avtopc'`)
+	_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login IN ('_avtopc_alice', '_avtopc_bob')`)
+
+	var repoID int64
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.repos (repo_git, repo_owner, repo_name, platform_id)
+		VALUES ('https://github.com/_avtopc/r', '_avtopc', 'r', 1) RETURNING repo_id`).Scan(&repoID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.commits WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.messages WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.pull_request_reviews WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.pull_requests WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.issues WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.repos WHERE repo_id = $1`, repoID)
+		_, _ = store.pool.Exec(ctx, `DELETE FROM aveloxis_data.contributors WHERE cntrb_login IN ('_avtopc_alice', '_avtopc_bob')`)
+	})
+
+	seed := func(login, id string) string {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.contributors (cntrb_id, cntrb_login, cntrb_full_name, gh_activity_class)
+			VALUES ($1::uuid, $2, $3, 'active')
+			ON CONFLICT (cntrb_login) WHERE cntrb_login != '' DO NOTHING`, id, login, login+" Full"); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	alice := seed("_avtopc_alice", "0100abcd-0000-0000-0000-00000000a1ce")
+	bob := seed("_avtopc_bob", "0100abcd-0000-0000-0000-000000000b0b")
+
+	in := time.Now().AddDate(0, -1, 0) // inside the window
+	out := time.Now().AddDate(-3, 0, 0)
+
+	// Alice: 1 commit (TWO file rows, same hash — must count once),
+	// 1 issue, 1 PR, 1 review, 1 comment. Bob: 1 commit only.
+	for _, f := range []string{"a.go", "b.go"} {
+		if _, err := store.pool.Exec(ctx, `
+			INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename, cmt_author_name, cmt_author_email, cmt_author_date, cmt_author_timestamp, cmt_ght_author_id)
+			VALUES ($1, 'aaaa111', $2, 'a', 'a@x', '2026-07-01', $3, $4::uuid)`, repoID, f, in, alice); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename, cmt_author_name, cmt_author_email, cmt_author_date, cmt_author_timestamp, cmt_ght_author_id)
+		VALUES ($1, 'bbbb222', 'c.go', 'b', 'b@x', '2026-07-01', $2, $3::uuid)`, repoID, in, bob); err != nil {
+		t.Fatal(err)
+	}
+	// Out-of-window commit for alice must NOT count.
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.commits (repo_id, cmt_commit_hash, cmt_filename, cmt_author_name, cmt_author_email, cmt_author_date, cmt_author_timestamp, cmt_ght_author_id)
+		VALUES ($1, 'old0333', 'd.go', 'a', 'a@x', '2023-07-01', $2, $3::uuid)`, repoID, out, alice); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.issues (repo_id, platform_issue_id, issue_number, reporter_id, created_at, issue_title)
+		VALUES ($1, 991, 991, $2::uuid, $3, 't')`, repoID, alice, in); err != nil {
+		t.Fatal(err)
+	}
+	var prID int64
+	if err := store.pool.QueryRow(ctx, `
+		INSERT INTO aveloxis_data.pull_requests (repo_id, platform_pr_id, pr_number, author_id, created_at)
+		VALUES ($1, 881, 881, $2::uuid, $3) RETURNING pull_request_id`, repoID, alice, in).Scan(&prID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.pull_request_reviews (repo_id, pull_request_id, platform_review_id, platform_id, cntrb_id, submitted_at)
+		VALUES ($1, $2, 771, 1, $3::uuid, $4)`, repoID, prID, alice, in); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.pool.Exec(ctx, `
+		INSERT INTO aveloxis_data.messages (repo_id, platform_msg_id, platform_id, cntrb_id, msg_text, msg_timestamp)
+		VALUES ($1, 661, 1, $2::uuid, 'hi', $3)`, repoID, alice, in); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 20)
+	if err != nil {
+		t.Fatalf("TopContributors: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 contributors, got %d: %+v", len(rows), rows)
+	}
+	// Alice ranks first (total 5 vs bob 1). Her commit count is 1
+	// (two file rows, one hash) + the out-of-window default window
+	// includes the old commit — wait, no: zero since/until = all time,
+	// so alice has 2 commits all-time. Use an explicit window below
+	// for the window assertion; here all-time totals:
+	a := rows[0]
+	if a.Login != "_avtopc_alice" {
+		t.Fatalf("expected alice ranked first, got %+v", a)
+	}
+	if a.Commits != 2 || a.Issues != 1 || a.PRs != 1 || a.Reviews != 1 || a.Comments != 1 {
+		t.Errorf("alice all-time counts wrong: %+v", a)
+	}
+	if a.Total != 6 {
+		t.Errorf("alice total = %d, want 6", a.Total)
+	}
+	if a.ActivityClass != "active" {
+		t.Errorf("activity_class not carried: %+v", a)
+	}
+	if rows[1].Login != "_avtopc_bob" || rows[1].Commits != 1 || rows[1].Total != 1 {
+		t.Errorf("bob row wrong: %+v", rows[1])
+	}
+
+	// Windowed: the 3-year-old commit falls out — alice commits = 1
+	// (deduped from two file rows), total 5.
+	since := time.Now().AddDate(0, -2, 0)
+	rows, err = store.TopContributors(ctx, repoID, since, time.Time{}, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Commits != 1 {
+		t.Errorf("windowed alice commits = %d, want 1 (DISTINCT hash + window filter)", rows[0].Commits)
+	}
+	if rows[0].Total != 5 {
+		t.Errorf("windowed alice total = %d, want 5", rows[0].Total)
+	}
+
+	// Limit applies AFTER ranking: limit 1 returns only alice.
+	rows, err = store.TopContributors(ctx, repoID, time.Time{}, time.Time{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Login != "_avtopc_alice" {
+		t.Errorf("limit 1 must return exactly the top-ranked row, got %+v", rows)
+	}
+}

--- a/internal/db/v025_1_history_unique_drop_test.go
+++ b/internal/db/v025_1_history_unique_drop_test.go
@@ -163,7 +163,7 @@ func TestV0251MigrationIsIdempotent(t *testing.T) {
 // on the second INSERT. With the fix, both INSERTs succeed.
 func TestV0251HistoryRotationAllowsRepeatedKeys(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 
 	pool := store.pool
 
@@ -263,7 +263,7 @@ func v0251Connect(t *testing.T) (*PostgresStore, context.Context) {
 // on distribution_id / manifest_id. Pin that the PKs survive.
 func TestV0251HistoryTablesStillHavePrimaryKey(t *testing.T) {
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 	pool := store.pool
 
 	for _, tbl := range []string{

--- a/internal/db/v025_3_distribution_repair_test.go
+++ b/internal/db/v025_3_distribution_repair_test.go
@@ -101,7 +101,7 @@ func TestV0253RepairExecutesMaxAcrossBothTables(t *testing.T) {
 	}
 
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 	pool := store.pool
 
 	const repoID = 888001
@@ -193,7 +193,7 @@ func TestV0253RepairSkipsReposWithNoRows(t *testing.T) {
 	}
 
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 	pool := store.pool
 
 	const repoID = 888002
@@ -231,7 +231,7 @@ func TestV0253RepairIsIdempotentAfterFirstRun(t *testing.T) {
 	}
 
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 	pool := store.pool
 
 	const repoID = 888003
@@ -311,7 +311,7 @@ func TestV0253ImmediateReclaimKnobAffectsEligibilityFilter(t *testing.T) {
 		t.Skip("AVELOXIS_TEST_DB not set — skipping integration test")
 	}
 	store, ctx := v0251Connect(t)
-	defer store.pool.Close()
+	t.Cleanup(store.pool.Close)
 	pool := store.pool
 
 	const repoPartial = 888011

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.66"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.66\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.67"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.67\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.70"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.70\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.72"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.72\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.68"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.68\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.69"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.69\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.74"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.74\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.75"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.75\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.57"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.57\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.58"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.58\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.69"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.69\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.70"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.70\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.64"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.64\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.65"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.65\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.73"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.73\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.74"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.74\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.75"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.75\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.76"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.76\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.67"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.67\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.68"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.68\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.58"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.58\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.64"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.64\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.72"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.72\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.73"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.73\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.54"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.54\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.57"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.57\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.65"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.65\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.66"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.66\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/v025_6_matview_rewrite_test.go
+++ b/internal/db/v025_6_matview_rewrite_test.go
@@ -311,8 +311,8 @@ func TestVersionStampedV0256(t *testing.T) {
 	// three VALUE-checking tripwires added — example-config effective
 	// defaults, commands-doc coverage, schema-count pins).
 	src := readSourceFile(t, "version.go")
-	if !strings.Contains(src, `var ToolVersion = "0.27.52"`) {
-		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.52\". The tool_version columns and SBOM output read this constant.")
+	if !strings.Contains(src, `var ToolVersion = "0.27.54"`) {
+		t.Error("internal/db/version.go must declare ToolVersion = \"0.27.54\". The tool_version columns and SBOM output read this constant.")
 	}
 }
 

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.64"
+var ToolVersion = "0.27.65"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.72"
+var ToolVersion = "0.27.73"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.52"
+var ToolVersion = "0.27.54"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.65"
+var ToolVersion = "0.27.66"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.75"
+var ToolVersion = "0.27.76"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.69"
+var ToolVersion = "0.27.70"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.67"
+var ToolVersion = "0.27.68"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.68"
+var ToolVersion = "0.27.69"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.74"
+var ToolVersion = "0.27.75"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.70"
+var ToolVersion = "0.27.72"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.57"
+var ToolVersion = "0.27.58"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.66"
+var ToolVersion = "0.27.67"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.73"
+var ToolVersion = "0.27.74"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.58"
+var ToolVersion = "0.27.64"

--- a/internal/db/version.go
+++ b/internal/db/version.go
@@ -6,4 +6,4 @@ package db
 // ToolVersion is set by the main package at startup.
 // Used in tool_version metadata columns across all tables.
 
-var ToolVersion = "0.27.54"
+var ToolVersion = "0.27.57"

--- a/internal/model/contributor_activity.go
+++ b/internal/model/contributor_activity.go
@@ -77,6 +77,31 @@ func (a ContributionActivity) LastContributionYear() int {
 	return last
 }
 
+// ContributorDayActivity is one (day, repository) cell of a
+// contributor's public activity history (v0.27.58) — binned from the
+// dated nodes of the four contributionsCollection by-repository
+// connections. Day is "2006-01-02". RepoFullName is GitHub's
+// nameWithOwner — usually a repository Aveloxis does NOT track (that's
+// the point: the ecosystem outside the fleet), so it is deliberately a
+// name, not a repos FK.
+type ContributorDayActivity struct {
+	Day          string
+	RepoFullName string
+	Commits      int
+	Issues       int
+	PRs          int
+	Reviews      int
+}
+
+// ContributorDayTotal is one day of the contribution calendar: the
+// TOTAL contribution count across all repositories, INCLUDING disclosed
+// private contributions — the only daily signal that carries private
+// activity (untyped and repo-less by GitHub's design).
+type ContributorDayTotal struct {
+	Day   string
+	Total int
+}
+
 // ClassifyContributorActivity maps the trailing-year numbers onto the
 // four activity classes. public and restricted are the trailing-year
 // counts; lastContributionYear is LastContributionYear() (0 = none

--- a/internal/model/contributor_activity.go
+++ b/internal/model/contributor_activity.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package model
+
+// contributor_activity.go — GitHub contribution-activity classification
+// (v0.27.57). Sourced from GraphQL contributionsCollection, which is the
+// only API surface that can distinguish "publicly active" from
+// "privately active but disclosed" from "quiet". GITHUB-ONLY: GitLab has
+// no equivalent of restrictedContributionsCount — private-profile users
+// are simply invisible — so gl-side contributors keep an empty class
+// (documented parity gap, per the house both-platforms-where-possible
+// rule).
+
+// Activity classes stored in contributors.gh_activity_class. The empty
+// string means "never checked" (or checked but the user was absent from
+// the API response — deleted/renamed accounts).
+const (
+	// ActivityPublicActive: public contributions > 0 in the trailing
+	// year. Public presence wins classification even when a larger
+	// restricted count exists — both numbers are stored, the class is
+	// the headline.
+	ActivityPublicActive = "public-active"
+	// ActivityPrivateActive: zero public contributions but a non-zero
+	// restrictedContributionsCount — the user works in private repos
+	// AND enabled "include private contributions" on their profile.
+	ActivityPrivateActive = "private-active"
+	// ActivityDormant: nothing observable in the trailing year, but
+	// contributionYears proves past activity.
+	ActivityDormant = "dormant"
+	// ActivityNoObservable: no observable activity, ever. Deliberately
+	// NOT named "inactive": GitHub makes truly-inactive users
+	// indistinguishable from users active only in private repos with
+	// disclosure OFF — privacy by design. Front ends must label this
+	// class honestly ("no observable activity").
+	ActivityNoObservable = "no-observable-activity"
+)
+
+// ContributionActivity is one user's trailing-year contribution summary
+// from GitHub's contributionsCollection.
+type ContributionActivity struct {
+	Login string
+	// CalendarTotal is contributionCalendar.totalContributions — public
+	// contributions PLUS disclosed private ones.
+	CalendarTotal int
+	// Restricted is restrictedContributionsCount: contributions in
+	// repositories the viewer cannot access. Non-zero only when the
+	// user enabled private-contribution disclosure; zero is therefore
+	// ambiguous (no private activity OR disclosure off).
+	Restricted int
+	// ContributionYears lists every year the user has any recorded
+	// contributions (e.g. [2026, 2025, 2019]).
+	ContributionYears []int
+}
+
+// PublicContributions derives the public share: the calendar total
+// includes disclosed private contributions, so public = total −
+// restricted, clamped at zero so an upstream accounting quirk can never
+// produce a negative stored value.
+func (a ContributionActivity) PublicContributions() int {
+	if p := a.CalendarTotal - a.Restricted; p > 0 {
+		return p
+	}
+	return 0
+}
+
+// LastContributionYear returns the most recent year with any recorded
+// contributions, or 0 when the user has none. Order-independent — the
+// API returns years descending but the contract must not depend on it.
+func (a ContributionActivity) LastContributionYear() int {
+	last := 0
+	for _, y := range a.ContributionYears {
+		if y > last {
+			last = y
+		}
+	}
+	return last
+}
+
+// ClassifyContributorActivity maps the trailing-year numbers onto the
+// four activity classes. public and restricted are the trailing-year
+// counts; lastContributionYear is LastContributionYear() (0 = none
+// ever).
+func ClassifyContributorActivity(public, restricted, lastContributionYear int) string {
+	switch {
+	case public > 0:
+		return ActivityPublicActive
+	case restricted > 0:
+		return ActivityPrivateActive
+	case lastContributionYear > 0:
+		return ActivityDormant
+	default:
+		return ActivityNoObservable
+	}
+}

--- a/internal/model/contributor_activity_test.go
+++ b/internal/model/contributor_activity_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package model
+
+import "testing"
+
+// contributor_activity_test.go — TDD suite for the v0.27.57 activity
+// classification (GitHub contributionsCollection).
+//
+// The four classes and their boundaries:
+//   public-active          — any public contributions in the trailing year
+//   private-active         — zero public, but restrictedContributionsCount > 0
+//                            (the user DISCLOSED private activity)
+//   dormant                — zero observable activity this year, but
+//                            contributionYears proves past activity
+//   no-observable-activity — nothing, ever. Deliberately NOT labeled
+//                            "inactive": GitHub makes truly-inactive
+//                            indistinguishable from active-only-in-private
+//                            with disclosure off (privacy by design).
+
+func TestClassifyContributorActivity(t *testing.T) {
+	cases := []struct {
+		name                       string
+		public, restricted, lastYr int
+		want                       string
+	}{
+		{"public activity wins", 1742, 1895, 2026, ActivityPublicActive},
+		{"public only", 3303, 0, 2026, ActivityPublicActive},
+		{"private only (disclosed)", 0, 812, 2026, ActivityPrivateActive},
+		{"dormant with history", 0, 0, 2021, ActivityDormant},
+		{"nothing ever", 0, 0, 0, ActivityNoObservable},
+		// A single public contribution beats any restricted count for
+		// classification — the page shows both numbers anyway.
+		{"boundary: one public", 1, 500, 2026, ActivityPublicActive},
+		{"boundary: one restricted", 0, 1, 2026, ActivityPrivateActive},
+	}
+	for _, c := range cases {
+		if got := ClassifyContributorActivity(c.public, c.restricted, c.lastYr); got != c.want {
+			t.Errorf("%s: ClassifyContributorActivity(%d, %d, %d) = %q, want %q",
+				c.name, c.public, c.restricted, c.lastYr, got, c.want)
+		}
+	}
+}
+
+// PublicContributions is derived as calendar-total minus restricted
+// (the calendar INCLUDES disclosed private contributions), clamped at
+// zero so a GitHub-side accounting quirk can never store a negative.
+func TestContributionActivityPublicDerivation(t *testing.T) {
+	a := ContributionActivity{CalendarTotal: 3637, Restricted: 1895}
+	if got := a.PublicContributions(); got != 1742 {
+		t.Errorf("PublicContributions() = %d, want 1742 (calendar 3637 - restricted 1895)", got)
+	}
+	clamped := ContributionActivity{CalendarTotal: 10, Restricted: 25}
+	if got := clamped.PublicContributions(); got != 0 {
+		t.Errorf("PublicContributions() must clamp at 0, got %d", got)
+	}
+}
+
+func TestLastContributionYear(t *testing.T) {
+	a := ContributionActivity{ContributionYears: []int{2019, 2021, 2016}}
+	if got := a.LastContributionYear(); got != 2021 {
+		t.Errorf("LastContributionYear() = %d, want 2021 (max of the years list, order-independent)", got)
+	}
+	var empty ContributionActivity
+	if got := empty.LastContributionYear(); got != 0 {
+		t.Errorf("LastContributionYear() on no history = %d, want 0", got)
+	}
+}

--- a/internal/platform/github/contributor_activity.go
+++ b/internal/platform/github/contributor_activity.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// contributor_activity.go — batched contributionsCollection fetch
+// (v0.27.57). The GraphQL contributionsCollection is the only API
+// surface that separates "publicly active" from "privately active but
+// disclosed" (restrictedContributionsCount — the profile page's "N
+// contributions in private repositories" line) from "quiet". The REST
+// events feed the breadth worker uses returns an empty list for all of
+// those states indistinguishably.
+//
+// GITHUB-ONLY by nature: GitLab has no restricted-contributions
+// equivalent (private profiles are simply invisible), so this lives on
+// *Client and is consumed through a narrow capability interface at the
+// scheduler — NOT on platform.Client.
+
+// contributorActivityBatchSize is how many aliased user() lookups ride
+// one GraphQL query. 100 matches the FetchIssueClosers precedent and
+// costs ~1 rate-limit point per query — a full 2.4M-contributor sweep
+// is ~24K queries against a 5K-points/hour/token budget.
+const contributorActivityBatchSize = 100
+
+// FetchContributorActivity returns trailing-year contribution summaries
+// for the given logins, keyed by login. Deleted/renamed users (per-path
+// NOT_FOUND → null node) are ABSENT from the map — absence means
+// "unknown", while presence with zeros means "confirmed quiet"; the
+// activity classification depends on that distinction. Empty logins are
+// skipped.
+func (c *Client) FetchContributorActivity(ctx context.Context, logins []string) (map[string]model.ContributionActivity, error) {
+	out := make(map[string]model.ContributionActivity, len(logins))
+	var batch []string
+	for _, l := range logins {
+		if l == "" {
+			continue
+		}
+		batch = append(batch, l)
+		if len(batch) == contributorActivityBatchSize {
+			if err := c.fetchActivityBatch(ctx, batch, out); err != nil {
+				return out, err
+			}
+			batch = batch[:0]
+		}
+	}
+	if len(batch) > 0 {
+		if err := c.fetchActivityBatch(ctx, batch, out); err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+type activityNode struct {
+	Login                   string `json:"login"`
+	ContributionsCollection struct {
+		RestrictedContributionsCount int   `json:"restrictedContributionsCount"`
+		ContributionYears            []int `json:"contributionYears"`
+		ContributionCalendar         struct {
+			TotalContributions int `json:"totalContributions"`
+		} `json:"contributionCalendar"`
+	} `json:"contributionsCollection"`
+}
+
+func (c *Client) fetchActivityBatch(ctx context.Context, logins []string, out map[string]model.ContributionActivity) error {
+	var b strings.Builder
+	b.WriteString("query {")
+	for i, login := range logins {
+		fmt.Fprintf(&b, `
+  u%d: user(login: %q) { login contributionsCollection { restrictedContributionsCount contributionYears contributionCalendar { totalContributions } } }`, i, login)
+	}
+	b.WriteString(" }")
+
+	// The GraphQL helper logs per-path errors (NOT_FOUND for deleted
+	// users) at WARN and still returns the data for the other aliases —
+	// their nodes arrive as null and are skipped below.
+	var resp map[string]json.RawMessage
+	if err := c.http.GraphQL(ctx, b.String(), nil, &resp); err != nil {
+		return fmt.Errorf("contributor activity batch: %w", err)
+	}
+	for i, login := range logins {
+		raw, ok := resp[fmt.Sprintf("u%d", i)]
+		if !ok || string(raw) == "null" {
+			continue // deleted/renamed → absent from the result
+		}
+		var node activityNode
+		if err := json.Unmarshal(raw, &node); err != nil {
+			continue
+		}
+		out[login] = model.ContributionActivity{
+			Login:             login,
+			CalendarTotal:     node.ContributionsCollection.ContributionCalendar.TotalContributions,
+			Restricted:        node.ContributionsCollection.RestrictedContributionsCount,
+			ContributionYears: node.ContributionsCollection.ContributionYears,
+		}
+	}
+	return nil
+}

--- a/internal/platform/github/contributor_activity_test.go
+++ b/internal/platform/github/contributor_activity_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package github
+
+// contributor_activity_test.go — TDD suite for the v0.27.57 batched
+// contributionsCollection fetcher. Mirrors the FetchIssueClosers
+// pattern: one aliased user() lookup per login, per-path NOT_FOUND
+// (deleted/renamed users) degrades to absence from the result map, and
+// batching keeps ~100 logins per HTTP round trip.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aveloxis/aveloxis/internal/platform"
+)
+
+func TestFetchContributorActivityBatchesAndDecodes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var queries int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		for _, needle := range []string{"contributionsCollection", "restrictedContributionsCount", "contributionYears", "totalContributions"} {
+			if !strings.Contains(req.Query, needle) {
+				t.Errorf("query must select %s, got: %.200s", needle, req.Query)
+			}
+		}
+		// u0: fully populated (the sgoggins probe shape, 2026-07-30);
+		// u1: deleted/renamed → per-path NOT_FOUND, node null;
+		// u2: brand-new account, zero everything.
+		fmt.Fprint(w, `{"data":{
+			"u0":{"login":"active-user","contributionsCollection":{"restrictedContributionsCount":1895,"contributionYears":[2026,2025,2010],"contributionCalendar":{"totalContributions":3637}}},
+			"u1":null,
+			"u2":{"login":"new-user","contributionsCollection":{"restrictedContributionsCount":0,"contributionYears":[],"contributionCalendar":{"totalContributions":0}}}
+		},"errors":[{"type":"NOT_FOUND","path":["u1"],"message":"Could not resolve to a User with the login of 'gone-user'."}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := New(srv.URL, platform.NewKeyPool([]string{"t"}, logger), logger)
+	got, err := client.FetchContributorActivity(t.Context(), []string{"active-user", "gone-user", "new-user"})
+	if err != nil {
+		t.Fatalf("FetchContributorActivity: %v", err)
+	}
+	if queries != 1 {
+		t.Errorf("3 logins must fit in ONE batched query, got %d", queries)
+	}
+	a, ok := got["active-user"]
+	if !ok {
+		t.Fatal("active-user missing from result")
+	}
+	if a.CalendarTotal != 3637 || a.Restricted != 1895 || a.LastContributionYear() != 2026 {
+		t.Errorf("active-user decoded wrong: %+v", a)
+	}
+	if a.PublicContributions() != 1742 {
+		t.Errorf("active-user public = %d, want 1742", a.PublicContributions())
+	}
+	// Deleted user: absent (no data → report no data), NOT an error.
+	if _, ok := got["gone-user"]; ok {
+		t.Error("gone-user (per-path NOT_FOUND) must be absent from the result map")
+	}
+	// Zero-everything user still present — absence means "unknown",
+	// presence-with-zeros means "confirmed quiet". The distinction is
+	// what the activity classes are built on.
+	z, ok := got["new-user"]
+	if !ok {
+		t.Fatal("new-user (zero contributions) must be PRESENT with zeros")
+	}
+	if z.CalendarTotal != 0 || z.Restricted != 0 || z.LastContributionYear() != 0 {
+		t.Errorf("new-user decoded wrong: %+v", z)
+	}
+}
+
+// More logins than one batch holds must split across multiple queries —
+// GitHub aliased-query batches are capped well under the point budget,
+// and a single oversized query would be rejected outright.
+func TestFetchContributorActivitySplitsLargeBatches(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var queries int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		aliases := strings.Count(req.Query, ": user(login:")
+		if aliases > contributorActivityBatchSize {
+			t.Errorf("query carries %d aliases, cap is %d", aliases, contributorActivityBatchSize)
+		}
+		fmt.Fprint(w, `{"data":{}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	logins := make([]string, contributorActivityBatchSize+1)
+	for i := range logins {
+		logins[i] = fmt.Sprintf("user%d", i)
+	}
+	client := New(srv.URL, platform.NewKeyPool([]string{"t"}, logger), logger)
+	if _, err := client.FetchContributorActivity(t.Context(), logins); err != nil {
+		t.Fatalf("FetchContributorActivity: %v", err)
+	}
+	if queries != 2 {
+		t.Errorf("batch-size+1 logins must take exactly 2 queries, got %d", queries)
+	}
+}

--- a/internal/platform/github/contributor_history.go
+++ b/internal/platform/github/contributor_history.go
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// contributor_history.go — v0.27.58 daily contributor-history fetch.
+// One GraphQL query per (user, window) returns, at rate-limit cost 1
+// (live-verified 2026-07-30): the daily contribution calendar
+// (includes disclosed private) plus the four by-repository connections
+// whose dated nodes give per-(day, repo) public activity. Windows are
+// operator-configurable (activity_history_window_days, default 180;
+// GitHub hard-caps any window at one year).
+//
+// Cap handling (operator contract): when a window hits the API's
+// 100-repositories-per-type cap or a contributions page overflows
+// (pageInfo.hasNextPage), the window is SUBDIVIDED in half and
+// re-fetched — cost stays proportional to real activity density —
+// with an INFO log per hit so loss rate is trackable. At the 1-day
+// minimum width a cap is unrecoverable: the loss is logged explicitly
+// and whatever WAS returned is kept.
+
+// HistoryWindow is one from/to span for a contributionsCollection
+// query. To is exclusive-ish (GitHub treats the range inclusively at
+// day granularity; adjacent windows share their boundary instant).
+type HistoryWindow struct {
+	From time.Time
+	To   time.Time
+}
+
+// historyMinWindow is the subdivision floor: below 48h a window's
+// halves would be sub-day, and the by-repository nodes are per-day
+// rollups — nothing finer exists to recover.
+const historyMinWindow = 48 * time.Hour
+
+// HistoryWindows tiles [account start → now] into windowDays-wide
+// spans, where the start is the later of account creation and Jan 1 of
+// the first contribution year. Windows with no overlap with any
+// contribution year are skipped (contributionYears is the API's own
+// index of non-empty years — querying the gaps would waste the whole
+// sweep's budget on empty windows). No years → nothing to fetch.
+func HistoryWindows(createdAt time.Time, years []int, now time.Time, windowDays int) []HistoryWindow {
+	if len(years) == 0 || windowDays <= 0 || !now.After(createdAt) {
+		return nil
+	}
+	active := make(map[int]bool, len(years))
+	minYear := years[0]
+	for _, y := range years {
+		active[y] = true
+		if y < minYear {
+			minYear = y
+		}
+	}
+	start := createdAt
+	if firstJan := time.Date(minYear, 1, 1, 0, 0, 0, 0, time.UTC); firstJan.After(start) {
+		start = firstJan
+	}
+	span := time.Duration(windowDays) * 24 * time.Hour
+	var out []HistoryWindow
+	for from := start; from.Before(now); from = from.Add(span) {
+		to := from.Add(span)
+		if to.After(now) {
+			to = now
+		}
+		overlaps := false
+		for y := from.Year(); y <= to.Year(); y++ {
+			if active[y] {
+				overlaps = true
+				break
+			}
+		}
+		if overlaps {
+			out = append(out, HistoryWindow{From: from, To: to})
+		}
+	}
+	return out
+}
+
+// FetchContributorHistoryMeta returns the account creation time and
+// contribution years — the inputs HistoryWindows needs. Cost: 1 point.
+func (c *Client) FetchContributorHistoryMeta(ctx context.Context, login string) (time.Time, []int, error) {
+	query := fmt.Sprintf(`query { user(login: %q) { createdAt contributionsCollection { contributionYears } } }`, login)
+	var resp struct {
+		User struct {
+			CreatedAt               time.Time `json:"createdAt"`
+			ContributionsCollection struct {
+				ContributionYears []int `json:"contributionYears"`
+			} `json:"contributionsCollection"`
+		} `json:"user"`
+	}
+	if err := c.http.GraphQL(ctx, query, nil, &resp); err != nil {
+		return time.Time{}, nil, fmt.Errorf("contributor history meta %q: %w", login, err)
+	}
+	return resp.User.CreatedAt, resp.User.ContributionsCollection.ContributionYears, nil
+}
+
+// historyAccumulator merges per-window results across windows and
+// subdivision levels.
+type historyAccumulator struct {
+	days   map[string]*model.ContributorDayActivity // key: day + "\x00" + repo
+	totals map[string]int                           // day → calendar total
+}
+
+func newHistoryAccumulator() *historyAccumulator {
+	return &historyAccumulator{days: map[string]*model.ContributorDayActivity{}, totals: map[string]int{}}
+}
+
+func (a *historyAccumulator) row(dayISO, repo string) *model.ContributorDayActivity {
+	key := dayISO + "\x00" + repo
+	if r, ok := a.days[key]; ok {
+		return r
+	}
+	r := &model.ContributorDayActivity{Day: dayISO, RepoFullName: repo}
+	a.days[key] = r
+	return r
+}
+
+// historyWindowResp mirrors the per-window GraphQL response.
+type historyWindowResp struct {
+	User struct {
+		ContributionsCollection historyCollection `json:"contributionsCollection"`
+	} `json:"user"`
+}
+
+type historyCollection struct {
+	ContributionCalendar struct {
+		Weeks []struct {
+			ContributionDays []struct {
+				Date              string `json:"date"`
+				ContributionCount int    `json:"contributionCount"`
+			} `json:"contributionDays"`
+		} `json:"weeks"`
+	} `json:"contributionCalendar"`
+	Commits []historyRepoEntry `json:"commitContributionsByRepository"`
+	Issues  []historyRepoEntry `json:"issueContributionsByRepository"`
+	PRs     []historyRepoEntry `json:"pullRequestContributionsByRepository"`
+	Reviews []historyRepoEntry `json:"pullRequestReviewContributionsByRepository"`
+}
+
+type historyRepoEntry struct {
+	Repository struct {
+		NameWithOwner string `json:"nameWithOwner"`
+	} `json:"repository"`
+	Contributions struct {
+		TotalCount int `json:"totalCount"`
+		PageInfo   struct {
+			HasNextPage bool `json:"hasNextPage"`
+		} `json:"pageInfo"`
+		Nodes []struct {
+			OccurredAt  time.Time `json:"occurredAt"`
+			CommitCount int       `json:"commitCount"`
+		} `json:"nodes"`
+	} `json:"contributions"`
+}
+
+// FetchContributorDailyHistory fetches and merges every window,
+// subdividing on cap hits. Errors abort (nothing is fabricated); the
+// caller retries the contributor on its next claim.
+func (c *Client) FetchContributorDailyHistory(ctx context.Context, login string, windows []HistoryWindow) ([]model.ContributorDayActivity, []model.ContributorDayTotal, error) {
+	acc := newHistoryAccumulator()
+	for _, w := range windows {
+		if err := c.fetchHistoryWindow(ctx, login, w, acc); err != nil {
+			return nil, nil, err
+		}
+	}
+	days := make([]model.ContributorDayActivity, 0, len(acc.days))
+	for _, r := range acc.days {
+		days = append(days, *r)
+	}
+	totals := make([]model.ContributorDayTotal, 0, len(acc.totals))
+	for d, n := range acc.totals {
+		totals = append(totals, model.ContributorDayTotal{Day: d, Total: n})
+	}
+	return days, totals, nil
+}
+
+func (c *Client) fetchHistoryWindow(ctx context.Context, login string, w HistoryWindow, acc *historyAccumulator) error {
+	query := fmt.Sprintf(`query { user(login: %q) { contributionsCollection(from: %q, to: %q) {
+  contributionCalendar { weeks { contributionDays { date contributionCount } } }
+  commitContributionsByRepository(maxRepositories: 100) { repository { nameWithOwner } contributions(first: 100) { totalCount pageInfo { hasNextPage } nodes { occurredAt commitCount } } }
+  issueContributionsByRepository(maxRepositories: 100) { repository { nameWithOwner } contributions(first: 100) { totalCount pageInfo { hasNextPage } nodes { occurredAt } } }
+  pullRequestContributionsByRepository(maxRepositories: 100) { repository { nameWithOwner } contributions(first: 100) { totalCount pageInfo { hasNextPage } nodes { occurredAt } } }
+  pullRequestReviewContributionsByRepository(maxRepositories: 100) { repository { nameWithOwner } contributions(first: 100) { totalCount pageInfo { hasNextPage } nodes { occurredAt } } }
+} } }`, login, w.From.UTC().Format(time.RFC3339), w.To.UTC().Format(time.RFC3339))
+
+	var resp historyWindowResp
+	if err := c.http.GraphQL(ctx, query, nil, &resp); err != nil {
+		return fmt.Errorf("contributor history window %q %s→%s: %w", login, w.From.Format("2006-01-02"), w.To.Format("2006-01-02"), err)
+	}
+	cc := resp.User.ContributionsCollection
+	capped := historyWindowCapped(cc)
+	if capped != "" {
+		if w.To.Sub(w.From) >= historyMinWindow {
+			// Subdivide: the halves re-fetch EVERYTHING in this span, so
+			// the capped (incomplete) result is discarded, not merged.
+			c.logger.Info("activity cap hit — subdividing window",
+				"login", login, "cap", capped,
+				"from", w.From.Format("2006-01-02"), "to", w.To.Format("2006-01-02"))
+			mid := w.From.Add(w.To.Sub(w.From) / 2)
+			if err := c.fetchHistoryWindow(ctx, login, HistoryWindow{From: w.From, To: mid}, acc); err != nil {
+				return err
+			}
+			return c.fetchHistoryWindow(ctx, login, HistoryWindow{From: mid, To: w.To}, acc)
+		}
+		c.logger.Info("activity cap hit at minimum window — data lost",
+			"login", login, "cap", capped,
+			"from", w.From.Format("2006-01-02"), "to", w.To.Format("2006-01-02"))
+		// Fall through: keep what WAS returned — partial beats nothing.
+	}
+
+	for _, week := range cc.ContributionCalendar.Weeks {
+		for _, d := range week.ContributionDays {
+			if d.ContributionCount > 0 {
+				acc.totals[d.Date] = d.ContributionCount
+			}
+		}
+	}
+	// Merge with ASSIGNMENT semantics, not accumulation: adjacent
+	// windows share a boundary instant and the API is day-bucketed, so
+	// a boundary day can legitimately arrive from BOTH windows with
+	// identical values — assignment makes that (and any re-fetch)
+	// idempotent, where += would double-count. Within one window, the
+	// per-item types are counted locally first, then assigned.
+	localCount := func(entries []historyRepoEntry) map[[2]string]int {
+		counts := map[[2]string]int{}
+		for _, e := range entries {
+			for _, n := range e.Contributions.Nodes {
+				key := [2]string{n.OccurredAt.Format("2006-01-02"), e.Repository.NameWithOwner}
+				if n.CommitCount > 0 {
+					counts[key] = n.CommitCount // per-(day,repo) rollup node
+				} else {
+					counts[key]++ // per-item node (issues/PRs/reviews)
+				}
+			}
+		}
+		return counts
+	}
+	for key, n := range localCount(cc.Commits) {
+		acc.row(key[0], key[1]).Commits = n
+	}
+	for key, n := range localCount(cc.Issues) {
+		acc.row(key[0], key[1]).Issues = n
+	}
+	for key, n := range localCount(cc.PRs) {
+		acc.row(key[0], key[1]).PRs = n
+	}
+	for key, n := range localCount(cc.Reviews) {
+		acc.row(key[0], key[1]).Reviews = n
+	}
+	return nil
+}
+
+// historyWindowCapped reports which cap (if any) a window response hit:
+// the 100-repositories-per-type list cap, or an overflowing
+// contributions page. Empty string = complete.
+func historyWindowCapped(cc historyCollection) string {
+	for name, entries := range map[string][]historyRepoEntry{
+		"commit": cc.Commits, "issue": cc.Issues, "pull_request": cc.PRs, "review": cc.Reviews,
+	} {
+		if len(entries) >= 100 {
+			return name + "-repo-cap"
+		}
+		for _, e := range entries {
+			if e.Contributions.PageInfo.HasNextPage {
+				return name + "-page-overflow"
+			}
+		}
+	}
+	return ""
+}

--- a/internal/platform/github/contributor_history_test.go
+++ b/internal/platform/github/contributor_history_test.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package github
+
+// contributor_history_test.go — TDD suite for the v0.27.58 daily
+// contributor-history fetcher. Contracts:
+//   - HistoryWindows tiles [account start → now] in configurable spans
+//     (config → behavior end-to-end per the config-knobs rule), skipping
+//     windows with no overlap with any contribution year;
+//   - one GraphQL query per (user, window); day rows merge the four
+//     contribution types per (day, repo); calendar day totals ride the
+//     same query;
+//   - hitting the API's caps (100 repositories per type, or a
+//     contribution page with hasNextPage) SUBDIVIDES the window in half
+//     rather than accepting loss, logging at INFO (operator ask:
+//     "log on INFO whenever a user hits the activity cap so we can
+//     keep track of loss rate");
+//   - at the 1-day minimum window a cap is unrecoverable: log the loss
+//     explicitly and keep what was returned.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/config"
+	"github.com/aveloxis/aveloxis/internal/platform"
+)
+
+func day(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestHistoryWindowsTilesAndSkipsInactiveYears(t *testing.T) {
+	created := day("2015-06-01")
+	years := []int{2026, 2025, 2016} // 2017-2024 inactive, 2015 pre-first-contribution
+	now := day("2026-07-30")
+	wins := HistoryWindows(created, years, now, 180)
+	if len(wins) == 0 {
+		t.Fatal("expected windows")
+	}
+	// Starts no earlier than Jan 1 of the first contribution year
+	// (2016) — 2015 has no contributions, and account creation caps it.
+	if wins[0].From.Before(day("2016-01-01")) {
+		t.Errorf("first window starts %s — must not precede the first contribution year", wins[0].From)
+	}
+	for _, w := range wins {
+		if !w.To.After(w.From) {
+			t.Fatalf("degenerate window %+v", w)
+		}
+		if w.To.Sub(w.From) > 180*24*time.Hour {
+			t.Errorf("window %s→%s exceeds the 180-day span", w.From, w.To)
+		}
+		// No window may lie entirely inside the inactive 2017-2024 gap.
+		if w.From.Year() >= 2017 && w.To.Year() <= 2024 {
+			t.Errorf("window %s→%s has no overlap with any contribution year and must be skipped", w.From, w.To)
+		}
+	}
+	last := wins[len(wins)-1]
+	if last.To.Before(now.Add(-24 * time.Hour)) {
+		t.Errorf("final window must reach now, ends %s", last.To)
+	}
+	if len(HistoryWindows(created, nil, now, 180)) != 0 {
+		t.Error("no contribution years → no windows (nothing to fetch)")
+	}
+}
+
+// The config→behavior path (config-knobs-end-to-end rule): the JSON
+// value flows through the accessor into the spans actually generated.
+func TestHistoryWindowsHonorConfiguredSpanEndToEnd(t *testing.T) {
+	var c config.CollectionConfig
+	if err := json.Unmarshal([]byte(`{"activity_history_window_days": 90}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	wins := HistoryWindows(day("2025-01-01"), []int{2025, 2026}, day("2026-01-01"), c.ActivityHistoryWindowDaysOrDefault())
+	if len(wins) < 4 {
+		t.Fatalf("a 1-year span at 90-day windows must yield >= 4 windows, got %d", len(wins))
+	}
+	for _, w := range wins {
+		if w.To.Sub(w.From) > 90*24*time.Hour {
+			t.Errorf("window %s→%s exceeds the configured 90-day span", w.From, w.To)
+		}
+	}
+}
+
+// historyResponse builds a window response. capRepos=true emits exactly
+// 100 commit-repo entries (the repo cap); overflow=true marks the first
+// repo's contributions page hasNextPage.
+func historyResponse(capRepos, overflow bool) string {
+	repoEntry := func(name string, dayISO string, n int, hasNext bool) string {
+		return fmt.Sprintf(`{"repository":{"nameWithOwner":%q},"contributions":{"totalCount":%d,"pageInfo":{"hasNextPage":%v},"nodes":[{"occurredAt":"%sT07:00:00Z","commitCount":%d}]}}`,
+			name, n, hasNext, dayISO, n)
+	}
+	var commitRepos []string
+	if capRepos {
+		for i := 0; i < 100; i++ {
+			commitRepos = append(commitRepos, repoEntry(fmt.Sprintf("o/r%d", i), "2026-03-05", 1, false))
+		}
+	} else {
+		commitRepos = append(commitRepos, repoEntry("aveloxis/aveloxis", "2026-03-05", 4, overflow))
+	}
+	return fmt.Sprintf(`{"data":{"user":{"contributionsCollection":{
+		"contributionCalendar":{"weeks":[{"contributionDays":[{"date":"2026-03-05","contributionCount":9}]}]},
+		"commitContributionsByRepository":[%s],
+		"issueContributionsByRepository":[{"repository":{"nameWithOwner":"aveloxis/aveloxis"},"contributions":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"occurredAt":"2026-03-05T07:00:00Z"}]}}],
+		"pullRequestContributionsByRepository":[],
+		"pullRequestReviewContributionsByRepository":[]
+	}}}}`, strings.Join(commitRepos, ","))
+}
+
+func newHistoryTestClient(t *testing.T, handler http.HandlerFunc) (*Client, *bytes.Buffer) {
+	t.Helper()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return New(srv.URL, platform.NewKeyPool([]string{"t"}, logger), logger), &logBuf
+}
+
+func TestFetchContributorDailyHistoryMergesTypes(t *testing.T) {
+	var queries int
+	client, _ := newHistoryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		fmt.Fprint(w, historyResponse(false, false))
+	})
+	wins := []HistoryWindow{
+		{From: day("2026-01-01"), To: day("2026-06-30")},
+		{From: day("2026-06-30"), To: day("2026-07-30")},
+	}
+	days, totals, err := client.FetchContributorDailyHistory(t.Context(), "sgoggins", wins)
+	if err != nil {
+		t.Fatalf("FetchContributorDailyHistory: %v", err)
+	}
+	if queries != 2 {
+		t.Errorf("2 uncapped windows must take exactly 2 queries, got %d", queries)
+	}
+	// Same (day, repo) from commit AND issue types merges into ONE row.
+	var found bool
+	for _, d := range days {
+		if d.Day == "2026-03-05" && d.RepoFullName == "aveloxis/aveloxis" {
+			found = true
+			if d.Commits != 4 || d.Issues != 1 {
+				t.Errorf("merged row wrong: %+v (want commits=4 issues=1)", d)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a merged (2026-03-05, aveloxis/aveloxis) day row")
+	}
+	var totalFound bool
+	for _, dt := range totals {
+		if dt.Day == "2026-03-05" && dt.Total == 9 {
+			totalFound = true
+		}
+	}
+	if !totalFound {
+		t.Error("calendar day totals must ride the same fetch (2026-03-05 → 9)")
+	}
+}
+
+func TestFetchContributorDailyHistorySubdividesOnCapAndLogs(t *testing.T) {
+	var queries int
+	client, logBuf := newHistoryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		if queries == 1 {
+			fmt.Fprint(w, historyResponse(true, false)) // 100 repos → cap
+			return
+		}
+		fmt.Fprint(w, historyResponse(false, false))
+	})
+	wins := []HistoryWindow{{From: day("2026-01-01"), To: day("2026-06-30")}}
+	_, _, err := client.FetchContributorDailyHistory(t.Context(), "busy-user", wins)
+	if err != nil {
+		t.Fatalf("FetchContributorDailyHistory: %v", err)
+	}
+	if queries != 3 {
+		t.Errorf("capped window must subdivide into two halves (1 + 2 queries), got %d", queries)
+	}
+	log := logBuf.String()
+	if !strings.Contains(log, "activity cap hit") {
+		t.Errorf("cap hits must log at INFO with 'activity cap hit' (loss-rate tracking), got: %s", log)
+	}
+	if !strings.Contains(log, "busy-user") {
+		t.Error("the cap log must identify the user")
+	}
+}
+
+func TestFetchContributorDailyHistoryMinWindowLossIsLogged(t *testing.T) {
+	var queries int
+	client, logBuf := newHistoryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		queries++
+		fmt.Fprint(w, historyResponse(true, false)) // ALWAYS capped
+	})
+	// A 1-day window cannot subdivide: exactly one query, loss logged.
+	wins := []HistoryWindow{{From: day("2026-03-05"), To: day("2026-03-06")}}
+	days, _, err := client.FetchContributorDailyHistory(t.Context(), "hyper-user", wins)
+	if err != nil {
+		t.Fatalf("FetchContributorDailyHistory: %v", err)
+	}
+	if queries != 1 {
+		t.Errorf("minimum-width window must not recurse (infinite subdivision guard), got %d queries", queries)
+	}
+	if len(days) == 0 {
+		t.Error("capped minimum window must still keep the data that WAS returned")
+	}
+	if !strings.Contains(logBuf.String(), "data lost") {
+		t.Errorf("unrecoverable cap at minimum window must log 'data lost': %s", logBuf.String())
+	}
+}
+
+func TestFetchContributorHistoryMeta(t *testing.T) {
+	client, _ := newHistoryTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"user":{"createdAt":"2010-08-29T16:25:48Z","contributionsCollection":{"contributionYears":[2026,2025,2010]}}}}`)
+	})
+	created, years, err := client.FetchContributorHistoryMeta(t.Context(), "sgoggins")
+	if err != nil {
+		t.Fatalf("FetchContributorHistoryMeta: %v", err)
+	}
+	if created.Year() != 2010 || len(years) != 3 || years[0] != 2026 {
+		t.Errorf("meta decoded wrong: created=%s years=%v", created, years)
+	}
+}

--- a/internal/scheduler/activity_classification.go
+++ b/internal/scheduler/activity_classification.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/db"
+	"github.com/aveloxis/aveloxis/internal/model"
+)
+
+// activity_classification.go — the v0.27.57 contributor
+// activity-classification sweep. GitHub's GraphQL
+// contributionsCollection is the only API surface that distinguishes
+// "publicly active" / "privately active but disclosed"
+// (restrictedContributionsCount) / "dormant" / "no observable
+// activity"; the REST events feed the breadth worker uses returns an
+// empty list for all non-public states indistinguishably. The sweep
+// claims contributors oldest-checked-first (same jittered-cooldown
+// contract as breadth), fetches summaries in ~100-login batched
+// GraphQL queries, classifies via model.ClassifyContributorActivity,
+// and writes the results onto contributors.gh_activity_*.
+//
+// GITHUB-ONLY: GitLab has no restricted-contributions equivalent
+// (private profiles are simply invisible), so the fetch is consumed
+// via the narrow capability interface below — satisfied by
+// *github.Client, absent on GitLab clients and test fakes, in which
+// case the sweep is a no-op. platform.Client is deliberately NOT
+// widened.
+
+// contributorActivityFetcher is the capability the sweep needs from
+// the GitHub client (the digestMailer / breadthStore narrow-interface
+// pattern).
+type contributorActivityFetcher interface {
+	FetchContributorActivity(ctx context.Context, logins []string) (map[string]model.ContributionActivity, error)
+}
+
+// Cadence constants — derived, not magic. Batch 2,500 every 15 minutes
+// = 240K checks/day = the 2.44M-contributor pool every ~10 days,
+// comfortably inside the breadth cooldown the sweep shares (the two
+// stay roughly in phase). API cost: 2,500 logins / 100-per-query = 25
+// GraphQL queries per tick ≈ 2,400/day — noise against the pooled
+// 5K-points/hour/token GraphQL budget.
+const (
+	activityCheckInterval = 15 * time.Minute
+	activityCheckBatch    = 2500
+)
+
+// runActivityClassification performs one sweep tick. Failure contract:
+// a failed FETCH marks nothing (the claimed batch stays at the queue
+// head and retries next tick — a transient GraphQL outage must not
+// stamp 2,500 contributors dataless for a whole cooldown period);
+// contributors ABSENT from a successful fetch (deleted/renamed
+// accounts, per-path NOT_FOUND) are mark-only stamped so they leave
+// the NULLS-FIRST claim head (the v0.20.17 lesson).
+func (s *Scheduler) runActivityClassification(ctx context.Context) {
+	fetcher, ok := s.ghClient.(contributorActivityFetcher)
+	if !ok {
+		return // no GitHub GraphQL client (GitLab-only deployment or test fake)
+	}
+	cooldown := s.cfg.Collection.BreadthCooldownDuration()
+	claimed, err := s.store.GetContributorsForActivityCheck(ctx, activityCheckBatch, cooldown)
+	if err != nil {
+		s.logger.Warn("activity classification: claim failed", "error", err)
+		return
+	}
+	if len(claimed) == 0 {
+		return
+	}
+	logins := make([]string, 0, len(claimed))
+	for _, c := range claimed {
+		logins = append(logins, c.Login)
+	}
+	start := time.Now()
+	activities, err := fetcher.FetchContributorActivity(ctx, logins)
+	if err != nil {
+		s.logger.Warn("activity classification: fetch failed — batch will retry next tick", "claimed", len(claimed), "error", err)
+		return
+	}
+
+	// classification split: present → classified update; absent → mark-only.
+	var updates []db.ContributorActivityUpdate
+	var absent []string
+	for _, c := range claimed {
+		act, ok := activities[c.Login]
+		if !ok {
+			absent = append(absent, c.ID)
+			continue
+		}
+		public := act.PublicContributions()
+		lastYear := act.LastContributionYear()
+		updates = append(updates, db.ContributorActivityUpdate{
+			CntrbID:              c.ID,
+			PublicContribs:       public,
+			RestrictedContribs:   act.Restricted,
+			LastContributionYear: lastYear,
+			ActivityClass:        model.ClassifyContributorActivity(public, act.Restricted, lastYear),
+		})
+	}
+	if len(updates) > 0 {
+		if err := s.store.UpdateContributorActivityBatch(ctx, updates); err != nil {
+			s.logger.Warn("activity classification: update failed", "count", len(updates), "error", err)
+			return
+		}
+	}
+	if len(absent) > 0 {
+		if err := s.store.MarkActivityCheckedBatch(ctx, absent); err != nil {
+			s.logger.Warn("activity classification: mark-absent failed", "count", len(absent), "error", err)
+		}
+	}
+	s.logger.Info("activity classification cycle complete",
+		"claimed", len(claimed), "classified", len(updates), "absent", len(absent),
+		"duration", time.Since(start).Truncate(time.Millisecond))
+}

--- a/internal/scheduler/activity_classification_test.go
+++ b/internal/scheduler/activity_classification_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+// activity_classification_test.go — TDD suite for the v0.27.57
+// contributor activity-classification ticker. Contracts pinned:
+//   - the GitHub-only fetch is reached via a NARROW capability
+//     interface satisfied by *github.Client (the digestMailer /
+//     breadthStore pattern) — platform.Client is NOT widened, so no
+//     test fake or GitLab implementation changes (regression safety);
+//   - a failed fetch marks NOTHING (the whole batch retries next
+//     tick — a transient GraphQL outage must not burn a cooldown
+//     period for 2,500 contributors);
+//   - contributors ABSENT from a successful fetch are mark-only
+//     (deleted/renamed accounts leave the claim head, v0.20.17);
+//   - the ticker rides Run's select loop under singleFlight.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func readSchedulerFile(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestActivityFetcherIsNarrowCapabilityInterface(t *testing.T) {
+	src := readSchedulerFile(t, "activity_classification.go")
+	if !strings.Contains(src, "type contributorActivityFetcher interface") {
+		t.Fatal("the GitHub-only fetch must be consumed via a scheduler-side capability interface, not by widening platform.Client (which would force every implementation and test fake to change)")
+	}
+	if !strings.Contains(src, "FetchContributorActivity(") {
+		t.Error("the capability interface must declare FetchContributorActivity")
+	}
+	if !strings.Contains(src, ".(contributorActivityFetcher)") {
+		t.Error("runActivityClassification must type-assert s.ghClient against the capability interface and no-op when absent (GitLab-only or fake clients)")
+	}
+}
+
+func TestActivityClassificationErrorPathMarksNothing(t *testing.T) {
+	src := readSchedulerFile(t, "activity_classification.go")
+	idx := strings.Index(src, "FetchContributorActivity(")
+	if idx < 0 {
+		t.Fatal("cannot find the fetch call")
+	}
+	// The error-handling window immediately after the fetch: it must
+	// return without any Mark/Update call, so the batch stays claimable
+	// for the next tick instead of burning a cooldown on an outage.
+	window := src[idx:]
+	if end := strings.Index(window, "// classification split"); end > 0 {
+		window = window[:end]
+	}
+	if !strings.Contains(window, "return") {
+		t.Fatal("the fetch-error path must return early")
+	}
+	if strings.Contains(window, "MarkActivityCheckedBatch") || strings.Contains(window, "UpdateContributorActivityBatch") {
+		t.Error("the fetch-error path must not mark or update anything — marking on outage would stamp 2,500 contributors with no data for a full cooldown period")
+	}
+}
+
+func TestActivityClassificationMarksAbsentContributors(t *testing.T) {
+	src := readSchedulerFile(t, "activity_classification.go")
+	if !strings.Contains(src, "MarkActivityCheckedBatch") {
+		t.Error("contributors absent from a successful fetch (deleted/renamed) must be mark-only stamped so they leave the NULLS-FIRST claim head")
+	}
+	if !strings.Contains(src, "UpdateContributorActivityBatch") {
+		t.Error("contributors present in the fetch must get the full classified update")
+	}
+	if !strings.Contains(src, "ClassifyContributorActivity") {
+		t.Error("classification must go through model.ClassifyContributorActivity — the single source of the class rules")
+	}
+}
+
+func TestActivityTickerWiredIntoRun(t *testing.T) {
+	src := readSchedulerFile(t, "scheduler.go")
+	if !strings.Contains(src, "activityTicker") {
+		t.Fatal("Run must declare an activityTicker for the classification sweep")
+	}
+	if !strings.Contains(src, "runActivityClassification") {
+		t.Fatal("Run's select loop must dispatch runActivityClassification")
+	}
+	if !strings.Contains(src, "s.singleFlight(&s.activityClassActive") {
+		t.Error("the ticker case must run under singleFlight so a slow sweep can't stack concurrent instances (the breadth/enrichment pattern)")
+	}
+}

--- a/internal/scheduler/activity_history.go
+++ b/internal/scheduler/activity_history.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aveloxis/aveloxis/internal/model"
+	"github.com/aveloxis/aveloxis/internal/platform"
+	"github.com/aveloxis/aveloxis/internal/platform/github"
+)
+
+// activity_history.go — the v0.27.58 daily contributor-history sweep.
+// For each claimed contributor: fetch account meta (createdAt +
+// contributionYears), tile the account's active span into
+// operator-configured windows (activity_history_window_days, default
+// 180), fetch each window's per-(day, repo) public activity + daily
+// calendar totals (the fetcher subdivides on cap hits and logs them at
+// INFO), and store everything with the gh_history_backfilled_at stamp
+// in one transaction. The claim's NULL-first ordering makes newly
+// discovered contributors self-staging, and its 90-day cooldown IS the
+// quarterly re-audit (operator decision 2026-07-30).
+//
+// GITHUB-ONLY via the narrow capability interface below (GitLab has no
+// contributionsCollection equivalent; platform.Client is not widened).
+
+// contributorHistoryFetcher is the capability the sweep needs from the
+// GitHub client.
+type contributorHistoryFetcher interface {
+	FetchContributorHistoryMeta(ctx context.Context, login string) (time.Time, []int, error)
+	FetchContributorDailyHistory(ctx context.Context, login string, windows []github.HistoryWindow) ([]model.ContributorDayActivity, []model.ContributorDayTotal, error)
+}
+
+// Cadence constants — derived, not magic. The full-fat window query
+// costs 1 rate-limit point (live-verified 2026-07-30), so the budget
+// constraint is query COUNT, not points. Batch 25 contributors per
+// 1-minute tick at an average ~10-30 windows each ≈ 250-750 queries/
+// minute peak ≈ 12% of the 73-token pool's hourly capacity, and the
+// bootstrap covers the active-classified million (claimed first) in
+// roughly two weeks. The re-audit cooldown is quarterly.
+const (
+	activityHistoryInterval = time.Minute
+	activityHistoryBatch    = 25
+	activityHistoryCooldown = 90 * 24 * time.Hour
+)
+
+// runActivityHistory performs one sweep tick. Per-contributor failure
+// contract: a missing account (meta 404 → ErrNotFound class) is
+// mark-only stamped; any OTHER error stamps nothing so the contributor
+// retries on the next claim.
+func (s *Scheduler) runActivityHistory(ctx context.Context) {
+	fetcher, ok := s.ghClient.(contributorHistoryFetcher)
+	if !ok {
+		return // no GitHub GraphQL client (GitLab-only deployment or test fake)
+	}
+	claimed, err := s.store.GetContributorsForHistoryBackfill(ctx, activityHistoryBatch, activityHistoryCooldown)
+	if err != nil {
+		s.logger.Warn("activity history: claim failed", "error", err)
+		return
+	}
+	if len(claimed) == 0 {
+		return
+	}
+	windowDays := s.cfg.Collection.ActivityHistoryWindowDaysOrDefault()
+	start := time.Now()
+	stored, marked, failed := 0, 0, 0
+	for _, c := range claimed {
+		if ctx.Err() != nil {
+			return
+		}
+		created, years, err := fetcher.FetchContributorHistoryMeta(ctx, c.Login)
+		if err != nil {
+			if errors.Is(err, platform.ErrNotFound) || platform.ClassifyError(err) == platform.ClassSkip {
+				// Deleted/renamed account: stamp so the claim head drains.
+				if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr == nil {
+					marked++
+				}
+				continue
+			}
+			s.logger.Warn("activity history: meta fetch failed — will retry on next claim", "login", c.Login, "error", err)
+			failed++
+			continue
+		}
+		windows := github.HistoryWindows(created, years, time.Now().UTC(), windowDays)
+		if len(windows) == 0 {
+			// Account exists but has zero contribution years: nothing to
+			// fetch, ever — stamp it.
+			if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr == nil {
+				marked++
+			}
+			continue
+		}
+		days, totals, err := fetcher.FetchContributorDailyHistory(ctx, c.Login, windows)
+		if err != nil {
+			s.logger.Warn("activity history: fetch failed — will retry on next claim", "login", c.Login, "windows", len(windows), "error", err)
+			failed++
+			continue
+		}
+		if err := s.store.StoreContributorActivityHistory(ctx, c.ID, days, totals); err != nil {
+			s.logger.Warn("activity history: store failed — will retry on next claim", "login", c.Login, "error", err)
+			failed++
+			continue
+		}
+		stored++
+	}
+	s.logger.Info("activity history cycle complete",
+		"claimed", len(claimed), "stored", stored, "marked_no_data", marked, "failed", failed,
+		"window_days", windowDays, "duration", time.Since(start).Truncate(time.Millisecond))
+}

--- a/internal/scheduler/activity_history.go
+++ b/internal/scheduler/activity_history.go
@@ -75,7 +75,14 @@ func (s *Scheduler) runActivityHistory(ctx context.Context) {
 		if err != nil {
 			if errors.Is(err, platform.ErrNotFound) || platform.ClassifyError(err) == platform.ClassSkip {
 				// Deleted/renamed account: stamp so the claim head drains.
-				if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr == nil {
+				// A failed stamp leaves the contributor at the claim head
+				// for a pointless re-fetch every tick — log it and count
+				// it as a failure so the operator sees the churn (Copilot
+				// review, PR #171).
+				if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr != nil {
+					s.logger.Warn("activity history: mark-only stamp failed — contributor will be re-claimed", "login", c.Login, "error", merr)
+					failed++
+				} else {
 					marked++
 				}
 				continue
@@ -87,8 +94,11 @@ func (s *Scheduler) runActivityHistory(ctx context.Context) {
 		windows := github.HistoryWindows(created, years, time.Now().UTC(), windowDays)
 		if len(windows) == 0 {
 			// Account exists but has zero contribution years: nothing to
-			// fetch, ever — stamp it.
-			if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr == nil {
+			// fetch, ever — stamp it. Same failure treatment as above.
+			if merr := s.store.MarkHistoryBackfilled(ctx, c.ID); merr != nil {
+				s.logger.Warn("activity history: zero-years stamp failed — contributor will be re-claimed", "login", c.Login, "error", merr)
+				failed++
+			} else {
 				marked++
 			}
 			continue

--- a/internal/scheduler/activity_history_test.go
+++ b/internal/scheduler/activity_history_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scheduler
+
+// activity_history_test.go — TDD suite for the v0.27.58 daily
+// contributor-history sweep worker. Contracts:
+//   - GitHub-only fetch via a narrow capability interface (platform.
+//     Client NOT widened — no regression surface);
+//   - windows are built from the CONFIGURED span
+//     (activity_history_window_days → ActivityHistoryWindowDaysOrDefault
+//     → HistoryWindows), the config-knobs-end-to-end wiring;
+//   - a contributor whose meta fetch 404s (deleted/renamed) is
+//     mark-only stamped; a fetch ERROR stamps nothing (retry next
+//     tick);
+//   - ticker rides Run's select under singleFlight.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHistoryFetcherIsNarrowCapabilityInterface(t *testing.T) {
+	src := readSchedulerFile(t, "activity_history.go")
+	if !strings.Contains(src, "type contributorHistoryFetcher interface") {
+		t.Fatal("history fetch must be consumed via a scheduler-side capability interface (platform.Client must not be widened)")
+	}
+	for _, m := range []string{"FetchContributorHistoryMeta(", "FetchContributorDailyHistory("} {
+		if !strings.Contains(src, m) {
+			t.Errorf("capability interface must declare %s", m)
+		}
+	}
+	if !strings.Contains(src, ".(contributorHistoryFetcher)") {
+		t.Error("runActivityHistory must type-assert s.ghClient and no-op when the capability is absent")
+	}
+}
+
+func TestHistoryWorkerUsesConfiguredWindowSpan(t *testing.T) {
+	src := readSchedulerFile(t, "activity_history.go")
+	if !strings.Contains(src, "ActivityHistoryWindowDaysOrDefault()") {
+		t.Fatal("the worker must build windows from the configured activity_history_window_days (via the clamping accessor) — the config-knobs-end-to-end contract")
+	}
+	if !strings.Contains(src, "github.HistoryWindows(") {
+		t.Error("windows must come from the shared github.HistoryWindows tiling function")
+	}
+}
+
+func TestHistoryWorkerFailureContract(t *testing.T) {
+	src := readSchedulerFile(t, "activity_history.go")
+	if !strings.Contains(src, "MarkHistoryBackfilled") {
+		t.Error("contributors with no fetchable account (meta absent) must be mark-only stamped so they leave the NULLS-FIRST claim head")
+	}
+	if !strings.Contains(src, "StoreContributorActivityHistory") {
+		t.Error("fetched history must go through the single-transaction StoreContributorActivityHistory (data + stamp atomic)")
+	}
+	// Error path: a failed history fetch must NOT stamp — pin the
+	// continue-without-mark shape. Anchor on the CALL site
+	// (fetcher.Fetch...), not the capability-interface declaration.
+	idx := strings.Index(src, "fetcher.FetchContributorDailyHistory(")
+	if idx < 0 {
+		t.Fatal("cannot find the history fetch call site")
+	}
+	window := src[idx:]
+	if end := strings.Index(window, "StoreContributorActivityHistory"); end > 0 {
+		window = window[:end]
+	}
+	if strings.Contains(window, "MarkHistoryBackfilled") {
+		t.Error("a FAILED history fetch must not stamp the contributor — the claim must retry next tick, not silently skip a cooldown period")
+	}
+}
+
+func TestHistoryTickerWiredIntoRun(t *testing.T) {
+	src := readSchedulerFile(t, "scheduler.go")
+	if !strings.Contains(src, "historyTicker") {
+		t.Fatal("Run must declare a historyTicker for the daily-history sweep")
+	}
+	if !strings.Contains(src, "runActivityHistory") {
+		t.Fatal("Run's select loop must dispatch runActivityHistory")
+	}
+	if !strings.Contains(src, "s.singleFlight(&s.activityHistActive") {
+		t.Error("the ticker must run under singleFlight (a slow sweep must not stack)")
+	}
+}

--- a/internal/scheduler/runjob_lifecycle_test.go
+++ b/internal/scheduler/runjob_lifecycle_test.go
@@ -45,7 +45,7 @@ func TestRunJobLifecycleEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	store.SetMatviewSkip(true)
 	if err := db.RunMigrations(ctx, store, logger); err != nil {
 		t.Fatalf("RunMigrations: %v", err)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -105,6 +105,7 @@ type Scheduler struct {
 	// tasks (see singleFlight).
 	enrichmentActive    atomic.Bool
 	activityClassActive atomic.Bool
+	activityHistActive  atomic.Bool
 	searchActive        atomic.Bool
 	affiliationsActive  atomic.Bool
 	breadthActive       atomic.Bool
@@ -339,6 +340,11 @@ func (s *Scheduler) Run(ctx context.Context) {
 	// activity_classification.go.
 	activityTicker := time.NewTicker(activityCheckInterval)
 	defer activityTicker.Stop()
+	// v0.27.58: daily contributor-history sweep (bootstrap + quarterly
+	// re-audit in one claim mechanism; constants derived in
+	// activity_history.go).
+	historyTicker := time.NewTicker(activityHistoryInterval)
+	defer historyTicker.Stop()
 	defer breadthTicker.Stop()
 	// v0.27.18: construct the breadth worker ONCE, here (not lazily in
 	// runBreadth, which runs in a per-tick goroutine — lazy init would
@@ -538,6 +544,9 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 		case <-activityTicker.C:
 			s.singleFlight(&s.activityClassActive, "activity-classification", func() { s.runActivityClassification(ctx) })
+
+		case <-historyTicker.C:
+			s.singleFlight(&s.activityHistActive, "activity-history", func() { s.runActivityHistory(ctx) })
 
 		case <-matviewCheckTicker.C:
 			now := time.Now()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -103,10 +103,11 @@ type Scheduler struct {
 
 	// v0.27.40 single-flight guards for the ticker-fired background
 	// tasks (see singleFlight).
-	enrichmentActive   atomic.Bool
-	searchActive       atomic.Bool
-	affiliationsActive atomic.Bool
-	breadthActive      atomic.Bool
+	enrichmentActive    atomic.Bool
+	activityClassActive atomic.Bool
+	searchActive        atomic.Bool
+	affiliationsActive  atomic.Bool
+	breadthActive       atomic.Bool
 	// v0.27.52: shared by the orgRefreshTicker pass AND the poll-tick
 	// demand scan (maybeScanNewOrgs) so the two can never overlap.
 	userOrgScanActive atomic.Bool
@@ -333,6 +334,11 @@ func (s *Scheduler) Run(ctx context.Context) {
 	// and left zero-event contributors stuck at the queue head
 	// forever.
 	breadthTicker := time.NewTicker(s.cfg.Collection.BreadthIntervalDuration())
+	// v0.27.57: contribution-activity classification sweep (GraphQL
+	// contributionsCollection). Cadence constants derived in
+	// activity_classification.go.
+	activityTicker := time.NewTicker(activityCheckInterval)
+	defer activityTicker.Stop()
 	defer breadthTicker.Stop()
 	// v0.27.18: construct the breadth worker ONCE, here (not lazily in
 	// runBreadth, which runs in a per-tick goroutine — lazy init would
@@ -529,6 +535,9 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 		case <-breadthTicker.C:
 			s.singleFlight(&s.breadthActive, "contributor-breadth", func() { s.runBreadth(ctx) })
+
+		case <-activityTicker.C:
+			s.singleFlight(&s.activityClassActive, "activity-classification", func() { s.runActivityClassification(ctx) })
 
 		case <-matviewCheckTicker.C:
 			now := time.Now()
@@ -1826,12 +1835,20 @@ func (s *Scheduler) rebuildMatviews(ctx context.Context) {
 
 	// Refresh dm_ aggregate tables (dm_repo_annual/monthly/weekly and
 	// dm_repo_group variants). These aggregate commit data by email,
-	// affiliation, and time period.
-	aggStart := time.Now()
-	if err := s.store.RefreshAllRepoAggregates(ctx, s.logger); err != nil {
-		s.logger.Error("dm_ aggregate refresh failed", "error", err)
+	// affiliation, and time period. v0.27.56: skippable by config —
+	// the per-repo loop ran 3+ days on the production fleet
+	// (2026-07-27→30) while MatviewRebuildActive held all collection
+	// claims paused; operators can now keep the weekly matview step
+	// and refresh dm_ tables only via `aveloxis refresh-views`.
+	if s.cfg.Collection.MatviewRebuildSkipDMAggregates {
+		s.logger.Info("dm_ aggregate refresh skipped by config (matview_rebuild_skip_dm_aggregates=true) — dm_ tables update only via refresh-views/migrate")
 	} else {
-		s.logger.Info("dm_ aggregate refresh complete", "duration", time.Since(aggStart).Truncate(time.Second))
+		aggStart := time.Now()
+		if err := s.store.RefreshAllRepoAggregates(ctx, s.logger); err != nil {
+			s.logger.Error("dm_ aggregate refresh failed", "error", err)
+		} else {
+			s.logger.Info("dm_ aggregate refresh complete", "duration", time.Since(aggStart).Truncate(time.Second))
+		}
 	}
 
 	s.logger.Info("weekly matview rebuild: collection will resume on next poll tick")

--- a/internal/scheduler/vuln_digest_test.go
+++ b/internal/scheduler/vuln_digest_test.go
@@ -120,7 +120,7 @@ func TestRunVulnDigestEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer store.Close()
+	t.Cleanup(store.Close)
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/scripts/create_email_lookup_indexes.sql
+++ b/scripts/create_email_lookup_indexes.sql
@@ -1,0 +1,46 @@
+-- create_email_lookup_indexes.sql — v0.27.54 interim operator relief
+--
+-- Fixes the hourly mailing-list sender-resolve candidates query
+-- (GetMailingListSenderResolveCandidates) observed running 30-50 min
+-- occupying 5 backends on aveloxis_large (2026-07-29): the NOT EXISTS
+-- against contributors plans as a nested-loop anti-join that seq-scans
+-- the 9.4 GB contributors heap once per outer row, because
+-- contributors.cntrb_email and cntrb_canonical have no indexes.
+--
+-- DELIBERATELY NON-PARTIAL (no "WHERE cntrb_email != ''"): the hot
+-- probes compare against a JOIN column (em.sender_email), and Postgres
+-- cannot prove a partial-index predicate from a join variable at plan
+-- time — a partial index would be ignored for exactly the query this
+-- exists to fix. (Partial works for the v0.19.9 gh_login index only
+-- because those probes are plan-time-known parameters.)
+--
+-- Safe to run while serve is up: CONCURRENTLY never blocks writes.
+-- Must NOT be wrapped in BEGIN/COMMIT (CONCURRENTLY refuses to run in
+-- a transaction block). Expect a few minutes per index on the 2.47M-row
+-- table. The v0.27.54 migration re-runs these as no-ops via
+-- IF NOT EXISTS, so hand-creating them now is the v0.25.34 pattern.
+--
+-- Run with:
+--   CFG=/path/to/aveloxis.chaoss.tv.json
+--   PGPASSWORD=$(jq -r .database.password "$CFG") psql \
+--     -h $(jq -r .database.host "$CFG") -p $(jq -r .database.port "$CFG") \
+--     -U $(jq -r .database.user "$CFG") -d $(jq -r .database.dbname "$CFG") \
+--     -f scripts/create_email_lookup_indexes.sql
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_email_lookup
+    ON aveloxis_data.contributors (cntrb_email);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contributors_canonical_lookup
+    ON aveloxis_data.contributors (cntrb_canonical);
+
+-- Verify: both rows must show indisvalid = t. An 'f' means the build
+-- was interrupted — DROP INDEX the invalid one and re-run this script
+-- (the migration's execCreateIndexConcurrently helper self-heals the
+-- same way).
+SELECT i.relname AS index_name, x.indisvalid
+FROM pg_index x
+JOIN pg_class i ON i.oid = x.indexrelid
+JOIN pg_class t ON t.oid = x.indrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE n.nspname = 'aveloxis_data'
+  AND i.relname IN ('idx_contributors_email_lookup', 'idx_contributors_canonical_lookup');

--- a/scripts/create_message_heal_index.sql
+++ b/scripts/create_message_heal_index.sql
@@ -1,0 +1,33 @@
+-- SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+-- SPDX-License-Identifier: MIT
+--
+-- v0.27.67 operator relief (2026-08-01): hand-create the msg_id probe
+-- index heal-messages needs, CONCURRENTLY, before the release deploys.
+-- The v0.27.67 migration then no-ops via IF NOT EXISTS (the v0.27.54
+-- pattern — see scripts/create_email_lookup_indexes.sql).
+--
+-- WHY: `aveloxis heal-messages`' batch SELECT resolves each pending
+-- worklist row's review-side parent by probing
+-- pull_request_review_message_ref.msg_id. The table's only
+-- msg_id-bearing index is uq_pr_review_msg_ref (pr_review_id, msg_id)
+-- — pr_review_id leads, so the probe walks all ~30.5M entries as a
+-- FILTER: measured 1.67 s per probe × 546,081 pending rows ≈ 10.5
+-- days for one SELECT. With this index the probe is a sub-ms seek and
+-- the batch resolves in minutes.
+--
+-- Run against the production DB (safe while serve is running —
+-- CONCURRENTLY doesn't block writes; expect minutes on the 41 GB
+-- table):
+--
+--   psql -h chaoss.tv -p 5434 -U aveloxis -d aveloxis_large \
+--        -f scripts/create_message_heal_index.sql
+--
+-- If a previous attempt was interrupted, drop the INVALID leftover
+-- first (check: SELECT indisvalid FROM pg_index i JOIN pg_class c ON
+-- c.oid = i.indexrelid WHERE c.relname =
+-- 'idx_pull_request_review_message_ref_msg_id'):
+--
+--   DROP INDEX IF EXISTS aveloxis_data.idx_pull_request_review_message_ref_msg_id;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pull_request_review_message_ref_msg_id
+    ON aveloxis_data.pull_request_review_message_ref (msg_id);

--- a/scripts/test_close_ordering_test.go
+++ b/scripts/test_close_ordering_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Sean Goggins, University of Missouri, Derek Howard
+// SPDX-License-Identifier: MIT
+
+package scripts
+
+// 2026-08-02 tripwire — the defer-vs-t.Cleanup ordering trap that
+// broke CI on PR #171: Go runs a test function's DEFERRED calls
+// BEFORE its t.Cleanup callbacks, so a test that does
+//
+//	store, ctx := v0251Connect(t)
+//	defer store.Close()          // runs FIRST at test end
+//	t.Cleanup(func() { ...pool.Exec(DELETE ...)... }) // runs against a CLOSED pool
+//
+// silently strands every fixture row its cleanups were supposed to
+// delete (the Exec errors are conventionally discarded). The
+// collections e2e leaked 3 queue rows with synthetic cached counts
+// this way, and the data-verify battery's "cached counts vs actual"
+// probe — running later in the same package — failed the build with
+// "CompleteJob's cumulative-count contract is broken" on perfectly
+// healthy code. Integration tests must register the pool close as
+// the FIRST t.Cleanup (`t.Cleanup(store.Close)`) so it runs LAST,
+// after every data cleanup.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var deferPoolClose = regexp.MustCompile(`\bdefer\s+(store|pool|s)\.(pool\.)?Close\(\)`)
+
+func TestNoDeferPoolCloseInTests(t *testing.T) {
+	root := repoRootDir(t)
+	var offenders []string
+	var scanned int
+	for _, dir := range []string{"internal", "cmd"} {
+		err := filepath.Walk(filepath.Join(root, dir), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if strings.Contains(path, ".claude") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			scanned++
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			// Strip // comments so prose describing the pattern (e.g.
+			// scheduler/shutdown_test.go's runServe discussion) can't
+			// false-match.
+			var code []string
+			for _, line := range strings.Split(string(raw), "\n") {
+				if i := strings.Index(line, "//"); i >= 0 {
+					line = line[:i]
+				}
+				code = append(code, line)
+			}
+			if loc := deferPoolClose.FindString(strings.Join(code, "\n")); loc != "" {
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+" ("+loc+")")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if scanned < 100 {
+		t.Fatalf("only scanned %d _test.go files — the walk is broken, fix the tripwire before trusting it", scanned)
+	}
+	for _, o := range offenders {
+		t.Errorf("%s: `defer <store>.Close()` in a test — deferred calls run BEFORE t.Cleanup callbacks, so any pool-using cleanup silently fails against a closed pool and strands fixture residue (the PR #171 CI failure). Use `t.Cleanup(store.Close)` immediately after connecting instead.", o)
+	}
+}
+
+// repoRootDir walks up from the working directory to the go.mod root.
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from the test working directory")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
Releases v0.27.53 → v0.27.76 This grew well past the original mailing-list scope — full surface below.

## Performance / heal infrastructure
- **v0.27.53** processor progress logging (the silent multi-day "processing staged data" phase now emits progress lines every 5K rows).
- **v0.27.54** email/canonical lookup indexes on `contributors` (the hourly sender-resolve query occupied 5 backends for 30–50 min via 9.4 GB seq scans).
- **v0.27.55** breadth-cooldown jitter (±10%) breaks the feast/famine echo in daily breadth marks.
- **v0.27.56** `matview_rebuild_skip_dm_aggregates` knob — the weekly rebuild's per-repo dm_ aggregate pass can be skipped independently (the 2026-07-27 fleet stall class).
- **v0.27.67** heal-messages "SELECT runs forever" — `idx_pull_request_review_message_ref_msg_id` (bare msg_id probes filter-scanned 30.5M index entries per worklist row).

## Contributor data
- **v0.27.57** activity classification (public / private-disclosed / dormant / no-observable) via GraphQL restrictedContributionsCount.
- **v0.27.58** daily contributor activity history (store-by-day, parameterizable windows, cap-hit subdivision).
- **v0.27.61/64/69** top-contributors + cross-repo "elsewhere" read APIs, hide-bots filter.

## Vulnerability accuracy (the zephyr false-CRITICAL class)
- **v0.27.71** malformed dependency versions defeated OSV matching — 5 parser fixes + central `normalizeParsedVersion` choke point (~130K garbage dep rows, 127K findings from malformed purls).
- **v0.27.72** heal-vulnerabilities normalizes stored purls at read time + full-corpus regression audit (72,232 production pairs, zero clean versions altered) + manifest-corpus golden net.
- **v0.27.73** OSV wire gate — one malformed purl no longer 400s a repo's whole batch; drops are logged BY NAME.

## Collections / groups / GUI backend
- **v0.27.59–66** landing count, repos.added_at, collections, new-repos feeds, allocation-bound hardening.
- **v0.27.70** per-user collection stars.
- **v0.27.74** collection repo-list data columns (cached counts, last-collected/activity, server-side allowlisted sort) + deep-link login + compare-as-sections GUI round.
- **v0.27.75** group repo list adopts the same collections table grammar (shared sort allowlist — the two listings cannot disagree).

## Review round (v0.27.76, this PR's Copilot + CI fixes)
- CI failure root-caused: `defer store.Close()` + `t.Cleanup(...)` in integration tests runs cleanups against a **closed pool** (defers run before cleanups), silently stranding fixture residue that the data-verify battery then flags. All ~75 test sites converted to `t.Cleanup(store.Close)`; repo-walking tripwire keeps the class dead.
- `handleContributorActivity`: 404 only on `pgx.ErrNoRows`; operational failures are logged 500s.
- `runActivityHistory`: mark-only stamp failures are logged and counted instead of silently re-claiming the contributor every tick.
- README table counts and the manifest-corpus golden.json comments were already resolved on the branch head.
